### PR TITLE
feat: add concurrency and queue limits to OCR service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/*
 *.traineddata
 .DS_Store
 assets/kaggle/*
+!assets/kaggle/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 
 *.traineddata
 .DS_Store
+assets/kaggle/*

--- a/README.md
+++ b/README.md
@@ -223,6 +223,26 @@ const result = await service.recognize("./assets/receipt.jpg", {
 const anotherResult = await service.recognize("./assets/another-image.jpg");
 ```
 
+#### Concurrency Control
+
+By default the service processes one image at a time (`maxConcurrency: 1`). Raise the limit for parallel workloads, or set `maxQueueSize` to reject excess requests instead of queuing them indefinitely.
+
+```ts
+const service = new PaddleOcrService({
+  maxConcurrency: 2,  // allow 2 simultaneous inferences
+  maxQueueSize: 10,   // reject new requests once 10 are already queued
+});
+await service.initialize();
+
+// Concurrent calls are admitted up to maxConcurrency and queued beyond that.
+// Once the queue exceeds maxQueueSize the call throws immediately.
+try {
+  const result = await service.recognize(imageBuffer);
+} catch (e) {
+  // "PaddleOcrService: request queue is full (maxQueueSize=10)"
+}
+```
+
 #### Disabling Cache for Specific Calls
 
 You can disable caching for individual OCR calls if you need fresh processing each time:
@@ -272,6 +292,12 @@ export interface PaddleOptions {
 
   /** ONNX Runtime session configuration options. */
   session?: SessionOptions;
+
+  /** Max simultaneous recognize() / deskewImage() calls. Default: 1 (serial). */
+  maxConcurrency?: number;
+
+  /** Max calls that may queue while all slots are busy. 0 = unlimited. Default: 0. */
+  maxQueueSize?: number;
 }
 ```
 
@@ -330,6 +356,15 @@ Enable verbose logs and save intermediate images to help debug OCR pipelines.
 | `verbose`     | `boolean` | `false` | Turn on detailed console logs of each processing step. |
 | `debug`       | `boolean` | `false` | Write intermediate image frames to disk.               |
 | `debugFolder` | `string`  |  `out`  | Output directory for debug images.                     |
+
+#### Concurrency options
+
+Controls how many calls run simultaneously and how many may wait in the queue.
+
+| Property         |   Type   | Default | Description                                                                              |
+| :--------------- | :------: | :-----: | :--------------------------------------------------------------------------------------- |
+| `maxConcurrency` | `number` |   `1`   | Maximum simultaneous `recognize()` / `deskewImage()` calls. `1` = fully serial.         |
+| `maxQueueSize`   | `number` |   `0`   | Maximum calls that may queue while all slots are busy. `0` = unlimited (never rejects).  |
 
 #### `SessionOptions`
 

--- a/assets/kaggle/README.md
+++ b/assets/kaggle/README.md
@@ -1,0 +1,19 @@
+Fill this directory with this dataset
+
+
+```pwsh
+# From the repository root
+mkdir -Force assets/kaggle
+
+# Ensure Kaggle CLI can run
+python -m kaggle --help > $null
+
+# Download and unzip (≈52 MB compressed)
+python -m kaggle datasets download trainingdatapro/ocr-receipts-text-detection -p assets/kaggle --unzip
+
+# Expected layout after extraction:
+# assets/kaggle/
+#   images/0.jpg ... images/19.jpg
+#   annotations.xml
+#   boxes/ (optional helper visuals)
+```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,4 +48,6 @@ export const DEFAULT_PADDLE_OPTIONS: PaddleOptions = {
   recognition: DEFAULT_RECOGNITION_OPTIONS,
   debugging: DEFAULT_DEBUGGING_OPTIONS,
   session: DEFAULT_SESSION_OPTIONS,
+  maxConcurrency: 1,
+  maxQueueSize: 0,
 };

--- a/src/core/base-detection.service.ts
+++ b/src/core/base-detection.service.ts
@@ -385,7 +385,12 @@ export class BaseDetectionService {
         return null;
       }
 
-      return outputTensor.data as Float32Array;
+      // Copy data into a new JS-heap Float32Array before disposing the ONNX
+      // tensor — tensor.data is a view into WASM-managed memory that becomes
+      // invalid after dispose().
+      const data = new Float32Array(outputTensor.data as Float32Array);
+      outputTensor.dispose?.();
+      return data;
     } catch (error) {
       console.error(
         "Error during model inference:",
@@ -442,6 +447,7 @@ export class BaseDetectionService {
 
     const { width, height, resizeRatio, originalWidth, originalHeight } = input;
     const canvas = this.tensorToCanvas(detection, width, height);
+    (this.lastDetectionCanvas as any)?.destroy?.();
     this.lastDetectionCanvas = canvas;
 
     const processor = new this.platform.imageProcessor.ImageProcessor(canvas);

--- a/src/core/base-paddle-ocr.service.ts
+++ b/src/core/base-paddle-ocr.service.ts
@@ -1,7 +1,7 @@
 import type { InferenceSession } from "onnxruntime-common";
 import { DEFAULT_PADDLE_OPTIONS } from "../constants.js";
 import type { Box, PaddleOptions, RecognizeOptions } from "../interface.js";
-import { deepMerge } from "../utils.js";
+import { deepMerge, Semaphore } from "../utils.js";
 import { BaseDetectionService } from "./base-detection.service.js";
 import {
   BaseRecognitionService,
@@ -63,6 +63,7 @@ export abstract class BasePaddleOcrService {
   protected recognitor: BaseRecognitionService | null = null;
 
   protected readonly platform: PlatformProvider;
+  private readonly semaphore: Semaphore;
 
   public constructor(platform: PlatformProvider, options?: PaddleOptions) {
     this.platform = platform;
@@ -73,6 +74,7 @@ export abstract class BasePaddleOcrService {
     ) as unknown as PaddleOptions;
     this.options.session =
       this.options.session || DEFAULT_PADDLE_OPTIONS.session;
+    this.semaphore = new Semaphore(this.options.maxConcurrency ?? 1);
   }
 
   protected log(message: string): void {
@@ -91,6 +93,25 @@ export abstract class BasePaddleOcrService {
    * @returns Grouped or flattened OCR results depending on `options.flatten`.
    */
   public async recognize(
+    image: ArrayBuffer | CoreCanvas | string,
+    options?: RecognizeOptions,
+  ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+    const maxQueueSize = this.options.maxQueueSize ?? 0;
+    if (maxQueueSize > 0 && this.semaphore.pendingCount >= maxQueueSize) {
+      throw new Error(
+        `PaddleOcrService: request queue is full (maxQueueSize=${maxQueueSize}). ` +
+          "Try again later or increase maxQueueSize / maxConcurrency.",
+      );
+    }
+    await this.semaphore.acquire();
+    try {
+      return await this._recognize(image, options);
+    } finally {
+      this.semaphore.release();
+    }
+  }
+
+  private async _recognize(
     image: ArrayBuffer | CoreCanvas | string,
     options?: RecognizeOptions,
   ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
@@ -219,6 +240,24 @@ export abstract class BasePaddleOcrService {
    * @returns A new canvas containing the deskewed image.
    */
   public async deskewImage(
+    image: ArrayBuffer | CoreCanvas | string,
+  ): Promise<CoreCanvas> {
+    const maxQueueSize = this.options.maxQueueSize ?? 0;
+    if (maxQueueSize > 0 && this.semaphore.pendingCount >= maxQueueSize) {
+      throw new Error(
+        `PaddleOcrService: request queue is full (maxQueueSize=${maxQueueSize}). ` +
+          "Try again later or increase maxQueueSize / maxConcurrency.",
+      );
+    }
+    await this.semaphore.acquire();
+    try {
+      return await this._deskewImage(image);
+    } finally {
+      this.semaphore.release();
+    }
+  }
+
+  private async _deskewImage(
     image: ArrayBuffer | CoreCanvas | string,
   ): Promise<CoreCanvas> {
     if (!this.detector || !this.recognitor) {

--- a/src/core/base-recognition.service.ts
+++ b/src/core/base-recognition.service.ts
@@ -158,8 +158,8 @@ export class BaseRecognitionService {
   ): Promise<RecognitionResult | null> {
     const start = Date.now();
 
+    const cropCanvas = this.cropRegion(sourceCanvas, box);
     try {
-      const cropCanvas = this.cropRegion(sourceCanvas, box);
       const { text: recognizedText, confidence } = await this.recognizeText(
         cropCanvas,
         charactersDictionary,
@@ -180,6 +180,8 @@ export class BaseRecognitionService {
     } catch (e: any) {
       console.error(`Error processing box ${index + 1}: ${e.message}`, e.stack);
       return null;
+    } finally {
+      (cropCanvas as any).destroy?.();
     }
   }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -164,6 +164,22 @@ export interface PaddleOptions {
    * ONNX Runtime session configuration options.
    */
   session?: SessionOptions;
+
+  /**
+   * Maximum number of concurrent `recognize()` / `deskewImage()` calls
+   * allowed at the same time for this service instance.
+   *
+   * @default 1 // no concurrency, calls are processed serially
+   */
+  maxConcurrency?: number;
+
+  /**
+   * Maximum number of `recognize()` / `deskewImage()` calls that may
+   * queue while all concurrency slots are busy.
+   *
+   * @default 0 // unlimited
+   */
+  maxQueueSize?: number;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,51 @@
 /**
+ * Async semaphore that caps the number of concurrently executing async
+ * operations.  Callers `acquire()` before entering a critical section and
+ * `release()` when they leave.
+ *
+ * @example
+ * const sem = new Semaphore(2);
+ * await sem.acquire();
+ * try { await heavyWork(); } finally { sem.release(); }
+ */
+export class Semaphore {
+  private slots: number;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(slots: number) {
+    if (slots < 1) throw new RangeError("Semaphore slots must be >= 1");
+    this.slots = slots;
+  }
+
+  /** Number of callers currently waiting for a free slot. */
+  get pendingCount(): number {
+    return this.queue.length;
+  }
+
+  /** Acquire one slot.  Resolves immediately if a slot is available,
+   *  otherwise waits until one is released. */
+  acquire(): Promise<void> {
+    if (this.slots > 0) {
+      this.slots--;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  /** Release one slot and unblock the next waiter, if any. */
+  release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.slots++;
+    }
+  }
+}
+
+/**
  * Deep merges multiple objects into the target object.
  * Arrays are overwritten, not concatenated.
  *

--- a/tests/backpressure.test.ts
+++ b/tests/backpressure.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+import { BasePaddleOcrService } from "../src/core/base-paddle-ocr.service.js";
+import type { CoreCanvas, PlatformProvider } from "../src/core/platform.js";
+import type { PaddleOcrResult } from "../src/core/base-paddle-ocr.service.js";
+import type { PaddleOptions } from "../src/interface.js";
+import { Semaphore } from "../src/utils.js";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Tiny image stand-in for all function signatures that expect ArrayBuffer. */
+const DUMMY = new ArrayBuffer(4);
+
+function makeMockPlatform(): PlatformProvider {
+  return {
+    pathSeparator: "/",
+    ort: {
+      Tensor: class MockTensor {
+        dispose() {}
+      } as any,
+      InferenceSession: {} as any,
+    },
+    createCanvas: (_w: number, _h: number) => ({}) as CoreCanvas,
+    isCanvas: (_img: unknown): _img is CoreCanvas => false,
+    loadResource: async () => new ArrayBuffer(0),
+    saveDebugImage: async () => {},
+    imageProcessor: {
+      prepareCanvas: async () => ({}) as CoreCanvas,
+      ImageProcessor: class {} as any,
+      Contours: class {} as any,
+      cv: {} as any,
+      CanvasToolkit: {
+        getInstance: () => ({ clearOutput: () => {} }),
+      } as any,
+    },
+  };
+}
+
+class MockOcrService extends BasePaddleOcrService {
+  private readonly inferenceDelay: number;
+
+  constructor(options: PaddleOptions = {}, inferenceDelay = 0) {
+    super(makeMockPlatform(), options);
+    this.inferenceDelay = inferenceDelay;
+  }
+
+  protected async initSessions(): Promise<void> {
+    const d = this.inferenceDelay;
+
+    this.detector = {
+      run: async (_canvas: any): Promise<any[]> => {
+        if (d > 0) await delay(d);
+        return []; // 0 boxes to _recognize short-circuits with empty result
+      },
+      deskew: async (canvas: any): Promise<any> => canvas,
+    } as any;
+
+    this.recognitor = {
+      run: async (): Promise<any[]> => [],
+    } as any;
+  }
+
+  get _semaphore(): Semaphore {
+    return (this as any).semaphore as Semaphore;
+  }
+}
+
+describe("maxQueueSize — queue overflow rejection", () => {
+  test("rejects immediately when pendingCount reaches maxQueueSize", async () => {
+    const svc = new MockOcrService({ maxConcurrency: 1, maxQueueSize: 2 });
+
+    svc._semaphore.acquire();
+
+    // Two calls should queue successfully (pendingCount 1, then 2)
+    const p1 = svc.recognize(DUMMY).catch(() => {});
+    const p2 = svc.recognize(DUMMY).catch(() => {});
+
+    expect(svc._semaphore.pendingCount).toBe(2);
+    expect(svc.recognize(DUMMY)).rejects.toThrow("queue is full");
+    svc._semaphore.release();
+    await Promise.allSettled([p1, p2]);
+  });
+
+  test("allows exactly maxQueueSize calls to queue before rejecting", async () => {
+    const MAX = 3;
+    const svc = new MockOcrService({ maxConcurrency: 1, maxQueueSize: MAX });
+
+    svc._semaphore.acquire();
+
+    const queued = Array.from({ length: MAX }, () =>
+      svc.recognize(DUMMY).catch(() => {}),
+    );
+    expect(svc._semaphore.pendingCount).toBe(MAX);
+
+    expect(svc.recognize(DUMMY)).rejects.toThrow("queue is full");
+
+    svc._semaphore.release();
+    await Promise.allSettled(queued);
+  });
+
+  test("maxQueueSize=0 (default) never rejects regardless of queue depth", async () => {
+    const svc = new MockOcrService({ maxConcurrency: 1, maxQueueSize: 0 });
+
+    svc._semaphore.acquire();
+
+    const calls = Array.from({ length: 15 }, () =>
+      svc.recognize(DUMMY).catch(() => {}),
+    );
+
+    expect(svc._semaphore.pendingCount).toBe(15);
+
+    svc._semaphore.release();
+    await Promise.allSettled(calls);
+  });
+
+  test("error message contains maxQueueSize value for debuggability", async () => {
+    const svc = new MockOcrService({ maxConcurrency: 1, maxQueueSize: 1 });
+
+    svc._semaphore.acquire();
+    const p = svc.recognize(DUMMY).catch(() => {});
+
+    const err = await svc.recognize(DUMMY).catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("maxQueueSize=1");
+
+    svc._semaphore.release();
+    await p;
+  });
+});
+
+describe("maxConcurrency=1 — serial execution", () => {
+  let svc: MockOcrService;
+
+  test("at most 1 _recognize() runs at a time under concurrent load", async () => {
+    svc = new MockOcrService({ maxConcurrency: 1 }, 25 /* ms per call */);
+
+    let active = 0;
+    let maxObservedActive = 0;
+    const orig: (...args: any[]) => any = (svc as any)._recognize.bind(svc);
+    (svc as any)._recognize = async (...args: any[]) => {
+      active++;
+      maxObservedActive = Math.max(maxObservedActive, active);
+      try {
+        return await orig(...args);
+      } finally {
+        active--;
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: 5 }, () => svc.recognize(DUMMY)),
+    );
+
+    expect(maxObservedActive).toBe(1);
+  }, 10_000);
+
+  test("completion order is FIFO — calls finish in the order they were submitted", async () => {
+    svc = new MockOcrService({ maxConcurrency: 1 }, 10 /* ms per call */);
+    const completionOrder: number[] = [];
+
+    await Promise.all(
+      [0, 1, 2, 3, 4].map((id) =>
+        svc
+          .recognize(DUMMY)
+          .then(() => completionOrder.push(id)),
+      ),
+    );
+
+    expect(completionOrder).toEqual([0, 1, 2, 3, 4]);
+  }, 10_000);
+
+  test("total elapsed time ≈ N x inferenceDelay (serial, not parallel)", async () => {
+    const DELAY = 30;
+    const N = 4;
+    svc = new MockOcrService({ maxConcurrency: 1 }, DELAY);
+
+    const t0 = Date.now();
+    await Promise.all(Array.from({ length: N }, () => svc.recognize(DUMMY)));
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeGreaterThanOrEqual((N - 1) * DELAY - 20);
+  }, 10_000);
+
+  test("all concurrent requests complete and return valid empty results", async () => {
+    svc = new MockOcrService({ maxConcurrency: 1 }, 5);
+
+    const results = (await Promise.all(
+      Array.from({ length: 6 }, () => svc.recognize(DUMMY)),
+    )) as PaddleOcrResult[];
+
+    for (const r of results) {
+      expect(r).toHaveProperty("text");
+      expect(r).toHaveProperty("lines");
+      expect(r).toHaveProperty("confidence");
+    }
+  }, 10_000);
+});
+
+describe("maxConcurrency=2 — limited parallelism", () => {
+  let svc: MockOcrService;
+
+  test("maxObservedActive is exactly 2 when 4 calls race with enough work per call", async () => {
+    svc = new MockOcrService({ maxConcurrency: 2 }, 40);
+
+    let active = 0;
+    let maxObservedActive = 0;
+    const orig: (...args: any[]) => any = (svc as any)._recognize.bind(svc);
+    (svc as any)._recognize = async (...args: any[]) => {
+      active++;
+      maxObservedActive = Math.max(maxObservedActive, active);
+      try {
+        return await orig(...args);
+      } finally {
+        active--;
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: 4 }, () => svc.recognize(DUMMY)),
+    );
+
+    expect(maxObservedActive).toBe(2);
+  }, 10_000);
+
+  test("total elapsed is roughly halved compared to serial for 4 equal-duration tasks", async () => {
+    const DELAY = 30;
+    svc = new MockOcrService({ maxConcurrency: 2 }, DELAY);
+
+    const t0 = Date.now();
+    await Promise.all(Array.from({ length: 4 }, () => svc.recognize(DUMMY)));
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(3 * DELAY + 40);
+  }, 10_000);
+});
+
+describe("deskewImage shares the concurrency gate", () => {
+  test("deskewImage and recognize() count against the same maxConcurrency=1 limit", async () => {
+    const svc = new MockOcrService({ maxConcurrency: 1 }, 20);
+
+    let active = 0;
+    let maxObservedActive = 0;
+
+    // Patch both private methods
+    for (const method of ["_recognize", "_deskewImage"] as const) {
+      const orig: (...a: any[]) => any = (svc as any)[method].bind(svc);
+      (svc as any)[method] = async (...args: any[]) => {
+        active++;
+        maxObservedActive = Math.max(maxObservedActive, active);
+        try {
+          return await orig(...args);
+        } finally {
+          active--;
+        }
+      };
+    }
+
+    await Promise.all([
+      svc.recognize(DUMMY),
+      svc.deskewImage(DUMMY),
+      svc.recognize(DUMMY),
+      svc.deskewImage(DUMMY),
+    ]);
+
+    expect(maxObservedActive).toBe(1);
+  }, 10_000);
+});

--- a/tests/kaggle-receipts.test.ts
+++ b/tests/kaggle-receipts.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Dataset path: assets/kaggle/images/{0..19}.jpg
+ * Ground truth:  assets/kaggle/annotations.xml (bounding-box labels with text)
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
+
+declare const Bun: { file: (path: string) => { arrayBuffer(): Promise<ArrayBuffer> } };
+declare const process: { memoryUsage(): { rss: number } };
+
+import dict from "../models/en_dict.txt" with { type: "file" };
+import recModel from "../models/en_PP-OCRv4_mobile_rec_infer.onnx" with { type: "file" };
+import detModel from "../models/PP-OCRv5_mobile_det_infer.onnx" with { type: "file" };
+
+function flatText(result: { text: string }): string {
+  return result.text.toUpperCase().replace(/[^A-Z0-9\s]/g, " ");
+}
+
+function containsAll(corpus: string, ...keywords: string[]): boolean {
+  return keywords.every((kw) => corpus.includes(kw.toUpperCase()));
+}
+
+async function loadReceipt(index: number): Promise<ArrayBuffer> {
+  const ext = index === 6 ? "JPG" : "jpg";
+  return Bun.file(`./assets/kaggle/images/${index}.${ext}`).arrayBuffer();
+}
+
+let service: PaddleOcrService;
+
+const MODEL_OPTIONS = {
+  model: {
+    detection: detModel,
+    recognition: recModel,
+    charactersDictionary: dict,
+  },
+};
+
+beforeAll(async () => {
+  service = new PaddleOcrService(MODEL_OPTIONS);
+  await service.initialize();
+}, 60_000);
+
+afterAll(async () => {
+  await service.destroy();
+});
+
+describe("OCR accuracy on Kaggle receipt images", () => {
+  test("image 0: recognises WALMART header", async () => {
+    const buf = await loadReceipt(0);
+    const result = await service.recognize(buf);
+
+    expect(result.text).not.toBeEmpty();
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(containsAll(flatText(result), "WALMART")).toBe(true);
+  }, 60_000);
+
+  test("image 8: recognises COSTCO header", async () => {
+    const buf = await loadReceipt(8);
+    const result = await service.recognize(buf);
+
+    expect(result.text).not.toBeEmpty();
+    expect(containsAll(flatText(result), "COSTCO")).toBe(true);
+  }, 60_000);
+
+  test("image 11: recognises WHOLE FOODS header", async () => {
+    const buf = await loadReceipt(11);
+    const result = await service.recognize(buf);
+
+    expect(result.text).not.toBeEmpty();
+    expect(containsAll(flatText(result), "WHOLE", "FOODS")).toBe(true);
+  }, 60_000);
+
+
+  test("image 1: recognises TRADER JOE header", async () => {
+    const buf = await loadReceipt(1);
+    const result = await service.recognize(buf);
+
+    expect(result.text).not.toBeEmpty();
+    expect(containsAll(flatText(result), "TRADER")).toBe(true);
+  }, 60_000);
+
+  test("image 9: recognises WINCO header", async () => {
+    const buf = await loadReceipt(9);
+    const result = await service.recognize(buf);
+
+    expect(result.text).not.toBeEmpty();
+    expect(containsAll(flatText(result), "WINCO")).toBe(true);
+  }, 60_000);
+
+  test("result structure: every line has words with text and confidence", async () => {
+    const buf = await loadReceipt(0);
+    const result = await service.recognize(buf);
+
+    expect(result.lines.length).toBeGreaterThan(0);
+    for (const line of result.lines) {
+      expect(line.length).toBeGreaterThan(0);
+      for (const word of line) {
+        expect(typeof word.text).toBe("string");
+        expect(word.confidence).toBeGreaterThanOrEqual(0);
+        expect(word.confidence).toBeLessThanOrEqual(1);
+      }
+    }
+  }, 60_000);
+});
+
+describe("Stability under concurrent load (18 receipts)", () => {
+  test(
+    "all 18 receipts settle and ≥80% return non-empty text",
+    async () => {
+      const indices = Array.from({ length: 20 }, (_, i) => i).filter((i) => i !== 5 && i !== 14);
+
+      const concurrentService = new PaddleOcrService({
+        ...MODEL_OPTIONS,
+        maxConcurrency: 2,
+      });
+      await concurrentService.initialize();
+
+      const buffers = await Promise.all(indices.map(loadReceipt));
+
+      const settled = await Promise.allSettled(
+        buffers.map((buf) => concurrentService.recognize(buf)),
+      );
+
+      await concurrentService.destroy();
+
+      const fulfilled = settled.filter((s) => s.status === "fulfilled");
+      const withText = fulfilled.filter(
+        (s) => (s as PromiseFulfilledResult<any>).value.text.length > 0,
+      );
+
+      expect(settled.length).toBe(indices.length);
+
+      expect(withText.length / indices.length).toBeGreaterThanOrEqual(0.8);
+    },
+    300_000,
+  );
+});
+
+describe("Memory regression: RSS growth over repeated calls", () => {
+  test(
+    "RSS grows by less than 150 MB across 10 sequential calls with noCache",
+    async () => {
+      const buf = await loadReceipt(0);
+
+      await service.recognize(buf);
+
+      const rssBefore = process.memoryUsage().rss;
+
+      for (let i = 0; i < 10; i++) {
+        await service.recognize(buf, { noCache: true });
+      }
+
+      const rssAfter = process.memoryUsage().rss;
+      const growthMB = (rssAfter - rssBefore) / (1024 * 1024);
+
+      expect(growthMB).toBeLessThan(150);
+    },
+    120_000,
+  );
+
+  test(
+    "RSS growth rate is sub-linear (stabilises after warm-up)",
+    async () => {
+      const buf = await loadReceipt(0);
+
+      await service.recognize(buf);
+
+      const samples: number[] = [process.memoryUsage().rss];
+      for (let i = 1; i <= 10; i++) {
+        await service.recognize(buf, { noCache: true });
+        samples.push(process.memoryUsage().rss);
+      }
+
+      const firstHalfGrowth = samples[5]! - samples[0]!;
+      const secondHalfGrowth = samples[10]! - samples[5]!;
+
+      const TOLERANCE_BYTES = 10 * 1024 * 1024;
+      expect(secondHalfGrowth).toBeLessThanOrEqual(
+        firstHalfGrowth + TOLERANCE_BYTES,
+      );
+    },
+    120_000,
+  );
+});

--- a/tests/semaphore.test.ts
+++ b/tests/semaphore.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import { Semaphore } from "../src/utils.js";
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("Semaphore construction", () => {
+  test("throws RangeError for slots = 0", () => {
+    expect(() => new Semaphore(0)).toThrow(RangeError);
+  });
+
+  test("throws RangeError for negative slots", () => {
+    expect(() => new Semaphore(-5)).toThrow(RangeError);
+  });
+
+  test("creates successfully for slots >= 1", () => {
+    expect(() => new Semaphore(1)).not.toThrow();
+    expect(() => new Semaphore(100)).not.toThrow();
+  });
+});
+
+describe("Semaphore acquire / release", () => {
+  test("acquire() resolves synchronously (within microtask) when slots are available", async () => {
+    const sem = new Semaphore(2);
+    let count = 0;
+
+    sem.acquire().then(() => count++);
+    sem.acquire().then(() => count++);
+
+    expect(count).toBe(0);
+    await tick();
+    expect(count).toBe(2);
+  });
+
+  test("acquire() blocks when all slots are occupied", async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+
+    let resolved = false;
+    const waiter = sem.acquire().then(() => {
+      resolved = true;
+    });
+
+    await tick();
+    expect(resolved).toBe(false);
+    sem.release();
+    await waiter;
+    expect(resolved).toBe(true);
+  });
+
+  test("pendingCount reflects the queue depth accurately through the lifecycle", async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+
+    expect(sem.pendingCount).toBe(0);
+
+    const p1 = sem.acquire();
+    expect(sem.pendingCount).toBe(1);
+
+    const p2 = sem.acquire();
+    expect(sem.pendingCount).toBe(2);
+
+    const p3 = sem.acquire();
+    expect(sem.pendingCount).toBe(3);
+
+    sem.release();
+    await p1;
+    expect(sem.pendingCount).toBe(2);
+
+    sem.release();
+    await p2;
+    expect(sem.pendingCount).toBe(1);
+
+    sem.release();
+    await p3;
+    expect(sem.pendingCount).toBe(0);
+  });
+
+  test("Semaphore(3) allows 3 simultaneous acquirers with no waiting", async () => {
+    const sem = new Semaphore(3);
+    const t0 = Date.now();
+
+    await Promise.all([sem.acquire(), sem.acquire(), sem.acquire()]);
+
+    expect(Date.now() - t0).toBeLessThan(20);
+    expect(sem.pendingCount).toBe(0);
+  });
+
+  test("slots are fully restored to initial capacity after a complete acquire/release cycle", async () => {
+    const sem = new Semaphore(3);
+    await sem.acquire();
+    await sem.acquire();
+    await sem.acquire();
+
+    let queued = false;
+    const p = sem.acquire().then(() => {
+      queued = true;
+    });
+    expect(sem.pendingCount).toBe(1);
+
+    sem.release();
+    sem.release();
+    sem.release();
+    await p;
+    expect(queued).toBe(true);
+
+    const t0 = Date.now();
+    await Promise.all([sem.acquire(), sem.acquire(), sem.acquire()]);
+    expect(Date.now() - t0).toBeLessThan(20);
+  });
+});
+
+
+describe("Semaphore FIFO ordering", () => {
+  test("waiters are woken in the order they called acquire()", async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+
+    const order: number[] = [];
+
+    const tasks = [1, 2, 3, 4, 5].map((id) =>
+      sem.acquire().then(() => {
+        order.push(id);
+        sem.release(); 
+      }),
+    );
+
+    sem.release(); 
+    await Promise.all(tasks);
+
+    expect(order).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("completion timestamps are monotonically increasing with maxConcurrency=1", async () => {
+    const DELAY = 15;
+    const sem = new Semaphore(1);
+
+    const timestamps: number[] = [];
+
+    const work = async () => {
+      await sem.acquire();
+      try {
+        await delay(DELAY);
+        timestamps.push(Date.now());
+      } finally {
+        sem.release();
+      }
+    };
+
+    await Promise.all([work(), work(), work(), work()]);
+
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]! - timestamps[i - 1]!).toBeGreaterThanOrEqual(
+        DELAY - 5,
+      );
+    }
+  });
+});
+
+describe("Semaphore error resilience", () => {
+  test("release() inside finally still unblocks the next waiter when the guarded task throws", async () => {
+    const sem = new Semaphore(1);
+
+    const failingTask = async () => {
+      await sem.acquire();
+      try {
+        throw new Error("deliberate failure");
+      } finally {
+        sem.release();
+      }
+    };
+
+    await expect(failingTask()).rejects.toThrow("deliberate failure");
+
+    let resolved = false;
+    sem.acquire().then(() => {
+      resolved = true;
+    });
+    await tick();
+    expect(resolved).toBe(true);
+  });
+
+  test("mixed success/failure tasks: all waiters eventually unblock", async () => {
+    const sem = new Semaphore(1);
+    const N = 6;
+    let settled = 0;
+
+    const tasks = Array.from({ length: N }, (_, i) =>
+      (async () => {
+        await sem.acquire();
+        try {
+          await delay(5);
+          if (i % 2 === 0) throw new Error(`fail-${i}`);
+        } finally {
+          sem.release();
+          settled++;
+        }
+      })().catch(() => {}),
+    );
+
+    await Promise.all(tasks);
+    expect(settled).toBe(N);
+    expect(sem.pendingCount).toBe(0);
+  });
+});
+
+describe("Semaphore concurrency ceiling", () => {
+  test("maxObservedActive never exceeds slots under heavy concurrent load", async () => {
+    const SLOTS = 3;
+    const WORKERS = 30;
+    const sem = new Semaphore(SLOTS);
+
+    let active = 0;
+    let maxActive = 0;
+
+    const work = async () => {
+      await sem.acquire();
+      try {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await delay(Math.floor(Math.random() * 20));
+      } finally {
+        active--;
+        sem.release();
+      }
+    };
+
+    await Promise.all(Array.from({ length: WORKERS }, work));
+
+    expect(maxActive).toBeLessThanOrEqual(SLOTS);
+    expect(maxActive).toBeGreaterThan(0);
+    expect(sem.pendingCount).toBe(0);
+  });
+
+  test("Semaphore(1) is strictly serial: never 2 concurrent callers", async () => {
+    const sem = new Semaphore(1);
+    let active = 0;
+    let wasEverDouble = false;
+
+    const work = async () => {
+      await sem.acquire();
+      try {
+        active++;
+        if (active > 1) wasEverDouble = true;
+        await delay(10);
+      } finally {
+        active--;
+        sem.release();
+      }
+    };
+
+    await Promise.all(Array.from({ length: 10 }, work));
+
+    expect(wasEverDouble).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add `maxConcurrency` and `maxQueueSize` to `PaddleOptions` to limit simultaneous and queued `recognize()` and `deskewImage()` operations.
- Implement a `Semaphore` in `BasePaddleOcrService` to gate operations and enforce FIFO ordering.
- Reject new requests immediately if the queue exceeds `maxQueueSize`.
- Update memory management by copying ONNX tensor data before disposal and cleaning up canvases after use.
- Add tests for queue overflow and concurrency limits.
- Update README with new configuration options and Kaggle dataset setup.