### PR TITLE
chore: add CI check that bun.lock stays in sync on dependabot PRs

### DIFF
--- a/.github/workflows/sync-bun-lock.yml
+++ b/.github/workflows/sync-bun-lock.yml
@@ -1,0 +1,38 @@
+# Dependabot updates package.json but cannot maintain bun.lock (its npm
+# ecosystem only knows package-lock.json / yarn.lock / pnpm-lock.yaml), so CI's
+# `--frozen-lockfile` install fails on every dep-changing Dependabot PR.
+#
+# This job VERIFIES the lockfile is in sync — it holds no credentials, so there
+# is nothing for a poisoned dependency to steal. It runs read-only, never auto-
+# commits, and uses --ignore-scripts so install lifecycle scripts never execute.
+# If bun.lock drifts, the check fails and you sync it locally:
+#   git checkout <dependabot-branch> && bun install && git commit -am '...' && git push
+name: Check bun.lock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.23
+
+      - name: Resolve lockfile
+        run: bun install --no-frozen-lockfile --ignore-scripts
+
+      - name: Fail if bun.lock is out of sync
+        run: |
+          if ! git diff --exit-code bun.lock; then
+            echo "::error::bun.lock is out of sync with package.json."
+            echo "Run locally on this branch: bun install && git commit -am 'chore: sync bun.lock' && git push"
+            exit 1
+          fi


### PR DESCRIPTION
## What

Adds `.github/workflows/sync-bun-lock.yml` — a verify-only CI check that fails when `bun.lock` drifts from `package.json`.

## Why

Dependabot's npm ecosystem can't maintain `bun.lock` (it only knows package-lock.json / yarn.lock / pnpm-lock.yaml). So every dep-changing Dependabot PR left the lockfile stale and broke CI's `bun install --frozen-lockfile` (e.g. PR #23). This surfaces the drift explicitly instead of failing cryptically.

## Design — why verify-only, not auto-commit

A credentialed auto-sync would need `pull_request_target` + checkout of PR content + a push token. That is the exact "pwn request" shape that supply-chain attacks (Shai-Hulud-style) abuse to steal CI credentials. This job deliberately holds **no credentials**:

- `pull_request` trigger, `permissions: contents: read` — no secrets exposed
- `--ignore-scripts` — install lifecycle scripts never execute
- never commits or pushes — just `git diff --exit-code bun.lock`

When a Dependabot PR changes deps, the check goes red and you sync the lockfile locally on the branch (`bun install`, commit, push).

Trade-off: a small manual step per dep-changing PR, in exchange for zero credential-theft surface.
