### PR TITLE
chore: make benchmarks use the default models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Developer experience
+
+- **Benchmarks now measure the shipped default models (v5).** `bench/batch.bench.ts` and `bench/profile.ts` hardcoded the stale v4 recognition model from `models/`; they now omit explicit model paths so every benchmark exercises the library default, matching `bench/index.bench.ts`. README benchmark numbers refreshed accordingly.
+
 ## [5.5.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -574,19 +574,19 @@ Absolute timings are thermal-sensitive on fanless hardware (Apple Silicon): sust
 
 ### Batch vs. concurrent `recognize()`
 
-`bench/batch.bench.ts` compares the ways to OCR many images, tracking peak RSS alongside time. Median over 7 rounds of 16 images each, Apple M1 / Bun 1.3.14, opencv, `noCache`:
+`bench/batch.bench.ts` compares the ways to OCR many images, tracking peak RSS alongside time. Default models (v5), median over 7 rounds of 16 images each, Apple M1 / Bun 1.3.14, opencv, `noCache`:
 
 ```bash
 task                          median      ±stddev        min        max   peak RSS
 ----------------------------------------------------------------------------------
-sequential for-loop          3807.6 ms     177.6 ms  3531.1 ms  4056.4 ms    1027 MB
-Promise.all(map(recognize))  3561.2 ms     142.3 ms  3302.1 ms  3719.8 ms    1408 MB
-batchRecognize (auto)        3650.6 ms     149.6 ms  3342.1 ms  3721.6 ms    1076 MB
-batchRecognize (c=4)         3649.7 ms     118.3 ms  3435.2 ms  3754.6 ms     990 MB
-batchRecognize (c=8)         3592.5 ms     130.7 ms  3340.5 ms  3712.8 ms    1084 MB
+sequential for-loop          3802.5 ms     300.6 ms  3169.4 ms  3979.7 ms    1059 MB
+Promise.all(map(recognize))  3543.5 ms     254.0 ms  3030.0 ms  3768.0 ms    1428 MB
+batchRecognize (auto)        3676.1 ms     200.9 ms  3217.1 ms  3761.3 ms    1096 MB
+batchRecognize (c=4)         3653.8 ms     239.1 ms  3170.1 ms  3804.1 ms    1027 MB
+batchRecognize (c=8)         3605.7 ms     187.6 ms  3202.1 ms  3786.6 ms    1096 MB
 ```
 
-On CPU, throughput is bound by ONNX Runtime's native thread pool (which already saturates all cores per inference), so every parallel approach lands within ~3% on time — JS-level concurrency cannot add cores that are already busy. The real difference is **memory**: unbounded `Promise.all` peaks at ~1400 MB and grows with batch size, while `batchRecognize` stays **bounded at ~990–1080 MB regardless of `N`**. So `batchRecognize` matches the fastest approach at lower, bounded peak memory — and the throughput win from concurrency shows up on GPU (overlapping host↔device) or I/O-bound inputs. Tune `BATCH_N` / `ROUNDS` via env.
+On CPU, throughput is bound by ONNX Runtime's native thread pool (which already saturates all cores per inference), so every parallel approach lands within ~4% on time — JS-level concurrency cannot add cores that are already busy. The real difference is **memory**: unbounded `Promise.all` peaks at ~1430 MB and grows with batch size, while `batchRecognize` stays **bounded at ~1030–1100 MB regardless of `N`**. So `batchRecognize` matches the fastest approach at lower, bounded peak memory — and the throughput win from concurrency shows up on GPU (overlapping host↔device) or I/O-bound inputs. Tune `BATCH_N` / `ROUNDS` via env.
 
 ## Contributing
 

--- a/bench/batch.bench.ts
+++ b/bench/batch.bench.ts
@@ -1,10 +1,6 @@
 import { PaddleOcrService } from "../src";
 import { Bench, printResults } from "./harness";
 
-import dict from "../models/en_dict.txt" with { type: "file" };
-import recModel from "../models/en_PP-OCRv4_mobile_rec_infer.onnx" with { type: "file" };
-import detModel from "../models/PP-OCRv5_mobile_det_infer.onnx" with { type: "file" };
-
 // Images per batch / measurement rounds. Override with env:
 //   BATCH_N=32 ROUNDS=9 bun bench/batch.bench.ts
 const N = Number(process.env.BATCH_N ?? 16);
@@ -13,8 +9,8 @@ const ROUNDS = Number(process.env.ROUNDS ?? 7);
 const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/receipt.jpg`).arrayBuffer();
 const images = Array.from({ length: N }, () => imageBuffer.slice(0));
 
+// Uses the library's default models (v5).
 const service = new PaddleOcrService({
-  model: { detection: detModel, recognition: recModel, charactersDictionary: dict },
   processing: { engine: "opencv" },
   recognition: { charactersDictionary: [] as string[] },
 });

--- a/bench/profile.ts
+++ b/bench/profile.ts
@@ -1,18 +1,6 @@
 import { performance } from "node:perf_hooks";
 import { PaddleOcrService } from "../src";
 
-import dict from "../models/en_dict.txt" with { type: "file" };
-import recModel from "../models/en_PP-OCRv4_mobile_rec_infer.onnx" with { type: "file" };
-import detModel from "../models/PP-OCRv5_mobile_det_infer.onnx" with { type: "file" };
-
-const modelOptions = {
-  model: {
-    detection: detModel,
-    recognition: recModel,
-    charactersDictionary: dict,
-  },
-};
-
 const imgFile = Bun.file(`${import.meta.dir}/../assets/receipt.jpg`);
 const imageBuffer = await imgFile.arrayBuffer();
 
@@ -34,7 +22,6 @@ for (const engine of ["opencv", "canvas-native"] as const) {
   console.log(`=== Engine: ${engine} ===`);
 
   const service = new PaddleOcrService({
-    ...modelOptions,
     processing: { engine },
   });
 


### PR DESCRIPTION
## What

Make every benchmark measure the library's **shipped default models (v5)**
instead of the stale v4 recognition model committed under `models/`, and
refresh the README benchmark numbers accordingly.

## Why

`models/en_PP-OCRv4_mobile_rec_infer.onnx` is a v4 recognition model, but the
library defaults to **v5** (`en_PP-OCRv5_mobile_rec_infer.ort`, fetched on first
run). `bench/batch.bench.ts` and `bench/profile.ts` imported the v4 file
explicitly, so they benchmarked a model the library doesn't ship — producing
misleading numbers (and a recurring "why is this v4?" confusion). `bench/index.bench.ts`
already used the default; this brings the others in line.

## How

- Drop the explicit `model: { detection, recognition, charactersDictionary }`
  paths from `bench/batch.bench.ts` and `bench/profile.ts`; `initialize()` then
  loads the default v5 models (auto-downloaded/cached, same as production).
- Re-ran `bench/batch.bench.ts` on v5 and updated the README "Batch vs.
  concurrent recognize()" table. Conclusion is unchanged: parallel approaches
  land within ~4% on time, and `batchRecognize` holds peak RSS bounded
  (~1030–1100 MB) vs unbounded `Promise.all` (~1430 MB).

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [x] Benchmark run if this touches the hot path (`bench/batch.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added (n/a — benchmarks only)

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser — WebAssembly fallback (Safari, older Firefox)
- [ ] Browser — WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- Benchmarks-only change; no runtime code touched.
