### PR TITLE
feat: add CLI exposing the full library surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Build
         run: bun run build
 
+      # The bin is only usable via npx/bunx if the build kept its shebang and
+      # executable bit; assert both, then that it actually runs.
+      - name: CLI — verify bin
+        run: |
+          test -x lib/cli/index.js
+          head -1 lib/cli/index.js | grep -q '^#!/usr/bin/env node'
+          node lib/cli/index.js --version
+
       # apps/serve is a standalone package (its own deps); check it separately.
       - name: Serve — install
         run: cd apps/serve && bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,5 +55,12 @@ jobs:
       - name: Copy package files
         run: cp README.md package.json lib/
 
+      # Guard the bin before it ships: it must run and be in the tarball, or
+      # `npx ppu-paddle-ocr` breaks for everyone.
+      - name: Verify CLI bin is runnable and packed
+        run: |
+          node lib/cli/index.js --version
+          npm pack ./lib --dry-run 2>&1 | grep -q 'cli/index.js'
+
       - name: Publish to npm
         run: npm publish ./lib --access=public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First-party CLI — `bunx ppu-paddle-ocr …` / `npx ppu-paddle-ocr …`.** Shipped as a `bin` in the package (no extra install), it covers the whole library surface: `recognize` (single image), `batch` and `stream` (globs or lists, with bounded concurrency), plus `download-models`, `clear-cache`, and `models`. Every `PaddleOptions` / `RecognizeOptions` field has a flag — `--strategy`, `--engine`, `--flatten`, `--model-detection/-recognition/-dict`, detection tuning (`--max-side-length`, `--mean`, `--std`, …), `--execution-providers`, `--concurrency`, and output controls (`--json`, `--pretty`, `-o`, `-q`). Recognized text goes to stdout, progress/logs to stderr; exit codes are `0` success / `1` runtime error / `2` usage error. Uses the default v5 models unless overridden. Cross-runtime (Node and Bun); no new runtime dependencies (`node:util.parseArgs`).
+
 ## [5.6.0] - 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Slack](https://img.shields.io/badge/Slack-Community-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/ppupaddleocrcommunity/shared_invite/zt-3uzp1uuma-lrkEq8OYBYhGdUtzRoVmUg) [![NPM](https://img.shields.io/npm/dw/ppu-paddle-ocr)](https://www.npmjs.com/package/ppu-paddle-ocr)
 
-Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, web browsers, and browser extensions. Docker-ready. The official SDK is browser-only and significantly slower. [Compare it for yourself](https://snowfluke.github.io/paddle-ocr-comparison/).
+Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only and significantly slower. [Compare it for yourself](https://snowfluke.github.io/paddle-ocr-comparison/).
 
-Need it as HTTP-service? dockerized? we've got you covered! Quickly spins up ppu-paddle-ocr REST API here: [ppu-paddle-ocr-serve](/apps/serve/README.md)
+Need it as HTTP-service? dockerized? we've got you covered! Quickly spins up ppu-paddle-ocr REST API here: [ppu-paddle-ocr-serve](/apps/serve/README.md). Need a CLI instead? sure here: [ppu-paddle-ocr CLI support](#command-line).
 
 ![ppu-paddle-ocr demo](https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr/refs/heads/main/assets/ppu-paddle-ocr-demo.jpg)
 
@@ -31,6 +31,7 @@ await service.destroy();
   - [Custom Models](#custom-models)
   - [Changing Models at Runtime](#changing-models-at-runtime)
   - [Per-Call Options](#per-call-options)
+- [Command Line](#command-line)
 - [Batch Recognition](#batch-recognition)
 - [Recognition Strategies](#recognition-strategies)
 - [Image Preprocessing](#image-preprocessing)
@@ -162,6 +163,33 @@ const result = await service.recognize("./assets/receipt.jpg", {
   strategy: "per-box",
 });
 ```
+
+## Command Line
+
+The package ships a `bin`, so you can OCR without writing any code — `bunx`/`npx` resolve it directly (no global install):
+
+```bash
+# one image → recognized text on stdout
+bunx ppu-paddle-ocr recognize receipt.jpg
+
+# a URL, as structured JSON
+npx ppu-paddle-ocr recognize https://example.com/invoice.png --json --pretty
+
+# many images (glob), fastest strategy, written to a file
+bunx ppu-paddle-ocr batch "scans/*.png" --strategy cross-line --json -o results.json
+
+# print each result as it finishes
+bunx ppu-paddle-ocr stream "scans/*.png"
+
+# pre-warm / clear the model cache, inspect the active config
+bunx ppu-paddle-ocr download-models
+bunx ppu-paddle-ocr clear-cache
+bunx ppu-paddle-ocr models --json
+```
+
+Every `PaddleOptions` / `RecognizeOptions` field maps to a flag: `--strategy`, `--engine`, `--flatten`, `--no-cache`, `--image-height`, `--model-detection/-recognition/-dict`, detection tuning (`--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`), `--execution-providers`, and for `batch`/`stream` `--concurrency`. Output is controlled by `--json`, `--pretty`, `-o/--output`, `-q/--quiet`, and `--verbose`.
+
+Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error. Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v5 models unless you override the `--model-*` flags.
 
 ## Batch Recognition
 

--- a/package.json
+++ b/package.json
@@ -37,13 +37,17 @@
     "text-recognition",
     "typescript-ocr",
     "web-ocr",
-    "docker-ocr"
+    "docker-ocr",
+    "cli-ocr"
   ],
   "author": "snowfluke",
   "license": "MIT",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
+  "bin": {
+    "ppu-paddle-ocr": "./cli/index.js"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,5 @@
 /// <reference types='bun-types' />
-import { existsSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path/posix";
 
 import { transpileDeclaration } from "typescript";
@@ -32,7 +32,16 @@ for (const path of new Bun.Glob("**/*.ts").scanSync(SOURCEDIR)) {
   const buf = await Bun.file(srcPath).text();
   const res = transpiler.transformSync(buf);
   if (res.length !== 0) {
-    Bun.write(`${outPathNoExt}.js`, res.replace(/const /g, "let "));
+    let js = res.replace(/const /g, "let ");
+
+    // Preserve a leading shebang the transpiler strips, then mark the bin
+    // executable so `npx`/`bunx ppu-paddle-ocr` can run it directly.
+    const shebang = buf.startsWith("#!") ? buf.slice(0, buf.indexOf("\n")) : null;
+    if (shebang && !js.startsWith("#!")) js = `${shebang}\n${js}`;
+
+    const outFile = `${outPathNoExt}.js`;
+    await Bun.write(outFile, js);
+    if (shebang) chmodSync(outFile, 0o755);
   }
   Bun.write(
     `${outPathNoExt}.d.ts`,

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -415,6 +415,43 @@ curl -F file=@receipt.jpg http://localhost:8080/v1/ocr
 
 What it provides on top of the raw SDK: one warmed `PaddleOcrService` behind a bounded inference queue (backpressure, no OOM/VRAM blow-up), sync / batch / SSE-stream / async-task OCR endpoints, a consistent response envelope with a request id, optional bearer auth + rate limiting + IP rules, Prometheus `/metrics`, and an OpenAPI spec rendered at `/docs`. Config is via env vars; models are pre-baked into the image (zero cold start). Use the standalone SDK (the rest of this skill) when you're building a JS/TS app; use the serve API when you want a deployable service. See [`apps/serve/README.md`](../../apps/serve/README.md).
 
+## The command-line interface (don't write a script)
+
+When the user just wants text out of an image — a one-shot, a shell pipeline, a
+quick check — point them at the bundled CLI instead of writing a `new → initialize
+→ recognize → destroy` script. It ships as a `bin` in the package, so `bunx`/`npx`
+run it with no install:
+
+```bash
+bunx ppu-paddle-ocr recognize receipt.jpg            # text → stdout
+bunx ppu-paddle-ocr recognize page.png --json --pretty
+bunx ppu-paddle-ocr batch "scans/*.png" --strategy cross-line --json -o out.json
+bunx ppu-paddle-ocr stream "scans/*.png"             # prints each result as it finishes
+bunx ppu-paddle-ocr download-models                  # warm the cache
+bunx ppu-paddle-ocr clear-cache
+bunx ppu-paddle-ocr models --json                    # active models / defaults / providers
+```
+
+Rules to remember:
+
+- It's **Node/Bun only** — the `bin` is the `ppu-paddle-ocr` entry point, not `/web`.
+- Every constructor / per-call option has a flag: `--strategy`, `--engine`,
+  `--flatten`, `--no-cache`, `--model-detection/-recognition/-dict`, detection
+  tuning (`--max-side-length`, `--mean`, `--std`, …), `--execution-providers`,
+  and `--concurrency` for batch/stream. Defaults match the SDK (v5 models,
+  `per-line`, `opencv`).
+- **Recognized text → stdout; progress and logs → stderr.** Pipe stdout safely;
+  add `-q` to silence stderr. `--json` emits the full result object (NDJSON for
+  `stream`); `-o <file>` writes to disk.
+- Exit codes: `0` success, `1` runtime error, `2` usage error. An image with no
+  detected text still exits `0` with empty output.
+- `recognize` is strictly one image; use `batch` (index-aligned JSON) or `stream`
+  (results in completion order) for many. Both isolate per-image failures and
+  exit `1` if any image failed.
+
+Reach for the CLI for ad-hoc/scripting use, the SDK when embedding in a JS/TS
+program, and `apps/serve` when you need a long-running HTTP service.
+
 ## Further reading
 
 - [`references/configuration.md`](references/configuration.md) — every option in `PaddleOptions`, defaults, and when to tune them.

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,178 @@
+/**
+ * Command implementations. Each owns one `PaddleOcrService` lifecycle and
+ * throws `CliError` on failure; the dispatcher in `index.ts` maps that to an
+ * exit code. Recognized text and structured JSON go to stdout; progress and
+ * logs go to stderr.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+import type { AnyOcrResult } from "../core/base-paddle-ocr.service.js";
+import { DEFAULT_MODEL_URLS } from "../core/base-paddle-ocr.service.js";
+import { PaddleOcrService } from "../processor/paddle-ocr.service.js";
+import {
+  CliError,
+  expandPatterns,
+  isMissingLocalFile,
+  loadImageInput,
+  logStderr,
+  writeOutput,
+} from "./io.js";
+import type { CliValues } from "./options.js";
+import { buildBatchOptions, buildPaddleOptions, buildRecognizeOptions } from "./options.js";
+
+type BatchEntry = {
+  file: string;
+  status: "fulfilled" | "rejected";
+  result?: AnyOcrResult;
+  error?: string;
+};
+
+function stringify(value: unknown, values: CliValues): string {
+  return JSON.stringify(value, null, values.pretty ? 2 : undefined);
+}
+
+function errMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+/** Fail fast if any local (non-URL) path is missing, before warming models. */
+function assertLocalFilesExist(files: string[]): void {
+  const missing = files.filter(isMissingLocalFile);
+  if (missing.length > 0) {
+    throw new CliError(`No such file${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`);
+  }
+}
+
+export async function runRecognize(images: string[], values: CliValues): Promise<void> {
+  const [image] = images;
+  if (!image || images.length !== 1) {
+    throw new CliError("recognize takes exactly one image; use 'batch' for multiple", 2);
+  }
+  const service = new PaddleOcrService(buildPaddleOptions(values));
+  try {
+    logStderr("Loading models...", Boolean(values.quiet));
+    await service.initialize();
+    const input = await loadImageInput(image);
+    const opts = buildRecognizeOptions(values);
+    const result = values.flatten
+      ? await service.recognize(input, { ...opts, flatten: true })
+      : await service.recognize(input, { ...opts, flatten: false });
+    if (values.json) {
+      writeOutput(stringify(result, values), values.output as string | undefined);
+    } else {
+      writeOutput(result.text, values.output as string | undefined);
+    }
+  } finally {
+    await service.destroy();
+  }
+}
+
+export async function runBatch(patterns: string[], values: CliValues): Promise<void> {
+  const files = expandPatterns(patterns);
+  if (files.length === 0) throw new CliError("batch needs at least one image", 2);
+  assertLocalFilesExist(files);
+
+  const service = new PaddleOcrService(buildPaddleOptions(values));
+  try {
+    logStderr(`Loading models, then OCR'ing ${files.length} image(s)...`, Boolean(values.quiet));
+    await service.initialize();
+
+    const inputs = async function* (): AsyncGenerator<ArrayBuffer> {
+      for (const file of files) yield loadImageInput(file);
+    };
+    const settled = await service.batchRecognize(inputs(), {
+      ...buildBatchOptions(values),
+      settle: true,
+      onProgress: (done) => logStderr(`  ${done}/${files.length}`, Boolean(values.quiet)),
+    });
+
+    const entries: BatchEntry[] = settled.map((item) => {
+      const file = files[item.index] ?? "?";
+      return item.status === "fulfilled"
+        ? { file, status: "fulfilled", result: item.value }
+        : { file, status: "rejected", error: errMessage(item.reason) };
+    });
+
+    if (values.json) {
+      writeOutput(stringify(entries, values), values.output as string | undefined);
+    } else {
+      const blocks = entries.map((e) =>
+        e.result ? `==> ${e.file} <==\n${e.result.text}` : `==> ${e.file} <==\nERROR: ${e.error}`
+      );
+      writeOutput(blocks.join("\n\n"), values.output as string | undefined);
+    }
+
+    if (entries.some((e) => e.status === "rejected")) {
+      throw new CliError(
+        `${entries.filter((e) => e.status === "rejected").length} image(s) failed`
+      );
+    }
+  } finally {
+    await service.destroy();
+  }
+}
+
+export async function runStream(patterns: string[], values: CliValues): Promise<void> {
+  const files = expandPatterns(patterns);
+  if (files.length === 0) throw new CliError("stream needs at least one image", 2);
+  assertLocalFilesExist(files);
+
+  const service = new PaddleOcrService(buildPaddleOptions(values));
+  let failures = 0;
+  try {
+    logStderr("Loading models...", Boolean(values.quiet));
+    await service.initialize();
+
+    const inputs = async function* (): AsyncGenerator<ArrayBuffer> {
+      for (const file of files) yield loadImageInput(file);
+    };
+    for await (const item of service.batchRecognizeStream(inputs(), {
+      ...buildBatchOptions(values),
+      settle: true,
+    })) {
+      const file = files[item.index] ?? "?";
+      if (item.status === "fulfilled") {
+        const entry: BatchEntry = { file, status: "fulfilled", result: item.value };
+        writeOutput(values.json ? stringify(entry, values) : `==> ${file} <==\n${item.value.text}`);
+      } else {
+        failures++;
+        const error = errMessage(item.reason);
+        const entry: BatchEntry = { file, status: "rejected", error };
+        if (values.json) writeOutput(stringify(entry, values));
+        else logStderr(`==> ${file} <==\nERROR: ${error}`, Boolean(values.quiet));
+      }
+    }
+  } finally {
+    await service.destroy();
+  }
+  if (failures > 0) throw new CliError(`${failures} image(s) failed`);
+}
+
+export async function runDownloadModels(values: CliValues): Promise<void> {
+  await PaddleOcrService.downloadModels({ verbose: !values.quiet });
+  logStderr("Models cached.", Boolean(values.quiet));
+}
+
+export function runClearCache(values: CliValues): void {
+  new PaddleOcrService().clearModelCache();
+  logStderr("Cache cleared.", Boolean(values.quiet));
+}
+
+export function runModels(values: CliValues): void {
+  const built = buildPaddleOptions(values);
+  const info = {
+    cacheDir: path.join(os.homedir(), ".cache", "ppu-paddle-ocr"),
+    models: {
+      detection: built.model?.detection ?? DEFAULT_MODEL_URLS.detection,
+      recognition: built.model?.recognition ?? DEFAULT_MODEL_URLS.recognition,
+      charactersDictionary:
+        built.model?.charactersDictionary ?? DEFAULT_MODEL_URLS.charactersDictionary,
+    },
+    strategy: built.recognition?.strategy ?? "per-line",
+    engine: built.processing?.engine ?? "opencv",
+    executionProviders: built.session?.executionProviders ?? ["cpu"],
+  };
+  writeOutput(stringify(info, values), values.output as string | undefined);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,63 @@
+/**
+ * Usage text for the `ppu-paddle-ocr` CLI. Printed to stdout for `help` /
+ * `--help`, and to stderr (followed by a non-zero exit) on usage errors.
+ */
+
+export const USAGE = `ppu-paddle-ocr — PaddleOCR on the command line
+
+Usage:
+  ppu-paddle-ocr <command> [args] [flags]
+
+Commands:
+  recognize <image>      OCR one image (file path or http(s) URL)
+  batch <pattern...>     OCR many images (globs or a list of paths/URLs)
+  stream <pattern...>    OCR many images, printing each result as it finishes
+  download-models        Pre-warm the model cache (~/.cache/ppu-paddle-ocr)
+  clear-cache            Delete the cached model files
+  models                 Print the active models, defaults, and providers
+  help                   Show this help
+  version                Show the installed version
+
+Recognition flags (recognize / batch / stream):
+  --strategy <s>                 per-box | per-line | cross-line  (default per-line)
+  --cross-line-width-factor <n>  bin-pack width multiplier for cross-line (default 1.0)
+  --engine <e>                   opencv | canvas-native  (default opencv)
+  --image-height <n>             recognition input height in px (default 48)
+  --flatten                      flat results in reading order instead of grouped lines
+  --no-cache                     bypass the in-memory result cache
+
+Model overrides:
+  --model-detection <path|url>
+  --model-recognition <path|url>
+  --model-dict <path|url>
+
+Detection tuning:
+  --max-side-length <n>          longest side before downscale (default 640)
+  --padding-vertical <n>         box padding, fraction of height (default 0.4)
+  --padding-horizontal <n>       box padding, fraction of height (default 0.6)
+  --min-area <n>                 drop boxes smaller than this area in px (default 50)
+  --mean <r,g,b>                 normalization mean (default 0.485,0.456,0.406)
+  --std <r,g,b>                  normalization std dev (default 0.229,0.224,0.225)
+
+Session:
+  --execution-providers <list>   comma-separated, e.g. cpu or cuda,cpu  (default cpu)
+
+Batch / stream:
+  --concurrency <n|auto>         images in flight at once (default auto)
+  --settle                       keep going past a failed image (default on for batch/stream)
+
+Output:
+  -o, --output <file>            write to a file instead of stdout
+  --json                         emit structured JSON (NDJSON for stream)
+  --pretty                       indent JSON output
+  -q, --quiet                    suppress progress/logs on stderr
+  --verbose                      log each processing step to stderr
+  --debug                        dump intermediate frames to disk
+  --debug-folder <dir>           where --debug writes (default out)
+
+Examples:
+  ppu-paddle-ocr recognize receipt.jpg
+  ppu-paddle-ocr recognize https://example.com/invoice.png --json --pretty
+  ppu-paddle-ocr batch "scans/*.png" --strategy cross-line -o results.json --json
+  ppu-paddle-ocr download-models --verbose
+`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * `ppu-paddle-ocr` executable entry point. Thin shim around {@link main}: wires
+ * argv, the SIGINT handler, and the final exit code. All logic lives in
+ * `run.ts` so it stays importable from tests without side effects.
+ */
+
+import { main } from "./run.js";
+
+process.on("SIGINT", () => process.exit(130));
+
+try {
+  process.exit(await main(process.argv.slice(2)));
+} catch (e) {
+  process.stderr.write(`${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`);
+  process.exit(1);
+}

--- a/src/cli/io.ts
+++ b/src/cli/io.ts
@@ -1,0 +1,101 @@
+/**
+ * Cross-runtime IO helpers for the CLI. Deliberately free of `Bun.*` globals so
+ * the published `bin` runs under plain `node` (via `npx`) as well as Bun.
+ */
+
+import { existsSync, globSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** A non-zero-exit error carrying the intended process exit code. */
+export class CliError extends Error {
+  public readonly code: number;
+  public constructor(message: string, code = 1) {
+    super(message);
+    this.name = "CliError";
+    this.code = code;
+  }
+}
+
+/** Throw a usage error (exit code 2). */
+export function usageError(message: string): never {
+  throw new CliError(message, 2);
+}
+
+const HTTP = /^https?:\/\//i;
+const GLOB_MAGIC = /[*?[\]{}]/;
+
+/**
+ * Resolve a CLI image argument to an `ArrayBuffer`. The Node `recognize()`
+ * accepts only `ArrayBuffer`/`Canvas`, so URLs are fetched here and files read
+ * from disk — which also sidesteps the SDK's absolute-path-only string rule.
+ */
+export async function loadImageInput(arg: string): Promise<ArrayBuffer> {
+  if (HTTP.test(arg)) {
+    const res = await fetch(arg);
+    if (!res.ok) throw new CliError(`Failed to fetch ${arg}: ${res.status} ${res.statusText}`);
+    return res.arrayBuffer();
+  }
+  if (!existsSync(arg)) throw new CliError(`No such file: ${arg}`);
+  const buf = readFileSync(arg);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+/** True if a non-URL path is missing on disk. URLs are assumed reachable. */
+export function isMissingLocalFile(arg: string): boolean {
+  return !HTTP.test(arg) && !existsSync(arg);
+}
+
+/**
+ * Expand positional patterns into a concrete list. Glob patterns are resolved
+ * against the filesystem; plain paths and URLs pass through verbatim so a typo
+ * surfaces as a clear "No such file" later instead of silently vanishing.
+ */
+export function expandPatterns(patterns: string[]): string[] {
+  const out: string[] = [];
+  for (const pattern of patterns) {
+    if (HTTP.test(pattern) || !GLOB_MAGIC.test(pattern)) {
+      out.push(pattern);
+      continue;
+    }
+    const matches = globSync(pattern).sort();
+    if (matches.length === 0) throw new CliError(`No files match: ${pattern}`);
+    out.push(...matches);
+  }
+  return out;
+}
+
+/** Walk up from this module to the nearest `ppu-paddle-ocr` package.json. */
+export function readVersion(): string {
+  let dir = import.meta.dirname;
+  for (;;) {
+    const pkgPath = join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+          name?: string;
+          version?: string;
+        };
+        if (pkg.name === "ppu-paddle-ocr" && pkg.version) return pkg.version;
+      } catch {
+        // keep walking up
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return "0.0.0";
+    dir = parent;
+  }
+}
+
+/** Write `content` to a file (with trailing newline) or to stdout. */
+export function writeOutput(content: string, outputPath?: string): void {
+  if (outputPath) {
+    writeFileSync(outputPath, content.endsWith("\n") ? content : `${content}\n`);
+    return;
+  }
+  process.stdout.write(content.endsWith("\n") ? content : `${content}\n`);
+}
+
+/** Log a line to stderr unless quiet. */
+export function logStderr(message: string, quiet: boolean): void {
+  if (!quiet) process.stderr.write(`${message}\n`);
+}

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,0 +1,190 @@
+/**
+ * Maps parsed CLI flags onto the library's option objects. Every flag here has
+ * a 1:1 counterpart in `PaddleOptions` / `RecognizeOptions`.
+ */
+
+import type { ParseArgsConfig } from "node:util";
+
+import type {
+  BatchRecognizeOptions,
+  PaddleOptions,
+  ProcessingEngine,
+  RecognitionStrategy,
+  RecognizeOptions,
+} from "../interface.js";
+import { usageError } from "./io.js";
+
+/** `parseArgs` option spec shared by every command. */
+export const PARSE_OPTIONS: NonNullable<ParseArgsConfig["options"]> = {
+  strategy: { type: "string" },
+  "cross-line-width-factor": { type: "string" },
+  engine: { type: "string" },
+  "image-height": { type: "string" },
+  flatten: { type: "boolean" },
+  "no-cache": { type: "boolean" },
+  "model-detection": { type: "string" },
+  "model-recognition": { type: "string" },
+  "model-dict": { type: "string" },
+  "max-side-length": { type: "string" },
+  "padding-vertical": { type: "string" },
+  "padding-horizontal": { type: "string" },
+  "min-area": { type: "string" },
+  mean: { type: "string" },
+  std: { type: "string" },
+  "execution-providers": { type: "string" },
+  concurrency: { type: "string" },
+  settle: { type: "boolean" },
+  output: { type: "string", short: "o" },
+  json: { type: "boolean" },
+  pretty: { type: "boolean" },
+  quiet: { type: "boolean", short: "q" },
+  verbose: { type: "boolean" },
+  debug: { type: "boolean" },
+  "debug-folder": { type: "string" },
+  help: { type: "boolean", short: "h" },
+  version: { type: "boolean", short: "v" },
+};
+
+/** Shape of `parseArgs().values` for the spec above. */
+export type CliValues = Record<string, string | boolean | undefined>;
+
+const STRATEGIES: RecognitionStrategy[] = ["per-box", "per-line", "cross-line"];
+const ENGINES: ProcessingEngine[] = ["opencv", "canvas-native"];
+
+function num(values: CliValues, key: string): number | undefined {
+  const raw = values[key];
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (Number.isNaN(n)) usageError(`--${key} must be a number, got "${String(raw)}"`);
+  return n;
+}
+
+function triple(values: CliValues, key: string): [number, number, number] | undefined {
+  const raw = values[key];
+  if (raw === undefined) return undefined;
+  const parts = String(raw)
+    .split(",")
+    .map((p) => Number(p.trim()));
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    usageError(`--${key} must be three comma-separated numbers, e.g. 0.485,0.456,0.406`);
+  }
+  return parts as [number, number, number];
+}
+
+function strategy(values: CliValues): RecognitionStrategy | undefined {
+  const raw = values.strategy;
+  if (raw === undefined) return undefined;
+  if (!STRATEGIES.includes(raw as RecognitionStrategy)) {
+    usageError(`--strategy must be one of ${STRATEGIES.join(" | ")}`);
+  }
+  return raw as RecognitionStrategy;
+}
+
+function engine(values: CliValues): ProcessingEngine | undefined {
+  const raw = values.engine;
+  if (raw === undefined) return undefined;
+  if (!ENGINES.includes(raw as ProcessingEngine)) {
+    usageError(`--engine must be one of ${ENGINES.join(" | ")}`);
+  }
+  return raw as ProcessingEngine;
+}
+
+/** Build the constructor `PaddleOptions` from parsed flags. */
+export function buildPaddleOptions(values: CliValues): PaddleOptions {
+  const options: PaddleOptions = {};
+
+  const detection = values["model-detection"] as string | undefined;
+  const recognition = values["model-recognition"] as string | undefined;
+  const dict = values["model-dict"] as string | undefined;
+  if (detection || recognition || dict) {
+    options.model = {
+      ...(detection ? { detection } : {}),
+      ...(recognition ? { recognition } : {}),
+      ...(dict ? { charactersDictionary: dict } : {}),
+    };
+  }
+
+  const mean = triple(values, "mean");
+  const stdDeviation = triple(values, "std");
+  const maxSideLength = num(values, "max-side-length");
+  const paddingVertical = num(values, "padding-vertical");
+  const paddingHorizontal = num(values, "padding-horizontal");
+  const minimumAreaThreshold = num(values, "min-area");
+  if (
+    mean ||
+    stdDeviation ||
+    maxSideLength !== undefined ||
+    paddingVertical !== undefined ||
+    paddingHorizontal !== undefined ||
+    minimumAreaThreshold !== undefined
+  ) {
+    options.detection = {
+      ...(mean ? { mean } : {}),
+      ...(stdDeviation ? { stdDeviation } : {}),
+      ...(maxSideLength !== undefined ? { maxSideLength } : {}),
+      ...(paddingVertical !== undefined ? { paddingVertical } : {}),
+      ...(paddingHorizontal !== undefined ? { paddingHorizontal } : {}),
+      ...(minimumAreaThreshold !== undefined ? { minimumAreaThreshold } : {}),
+    };
+  }
+
+  const strat = strategy(values);
+  const imageHeight = num(values, "image-height");
+  const crossLineWidthFactor = num(values, "cross-line-width-factor");
+  // `charactersDictionary: []` is the documented placeholder — initialize()
+  // fills it from the recognition model's dictionary.
+  options.recognition = {
+    charactersDictionary: [],
+    ...(strat ? { strategy: strat } : {}),
+    ...(imageHeight !== undefined ? { imageHeight } : {}),
+    ...(crossLineWidthFactor !== undefined ? { crossLineWidthFactor } : {}),
+  };
+
+  const eng = engine(values);
+  if (eng) options.processing = { engine: eng };
+
+  const providers = values["execution-providers"] as string | undefined;
+  if (providers) {
+    options.session = {
+      executionProviders: providers.split(",").map((p) => p.trim()),
+    };
+  }
+
+  if (values.verbose || values.debug || values["debug-folder"]) {
+    options.debugging = {
+      ...(values.verbose ? { verbose: true } : {}),
+      ...(values.debug ? { debug: true } : {}),
+      ...(values["debug-folder"] ? { debugFolder: values["debug-folder"] as string } : {}),
+    };
+  }
+
+  return options;
+}
+
+/** Per-call recognize options from parsed flags. */
+export function buildRecognizeOptions(values: CliValues): RecognizeOptions {
+  return {
+    ...(values.flatten ? { flatten: true } : {}),
+    ...(values["no-cache"] ? { noCache: true } : {}),
+    ...(strategy(values) ? { strategy: strategy(values) } : {}),
+  };
+}
+
+/** Batch options: recognize options plus concurrency/settle. */
+export function buildBatchOptions(values: CliValues): BatchRecognizeOptions {
+  const raw = values.concurrency as string | undefined;
+  let concurrency: number | "auto" | undefined;
+  if (raw !== undefined) {
+    if (raw === "auto") {
+      concurrency = "auto";
+    } else {
+      const n = Number(raw);
+      if (Number.isNaN(n) || n < 1) usageError(`--concurrency must be a positive number or "auto"`);
+      concurrency = n;
+    }
+  }
+  return {
+    ...buildRecognizeOptions(values),
+    ...(concurrency !== undefined ? { concurrency } : {}),
+  };
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,84 @@
+/**
+ * Argv parsing and command dispatch. Kept free of top-level side effects so it
+ * can be imported and exercised in tests; `index.ts` is the executable shim
+ * that calls {@link main} and translates the return value into an exit code.
+ *
+ * Exit codes: 0 success, 1 runtime error, 2 usage error.
+ */
+
+import { parseArgs } from "node:util";
+
+import {
+  runBatch,
+  runClearCache,
+  runDownloadModels,
+  runModels,
+  runRecognize,
+  runStream,
+} from "./commands.js";
+import { USAGE } from "./help.js";
+import { CliError, readVersion } from "./io.js";
+import type { CliValues } from "./options.js";
+import { PARSE_OPTIONS } from "./options.js";
+
+async function dispatch(command: string, rest: string[], values: CliValues): Promise<void> {
+  switch (command) {
+    case "recognize":
+      return runRecognize(rest, values);
+    case "batch":
+      return runBatch(rest, values);
+    case "stream":
+      return runStream(rest, values);
+    case "download-models":
+      return runDownloadModels(values);
+    case "clear-cache":
+      return runClearCache(values);
+    case "models":
+      return runModels(values);
+    default:
+      throw new CliError(`Unknown command: ${command}\n\n${USAGE}`, 2);
+  }
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: PARSE_OPTIONS,
+      allowPositionals: true,
+      strict: true,
+    });
+  } catch (e) {
+    process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n\n${USAGE}`);
+    return 2;
+  }
+
+  const values = parsed.values as CliValues;
+  const [command, ...rest] = parsed.positionals;
+
+  if (values.version) {
+    process.stdout.write(`${readVersion()}\n`);
+    return 0;
+  }
+  if (!command || command === "help" || values.help) {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+  if (command === "version") {
+    process.stdout.write(`${readVersion()}\n`);
+    return 0;
+  }
+
+  try {
+    await dispatch(command, rest, values);
+    return 0;
+  } catch (e) {
+    if (e instanceof CliError) {
+      process.stderr.write(`${e.message}\n`);
+      return e.code;
+    }
+    process.stderr.write(`${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`);
+    return 1;
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
+import { expandPatterns, isMissingLocalFile, loadImageInput } from "../src/cli/io.js";
+import {
+  buildBatchOptions,
+  buildPaddleOptions,
+  buildRecognizeOptions,
+} from "../src/cli/options.js";
+import { main } from "../src/cli/run.js";
+
+const ASSETS = `${import.meta.dir}/../assets`;
+const RECEIPT = `${ASSETS}/receipt.jpg`;
+const TILTED = `${ASSETS}/tilted.png`;
+
+let workdir: string;
+let badImage: string;
+
+/** Run `main` with stdout/stderr captured in-process. */
+async function run(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  let out = "";
+  let err = "";
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = (chunk: string) => ((out += chunk), true);
+  process.stderr.write = (chunk: string) => ((err += chunk), true);
+  try {
+    const code = await main(args);
+    return { code, out, err };
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+}
+
+beforeAll(async () => {
+  // Warm the cache once so OCR commands don't pay download latency per test.
+  await PaddleOcrService.downloadModels();
+  workdir = mkdtempSync(join(tmpdir(), "ppu-cli-"));
+  badImage = join(workdir, "not-an-image.png");
+  writeFileSync(badImage, "this is not a PNG");
+});
+
+afterAll(() => {
+  if (workdir && existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+});
+
+// ─── Option builders (pure, no models) ──────────────────────────────────────
+
+describe("option builders", () => {
+  test("buildRecognizeOptions maps the per-call flags", () => {
+    expect(buildRecognizeOptions({ flatten: true, "no-cache": true })).toEqual({
+      flatten: true,
+      noCache: true,
+    });
+    expect(buildRecognizeOptions({ strategy: "per-box" })).toEqual({ strategy: "per-box" });
+    expect(buildRecognizeOptions({})).toEqual({});
+  });
+
+  test("buildPaddleOptions maps detection, recognition, processing, session, model", () => {
+    const opts = buildPaddleOptions({
+      "model-detection": "/d.onnx",
+      "model-dict": "/dict.txt",
+      strategy: "cross-line",
+      "cross-line-width-factor": "1.2",
+      "image-height": "64",
+      engine: "canvas-native",
+      "max-side-length": "960",
+      mean: "0.1,0.2,0.3",
+      "execution-providers": "cuda,cpu",
+      verbose: true,
+    });
+    expect(opts.model).toEqual({ detection: "/d.onnx", charactersDictionary: "/dict.txt" });
+    expect(opts.detection).toEqual({ maxSideLength: 960, mean: [0.1, 0.2, 0.3] });
+    expect(opts.recognition).toEqual({
+      charactersDictionary: [],
+      strategy: "cross-line",
+      crossLineWidthFactor: 1.2,
+      imageHeight: 64,
+    });
+    expect(opts.processing).toEqual({ engine: "canvas-native" });
+    expect(opts.session).toEqual({ executionProviders: ["cuda", "cpu"] });
+    expect(opts.debugging).toEqual({ verbose: true });
+  });
+
+  test("buildBatchOptions parses concurrency", () => {
+    expect(buildBatchOptions({ concurrency: "auto" }).concurrency).toBe("auto");
+    expect(buildBatchOptions({ concurrency: "4" }).concurrency).toBe(4);
+    expect(buildBatchOptions({}).concurrency).toBeUndefined();
+  });
+
+  test("invalid flag values throw a usage error (exit code 2)", () => {
+    expect(() => buildPaddleOptions({ strategy: "nonsense" })).toThrow();
+    expect(() => buildPaddleOptions({ engine: "nonsense" })).toThrow();
+    expect(() => buildPaddleOptions({ "max-side-length": "abc" })).toThrow();
+    expect(() => buildPaddleOptions({ mean: "1,2" })).toThrow();
+    expect(() => buildBatchOptions({ concurrency: "0" })).toThrow();
+  });
+});
+
+// ─── IO helpers ─────────────────────────────────────────────────────────────
+
+describe("io helpers", () => {
+  test("expandPatterns globs, passes literals through, and errors on no match", () => {
+    expect(expandPatterns([RECEIPT])).toEqual([RECEIPT]);
+    expect(expandPatterns(["https://example.com/a.png"])).toEqual(["https://example.com/a.png"]);
+    expect(expandPatterns([`${ASSETS}/*.jpg`].map(String)).length).toBeGreaterThan(0);
+    expect(() => expandPatterns([`${ASSETS}/does-not-exist-*.zzz`])).toThrow();
+  });
+
+  test("isMissingLocalFile flags missing paths but trusts URLs", () => {
+    expect(isMissingLocalFile(RECEIPT)).toBe(false);
+    expect(isMissingLocalFile(`${ASSETS}/nope.jpg`)).toBe(true);
+    expect(isMissingLocalFile("https://example.com/x.png")).toBe(false);
+  });
+
+  test("loadImageInput reads a file into an ArrayBuffer and rejects missing files", async () => {
+    const buf = await loadImageInput(RECEIPT);
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+    expect(buf.byteLength).toBeGreaterThan(0);
+    await expect(loadImageInput(`${ASSETS}/nope.jpg`)).rejects.toBeDefined();
+  });
+});
+
+// ─── Usage / argument handling (no models) ──────────────────────────────────
+
+describe("argument handling", () => {
+  test("--version prints the package version", async () => {
+    const { code, out } = await run(["--version"]);
+    expect(code).toBe(0);
+    expect(out.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("help and no-args both print usage", async () => {
+    expect((await run(["help"])).out).toContain("Usage:");
+    const noArgs = await run([]);
+    expect(noArgs.code).toBe(0);
+    expect(noArgs.out).toContain("Usage:");
+  });
+
+  test("unknown command exits 2 with usage", async () => {
+    const { code, err } = await run(["frobnicate"]);
+    expect(code).toBe(2);
+    expect(err).toContain("Unknown command");
+  });
+
+  test("unknown flag exits 2", async () => {
+    expect((await run(["recognize", "x.jpg", "--nope"])).code).toBe(2);
+  });
+
+  test("recognize requires exactly one image", async () => {
+    expect((await run(["recognize"])).code).toBe(2);
+    expect((await run(["recognize", "a.jpg", "b.jpg"])).code).toBe(2);
+  });
+
+  test("batch/stream require at least one image", async () => {
+    expect((await run(["batch"])).code).toBe(2);
+    expect((await run(["stream"])).code).toBe(2);
+  });
+
+  test("invalid --strategy is a usage error", async () => {
+    expect((await run(["recognize", RECEIPT, "--strategy", "bogus"])).code).toBe(2);
+  });
+
+  test("a missing image is a runtime error (exit 1)", async () => {
+    const { code, err } = await run(["recognize", `${ASSETS}/nope.jpg`]);
+    expect(code).toBe(1);
+    expect(err).toContain("No such file");
+  });
+
+  test("batch fails fast when a local file is missing", async () => {
+    expect((await run(["batch", RECEIPT, `${ASSETS}/nope.jpg`])).code).toBe(1);
+  });
+});
+
+// ─── OCR happy paths ────────────────────────────────────────────────────────
+
+describe("recognize", () => {
+  test("prints recognized text to stdout", async () => {
+    const { code, out } = await run(["recognize", RECEIPT, "-q"]);
+    expect(code).toBe(0);
+    expect(out.trim().length).toBeGreaterThan(0);
+  });
+
+  test("--json emits a grouped result with lines", async () => {
+    const { code, out } = await run(["recognize", TILTED, "--json", "-q"]);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out) as { text: string; lines: unknown[]; confidence: number };
+    expect(parsed).toHaveProperty("lines");
+    expect(typeof parsed.text).toBe("string");
+    expect(parsed.confidence).toBeGreaterThan(0);
+  });
+
+  test("--json --flatten emits a flat results array", async () => {
+    const { out } = await run(["recognize", TILTED, "--json", "--flatten", "-q"]);
+    const parsed = JSON.parse(out) as { results: unknown[] };
+    expect(Array.isArray(parsed.results)).toBe(true);
+  });
+
+  test("-o writes to a file instead of stdout", async () => {
+    const outFile = join(workdir, "out.txt");
+    const { code, out } = await run(["recognize", RECEIPT, "-o", outFile, "-q"]);
+    expect(code).toBe(0);
+    expect(out).toBe("");
+    expect(readFileSync(outFile, "utf-8").trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("batch", () => {
+  test("--json returns one index-aligned entry per image", async () => {
+    const { code, out } = await run(["batch", TILTED, RECEIPT, "--json", "-q"]);
+    expect(code).toBe(0);
+    const entries = JSON.parse(out) as { file: string; status: string; result?: unknown }[];
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.file).toBe(TILTED);
+    expect(entries[1]?.file).toBe(RECEIPT);
+    expect(entries.every((e) => e.status === "fulfilled")).toBe(true);
+  });
+
+  test("text output delimits each file", async () => {
+    const { out } = await run(["batch", TILTED, "-q"]);
+    expect(out).toContain(`==> ${TILTED} <==`);
+  });
+
+  test("an undecodable image is isolated and reported, with exit code 1", async () => {
+    const { code, out } = await run(["batch", TILTED, badImage, "--json", "-q"]);
+    expect(code).toBe(1);
+    const entries = JSON.parse(out) as { file: string; status: string; error?: string }[];
+    const bad = entries.find((e) => e.file === badImage);
+    expect(bad?.status).toBe("rejected");
+    expect(typeof bad?.error).toBe("string");
+  });
+});
+
+describe("stream", () => {
+  test("emits one block per image as work completes", async () => {
+    const { code, out } = await run(["stream", TILTED, RECEIPT, "-q"]);
+    expect(code).toBe(0);
+    expect(out.match(/==>/g)?.length).toBe(2);
+  });
+
+  test("--json emits NDJSON, one object per line", async () => {
+    const { out } = await run(["stream", TILTED, RECEIPT, "--json", "-q"]);
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+});
+
+// ─── Utility commands ───────────────────────────────────────────────────────
+
+describe("utility commands", () => {
+  test("models reports the active configuration as JSON", async () => {
+    const { code, out } = await run(["models", "--json"]);
+    expect(code).toBe(0);
+    const info = JSON.parse(out) as { models: { detection: string }; engine: string };
+    expect(info.models.detection).toContain("PP-OCRv5");
+    expect(info.engine).toBe("opencv");
+  });
+
+  test("models reflects overrides", async () => {
+    const { out } = await run(["models", "--json", "--engine", "canvas-native"]);
+    expect((JSON.parse(out) as { engine: string }).engine).toBe("canvas-native");
+  });
+
+  test("download-models succeeds against the warm cache", async () => {
+    expect((await run(["download-models", "-q"])).code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds a first-party command-line interface, shipped as a `bin` in the package, so
`bunx ppu-paddle-ocr …` / `npx ppu-paddle-ocr …` run OCR with no install and no
script. It exposes the whole library surface: `recognize`, `batch`, `stream`,
`download-models`, `clear-cache`, and `models`.

Fixes #31.

## Why

The library is great for embedding and `apps/serve` covers OCR-as-a-service, but
there was no quick path for "I have an image, give me the text now" — every user
had to hand-write the `new → initialize → recognize → destroy` dance. The CLI
closes that gap for one-shots, shell pipelines, and CI checks, while reusing the
exact same engine and defaults as the SDK (v5 models, `per-line`, `opencv`).

## How

- `bin` in the root package resolves `bunx/npx ppu-paddle-ocr` directly; source
  lives in `src/cli/` and builds into `lib/cli/`.
- `src/cli/run.ts` holds argv parsing + dispatch (side-effect free, so it's
  unit-testable); `src/cli/index.ts` is the thin executable shim
  (`#!/usr/bin/env node`, SIGINT, exit code). `commands.ts` owns one
  `PaddleOcrService` lifecycle per invocation; `options.ts` maps every flag onto
  `PaddleOptions` / `RecognizeOptions`; `io.ts` keeps things cross-runtime.
- Parsed with `node:util.parseArgs` — **no new runtime dependency** — and free of
  `Bun.*` globals so the published bin runs under plain `node` too. URLs are
  fetched and files read to `ArrayBuffer` in the CLI, since the Node `recognize`
  accepts only `ArrayBuffer`/`Canvas`.
- Recognized text → stdout, progress/logs → stderr; exit codes `0` success, `1`
  runtime error, `2` usage error. Uses default v5 models unless `--model-*`
  overrides them.
- `scripts/build.ts` now preserves the shebang the transpiler strips and sets the
  `0755` executable bit; `ci.yml` and `publish.yml` verify the bin runs and is
  packed (`npm pack` includes `cli/index.js`).

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path — N/A, CLI wraps the existing API
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated (new "Command Line" section)
- [x] New tests added (`tests/cli.test.ts` — option mapping, IO helpers, every
      exit code, OCR happy + failure paths)

> Note: the full suite is green under the CI-pinned Bun 1.2.23. On Bun 1.3.x the
> unrelated `engine-parity` test intermittently hits the known "Session already
> disposed" ONNX teardown race (passes in isolation); `tests/cli.test.ts` is
> unaffected.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser — WebAssembly fallback (Safari, older Firefox)
- [ ] Browser — WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

> The CLI is Node/Bun-only by design (it's the `ppu-paddle-ocr` entry point, not
> `/web`), so the browser rows don't apply.

### Related

- Closes #31
