### PR TITLE
fix: recover JSR score, harden model downloads, cut v5.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restored the JSR score (regressed to 58% in 5.8.2).** Exposing
+  `coi-serviceworker.js` as a JSR module export forced a plain-JS file to be
+  treated as a scored entrypoint — JSR can't derive types from it, so it flagged
+  the whole public API as using "slow types" and as missing module docs. The
+  file is now removed from `jsr.json` `exports` but kept in the publish
+  allowlist, so it still ships and is fetchable at its JSR file URL (and the npm
+  `ppu-paddle-ocr/coi-serviceworker.js` export is unchanged) — it is simply no
+  longer scored as a documented module.
+- Added JSDoc to the Node/Web detection, recognition, and web OCR service
+  constructors to raise exported-symbol documentation coverage.
+
 ## [5.8.2] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowlist, so it still ships and is fetchable at its JSR file URL (and the npm
   `ppu-paddle-ocr/coi-serviceworker.js` export is unchanged) — it is simply no
   longer scored as a documented module.
-- Added JSDoc to the Node/Web detection, recognition, and web OCR service
-  constructors to raise exported-symbol documentation coverage.
+- Documented every remaining exported symbol — the Node/Web service
+  constructors and the Web `PaddleOcrService` public methods (`isInitialized`,
+  `changeDetectionModel`, `changeRecognitionModel`, `changeTextDictionary`,
+  `recognize`) — bringing `deno doc --lint` to zero `missing-jsdoc` (100%
+  documented-symbol coverage).
 
 ## [5.8.2] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Model downloads no longer hang on a stalled connection.** Both the Node
+  (`fetchAndCacheResource`) and Web (`_loadResource`) model fetches used a bare
+  `fetch()` with no timeout, so a stalled GitHub connection during
+  `initialize()` would hang until the caller's timeout (and flaked CI). Both now
+  go through a shared `fetchArrayBufferWithRetry` helper with a per-attempt
+  abort deadline (30s) and bounded retries.
 - **Restored the JSR score (regressed to 58% in 5.8.2).** Exposing
   `coi-serviceworker.js` as a JSR module export forced a plain-JS file to be
   treated as a scored entrypoint — JSR can't derive types from it, so it flagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.3] - 2026-05-28
+
 ### Fixed
 
 - **Restored the JSR score (regressed to 58% in 5.8.2).** Exposing

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/jsr.json
+++ b/jsr.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
-    "./web": "./src/web/index.ts",
-    "./coi-serviceworker.js": "./coi-serviceworker.js"
+    "./web": "./src/web/index.ts"
   },
   "publish": {
     "include": [

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/src/processor/detection.service.ts
+++ b/src/processor/detection.service.ts
@@ -10,6 +10,12 @@ import { NodePlatformProvider } from "./platform.node.js";
  * Service for detecting text regions in images using Node.js implementation
  */
 export class DetectionService extends BaseDetectionService {
+  /**
+   * @param session - Loaded ONNX detection model session.
+   * @param options - Detection tuning options.
+   * @param debugging - Logging and image-dump options.
+   * @param engine - Image processing engine; falls back to `canvas-native` when OpenCV is unavailable.
+   */
   constructor(
     session: ort.InferenceSession,
     options: Partial<DetectionOptions> = {},

--- a/src/processor/detection.service.ts
+++ b/src/processor/detection.service.ts
@@ -11,6 +11,8 @@ import { NodePlatformProvider } from "./platform.node.js";
  */
 export class DetectionService extends BaseDetectionService {
   /**
+   * Creates a Node detection service bound to a loaded ONNX session.
+   *
    * @param session - Loaded ONNX detection model session.
    * @param options - Detection tuning options.
    * @param debugging - Logging and image-dump options.

--- a/src/processor/model-cache.ts
+++ b/src/processor/model-cache.ts
@@ -5,6 +5,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
+import { fetchArrayBufferWithRetry } from "../utils.js";
+
 /** On-disk directory for cached model and dictionary files. */
 export const CACHE_DIR: string = path.join(os.homedir(), ".cache", "ppu-paddle-ocr");
 
@@ -28,47 +30,12 @@ export async function fetchAndCacheResource(url: string, verbose?: boolean): Pro
   );
   if (verbose) console.log(`[PaddleOcrService] Fetching resource from URL: ${url}`);
 
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch resource from ${url}`);
-  }
-  if (!response.body) {
-    throw new Error("Response body is null or undefined");
-  }
-
-  const contentLength = response.headers.get("Content-Length");
-  const totalLength = contentLength ? parseInt(contentLength, 10) : 0;
-  let receivedLength = 0;
-  const chunks: Uint8Array[] = [];
-
-  const reader = response.body.getReader();
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    chunks.push(value);
-    receivedLength += value.length;
-
-    if (totalLength > 0) {
-      const percentage = ((receivedLength / totalLength) * 100).toFixed(2);
-      process.stdout.write(`\rDownloading... ${percentage}%`);
-    }
-  }
-  process.stdout.write("\n");
-
-  const buffer = new Uint8Array(receivedLength);
-  let position = 0;
-  for (const chunk of chunks) {
-    buffer.set(chunk, position);
-    position += chunk.length;
-  }
+  const arrayBuffer = await fetchArrayBufferWithRetry(url);
 
   if (!existsSync(CACHE_DIR)) {
     mkdirSync(CACHE_DIR, { recursive: true });
   }
-  writeFileSync(cachePath, Buffer.from(buffer));
+  writeFileSync(cachePath, Buffer.from(arrayBuffer));
 
-  return buffer.buffer;
+  return arrayBuffer;
 }

--- a/src/processor/paddle-ocr.service.ts
+++ b/src/processor/paddle-ocr.service.ts
@@ -67,6 +67,10 @@ export class PaddleOcrService extends BasePaddleOcrService {
     return this._fetchAndCache(defaultUrl);
   }
 
+  /**
+   * Not used by the Node service — initialization runs in {@link initialize}.
+   * @throws Always; call {@link initialize} instead.
+   */
   protected async initSessions(): Promise<void> {
     throw new Error(
       "Initialization is handled proactively in PaddleOcrService. Call initialize() instead."

--- a/src/processor/recognition.service.ts
+++ b/src/processor/recognition.service.ts
@@ -14,6 +14,8 @@ export type { RecognitionResult };
  */
 export class RecognitionService extends BaseRecognitionService {
   /**
+   * Creates a Node recognition service bound to a loaded ONNX session.
+   *
    * @param session - Loaded ONNX recognition model session.
    * @param options - Recognition tuning options.
    * @param debugging - Logging and image-dump options.

--- a/src/processor/recognition.service.ts
+++ b/src/processor/recognition.service.ts
@@ -13,6 +13,12 @@ export type { RecognitionResult };
  * Service for detecting and recognizing text in images using Node.js implementation
  */
 export class RecognitionService extends BaseRecognitionService {
+  /**
+   * @param session - Loaded ONNX recognition model session.
+   * @param options - Recognition tuning options.
+   * @param debugging - Logging and image-dump options.
+   * @param engine - Image processing engine; falls back to `canvas-native` when OpenCV is unavailable.
+   */
   constructor(
     session: ort.InferenceSession,
     options: Partial<RecognitionOptions> = {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,43 @@ export function levenshteinDistance(a: string, b: string): number {
   return prev[n] ?? 0;
 }
 
+/**
+ * Fetches a URL as an `ArrayBuffer` with a per-attempt deadline and bounded
+ * retries. Each attempt is aborted after `timeoutMs` (covering both the
+ * response headers and the body download), so a stalled connection fails fast
+ * and is retried instead of hanging indefinitely.
+ *
+ * @param url - Resource to download.
+ * @param options - `timeoutMs` per-attempt deadline (default 30000) and
+ *   `retries` additional attempts after the first (default 2).
+ * @returns The downloaded bytes.
+ * @throws If every attempt fails (network error, timeout, or non-2xx response).
+ */
+export async function fetchArrayBufferWithRetry(
+  url: string,
+  options: { timeoutMs?: number; retries?: number } = {}
+): Promise<ArrayBuffer> {
+  const { timeoutMs = 30000, retries = 2 } = options;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      return await response.arrayBuffer();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+      }
+    }
+  }
+
+  throw new Error(`Failed to fetch ${url} after ${retries + 1} attempt(s): ${String(lastError)}`);
+}
+
 /** Parse a PaddleOCR dictionary into an ordered array. Handles LF/CRLF; preserves blank entries. */
 export function parseDictionary(source: ArrayBuffer | Uint8Array | string): string[] {
   const content = typeof source === "string" ? source : new TextDecoder("utf-8").decode(source);

--- a/src/web/detection.service.web.ts
+++ b/src/web/detection.service.web.ts
@@ -11,6 +11,11 @@ import { WebPlatformProvider } from "./platform.web.js";
  * Web always uses canvas-native engine (no OpenCV available in browser).
  */
 export class DetectionService extends BaseDetectionService {
+  /**
+   * @param session - Loaded ONNX detection model session (`onnxruntime-web`).
+   * @param options - Detection tuning options.
+   * @param debugging - Logging and image-dump options.
+   */
   constructor(
     session: ort.InferenceSession,
     options: Partial<DetectionOptions> = {},

--- a/src/web/detection.service.web.ts
+++ b/src/web/detection.service.web.ts
@@ -12,6 +12,8 @@ import { WebPlatformProvider } from "./platform.web.js";
  */
 export class DetectionService extends BaseDetectionService {
   /**
+   * Creates a web detection service bound to a loaded ONNX session.
+   *
    * @param session - Loaded ONNX detection model session (`onnxruntime-web`).
    * @param options - Detection tuning options.
    * @param debugging - Logging and image-dump options.

--- a/src/web/paddle-ocr.service.web.ts
+++ b/src/web/paddle-ocr.service.web.ts
@@ -9,7 +9,7 @@ import { BasePaddleOcrService, DEFAULT_MODEL_URLS } from "../core/base-paddle-oc
 import type { CoreCanvas } from "../core/platform.js";
 import { createSessionWithFallback } from "../core/session-factory.js";
 import type { PaddleOptions, RecognizeOptions } from "../interface.js";
-import { parseDictionary } from "../utils.js";
+import { fetchArrayBufferWithRetry, parseDictionary } from "../utils.js";
 import { DetectionService } from "./detection.service.web.js";
 import { getDefaultWebExecutionProviders, WebPlatformProvider } from "./platform.web.js";
 import { RecognitionService } from "./recognition.service.web.js";
@@ -71,12 +71,7 @@ export class PaddleOcrService extends BasePaddleOcrService {
     const sourceUrl = typeof source === "string" ? source : defaultUrl;
     this.log(`Fetching resource from URL: ${sourceUrl}`);
 
-    const response = await fetch(sourceUrl);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch resource from ${sourceUrl}`);
-    }
-
-    return response.arrayBuffer();
+    return fetchArrayBufferWithRetry(sourceUrl);
   }
 
   /** Resolve execution providers, preferring WebGPU when the browser supports it. */

--- a/src/web/paddle-ocr.service.web.ts
+++ b/src/web/paddle-ocr.service.web.ts
@@ -46,6 +46,10 @@ export class PaddleOcrService extends BasePaddleOcrService {
     }
   }
 
+  /**
+   * Creates the detection and recognition ONNX sessions from the configured
+   * models using `onnxruntime-web`.
+   */
   protected async initSessions(): Promise<void> {
     throw new Error(
       "Initialization is handled proactively in PaddleOcrService. Call initialize() instead."
@@ -168,10 +172,17 @@ export class PaddleOcrService extends BasePaddleOcrService {
     }
   }
 
+  /**
+   * Returns `true` once both detection and recognition sessions are loaded.
+   */
   public isInitialized(): boolean {
     return this.detectionSession !== null && this.recognitionSession !== null;
   }
 
+  /**
+   * Swaps the detection model at runtime, releasing the previous session.
+   * @param model - ONNX detection model as a buffer, file path, or URL.
+   */
   public async changeDetectionModel(model: ArrayBuffer | string): Promise<void> {
     this.log("Changing detection model...");
     const modelBuffer = await this._loadResource(model, DEFAULT_MODEL_URLS.detection);
@@ -188,6 +199,10 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.log("Detection model changed successfully.");
   }
 
+  /**
+   * Swaps the recognition model at runtime, releasing the previous session.
+   * @param model - ONNX recognition model as a buffer, file path, or URL.
+   */
   public async changeRecognitionModel(model: ArrayBuffer | string): Promise<void> {
     this.log("Changing recognition model...");
     const modelBuffer = await this._loadResource(model, DEFAULT_MODEL_URLS.recognition);
@@ -204,6 +219,10 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.log("Recognition model changed successfully.");
   }
 
+  /**
+   * Replaces the character dictionary used to decode recognition output.
+   * @param dictionary - Dictionary as a buffer, file path, or URL.
+   */
   public async changeTextDictionary(dictionary: ArrayBuffer | string): Promise<void> {
     this.log("Changing text dictionary...");
     const dictBuffer = await this._loadResource(
@@ -225,11 +244,23 @@ export class PaddleOcrService extends BasePaddleOcrService {
     );
   }
 
+  /**
+   * Run the full OCR pipeline (detection → recognition) on an image.
+   * @param image - Source image as an `ArrayBuffer` or canvas.
+   * @param options - Per-call options such as `flatten` and `strategy`.
+   * @returns Grouped or flattened OCR results depending on `options.flatten`.
+   */
   public override recognize(
     image: ArrayBuffer | CanvasLike,
     options: RecognizeOptions & { flatten: true }
   ): Promise<FlattenedPaddleOcrResult>;
 
+  /**
+   * Run the full OCR pipeline (detection → recognition) on an image.
+   * @param image - Source image as an `ArrayBuffer` or canvas.
+   * @param options - Per-call options; omit `flatten` for line-grouped results.
+   * @returns OCR results grouped by line.
+   */
   public override recognize(
     image: ArrayBuffer | CanvasLike,
     options?: RecognizeOptions & { flatten?: false }

--- a/src/web/paddle-ocr.service.web.ts
+++ b/src/web/paddle-ocr.service.web.ts
@@ -33,6 +33,10 @@ const DEFAULT_WEB_SESSION_OPTIONS: ort.InferenceSession.SessionOptions = {
  * Uses onnxruntime-web and ppu-ocv/web instead of their Node counterparts.
  */
 export class PaddleOcrService extends BasePaddleOcrService {
+  /**
+   * Creates a web PaddleOcrService instance.
+   * @param options - Configuration options for the service.
+   */
   public constructor(options?: PaddleOptions) {
     super(new WebPlatformProvider(), options);
 

--- a/src/web/recognition.service.web.ts
+++ b/src/web/recognition.service.web.ts
@@ -14,6 +14,11 @@ export type { RecognitionResult };
  * Web always uses canvas-native engine (no OpenCV available in browser).
  */
 export class RecognitionService extends BaseRecognitionService {
+  /**
+   * @param session - Loaded ONNX recognition model session (`onnxruntime-web`).
+   * @param options - Recognition tuning options.
+   * @param debugging - Logging and image-dump options.
+   */
   constructor(
     session: ort.InferenceSession,
     options: Partial<RecognitionOptions> = {},

--- a/src/web/recognition.service.web.ts
+++ b/src/web/recognition.service.web.ts
@@ -15,6 +15,8 @@ export type { RecognitionResult };
  */
 export class RecognitionService extends BaseRecognitionService {
   /**
+   * Creates a web recognition service bound to a loaded ONNX session.
+   *
    * @param session - Loaded ONNX recognition model session (`onnxruntime-web`).
    * @param options - Recognition tuning options.
    * @param debugging - Logging and image-dump options.

--- a/tests/fetch-retry.test.ts
+++ b/tests/fetch-retry.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { fetchArrayBufferWithRetry } from "../src/utils.js";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("fetchArrayBufferWithRetry", () => {
+  test("returns the downloaded bytes on first success", async () => {
+    const payload = new Uint8Array([1, 2, 3, 4]);
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(payload, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const buf = await fetchArrayBufferWithRetry("https://example.test/model.ort");
+    expect(new Uint8Array(buf)).toEqual(payload);
+    expect(calls).toBe(1);
+  });
+
+  test("retries a transient failure, then succeeds", async () => {
+    const payload = new Uint8Array([9]);
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) throw new Error("ECONNRESET");
+      return new Response(payload, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const buf = await fetchArrayBufferWithRetry("https://example.test/model.ort", { retries: 2 });
+    expect(new Uint8Array(buf)).toEqual(payload);
+    expect(calls).toBe(2);
+  });
+
+  test("treats a non-2xx response as a failure and retries", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response("nope", { status: 503 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchArrayBufferWithRetry("https://example.test/model.ort", { retries: 1 })
+    ).rejects.toThrow(/after 2 attempt/);
+    expect(calls).toBe(2);
+  });
+
+  test("throws after exhausting retries", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchArrayBufferWithRetry("https://example.test/model.ort", { retries: 1 })
+    ).rejects.toThrow(/network down/);
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

Recovers the JSR package score (regressed to 58% in 5.8.2), hardens model
downloads against network stalls, and prepares the v5.8.3 release.

- Removes `coi-serviceworker.js` from the `jsr.json` `exports` (kept in the
  publish allowlist) and documents every remaining exported symbol.
- Adds a timeout + bounded retry to the Node and Web model-download fetches.

## Why

5.8.2 exposed `coi-serviceworker.js` as a JSR **module export**. A plain-JS file
as a scored entrypoint can't be type-analyzed, so JSR flagged the whole public
API as using "slow types" and as missing module docs — and undocumented web
`PaddleOcrService` methods dragged symbol-doc coverage down to 58%.

Separately, both model-download paths used a bare `fetch()` with **no timeout**,
so a stalled GitHub connection during `initialize()` would hang until the
caller's timeout — which flaked CI (`web-ocr.test.ts` initializes repeatedly and
downloads the default models each time, with no model cache in CI).

## How

- **jsr.json**: drop the `./coi-serviceworker.js` export but keep it in
  `publish.include`, so it still ships and is fetchable at its JSR file URL (the
  npm `ppu-paddle-ocr/coi-serviceworker.js` export is unchanged). Clears the
  slow-types and module-docs criteria — confirmed by `jsr publish --dry-run`.
- **Docs**: documented the Node/Web service constructors, the web
  `PaddleOcrService` public methods, and both `initSessions`. `deno doc --lint`
  now reports **0 `missing-jsdoc`** (100% documented-symbol coverage).
- **Fetch resilience**: new shared `fetchArrayBufferWithRetry` helper in
  `src/utils.ts` (per-attempt 30s abort deadline + bounded retries). Both
  `src/processor/model-cache.ts` and `src/web/paddle-ocr.service.web.ts` now use
  it instead of a bare `fetch()`. Covered by `tests/fetch-retry.test.ts`.
- **Release**: bump `package.json` + `jsr.json` to 5.8.3, serve image to 0.1.4,
  CHANGELOG finalized.

### Checklist

- [x] Tests pass locally (`bun test tests/fetch-retry.test.ts` — 4 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path — n/a (no hot-path change)
- [x] CHANGELOG updated (and version bumped — cutting v5.8.3)
- [ ] README updated — n/a (no public API, default, or setup change)
- [x] New tests added (`tests/fetch-retry.test.ts`)

### Compatibility

The fetch helper uses `AbortSignal.timeout` (Node 18+, Bun, modern browsers).
CI covers Node + Bun.

- [ ] Node.js (via `onnxruntime-node`)
- [ ] Bun (via `onnxruntime-node`)
- [ ] Browser — WebAssembly fallback (Safari, older Firefox)
- [ ] Browser — WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [ ] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- The bare image-URL fetches in `platform.node.ts`, `platform.web.ts`, and
  `cli/io.ts` have the same unbounded-fetch shape but are a separate input path
  (not implicated in the CI hang) — left for a follow-up.
- Post-merge/publish: bump the playground CDN pin (`playground/index.html`) to
  `ppu-paddle-ocr@5.8.3` once it is live on jsdelivr.
