### PR TITLE
perf: avoid repeated line height recomputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve OCR line grouping scalability by avoiding repeated average-height recomputation.
+
 ## [5.8.3] - 2026-05-28
 
 ### Fixed

--- a/src/core/recognition/line-grouping.ts
+++ b/src/core/recognition/line-grouping.ts
@@ -22,6 +22,7 @@ export function groupBoxesIntoLines(
   const firstSorted = sorted[0];
   if (!firstSorted) return [];
   let currentLine = [firstSorted];
+  let currentLineHeightSum = firstSorted.box.height;
   let avgHeight = firstSorted.box.height;
 
   for (let i = 1; i < sorted.length; i++) {
@@ -33,11 +34,13 @@ export function groupBoxesIntoLines(
 
     if (verticalGap <= threshold) {
       currentLine.push(current);
-      avgHeight = currentLine.reduce((sum, item) => sum + item.box.height, 0) / currentLine.length;
+      currentLineHeightSum += current.box.height;
+      avgHeight = currentLineHeightSum / currentLine.length;
     } else {
       currentLine.sort((a, b) => a.box.x - b.box.x);
       lines.push(currentLine);
       currentLine = [current];
+      currentLineHeightSum = current.box.height;
       avgHeight = current.box.height;
     }
   }

--- a/src/core/recognition/result-grouping.ts
+++ b/src/core/recognition/result-grouping.ts
@@ -22,6 +22,7 @@ export function groupRecognitionResultsByLine(recognition: RecognitionResult[]):
   const firstRec = recognition[0];
   if (!firstRec) return result;
   let currentLine: RecognitionResult[] = [firstRec];
+  let currentLineHeightSum = firstRec.box.height;
   let fullText = firstRec.text;
   let avgHeight = firstRec.box.height;
 
@@ -35,12 +36,14 @@ export function groupRecognitionResultsByLine(recognition: RecognitionResult[]):
 
     if (verticalGap <= threshold) {
       currentLine.push(current);
+      currentLineHeightSum += current.box.height;
       fullText += ` ${current.text}`;
-      avgHeight = currentLine.reduce((sum, r) => sum + r.box.height, 0) / currentLine.length;
+      avgHeight = currentLineHeightSum / currentLine.length;
     } else {
       result.lines.push([...currentLine]);
       fullText += `\n${current.text}`;
       currentLine = [current];
+      currentLineHeightSum = current.box.height;
       avgHeight = current.box.height;
     }
   }


### PR DESCRIPTION
## What

Replaces repeated average-height recomputation in OCR line grouping with an incremental running height sum.

This updates the grouping logic in:

- `src/core/recognition/line-grouping.ts`
- `src/core/recognition/result-grouping.ts`

## Why

The previous implementation recalculated the current line’s average height with `currentLine.reduce(...)` every time a box or recognition result was appended to the current line. For dense OCR output or long lines, this repeatedly scans a growing array and gives the grouping step accidental O(n²) behavior in the worst case.

This change keeps the same grouping behavior and average-height formula, but updates the sum incrementally so each append updates the average in O(1). The end-to-end OCR benchmark is noisy relative to the size of this change because model inference and image processing dominate runtime, so I do not claim a measurable end-to-end speedup from the receipt sample. The goal is to remove the scaling hazard while preserving accuracy.

Benchmark before/after on `assets/receipt.jpg`:

```text
Before:
[per-box][opencv][noCache]             708.8 ms
[per-line][opencv][noCache]            636.1 ms
[cross-line][opencv][noCache]          627.3 ms
[per-box][canvas-native][noCache]      705.7 ms
[per-line][canvas-native][noCache]     686.7 ms
[cross-line][canvas-native][noCache]   650.0 ms

After:
[per-box][opencv][noCache]             709.2 ms
[per-line][opencv][noCache]            633.6 ms
[cross-line][opencv][noCache]          633.7 ms
[per-box][canvas-native][noCache]      713.7 ms
[per-line][canvas-native][noCache]     669.5 ms
[cross-line][canvas-native][noCache]   657.6 ms
```

The medians are within the observed benchmark variance, so these numbers should be read as “no obvious regression” rather than proof of end-to-end speedup.

Accuracy is preserved on the receipt sample:

```text
Before:
[opencv]
  per-box        accuracy=97.91%  dist=8
  per-line       accuracy=99.22%  dist=3
  cross-line     accuracy=96.34%  dist=14

[canvas-native]
  per-box        accuracy=97.65%  dist=9
  per-line       accuracy=98.43%  dist=6
  cross-line     accuracy=97.65%  dist=9

After:
[opencv]
  per-box        accuracy=97.91%  dist=8
  per-line       accuracy=99.22%  dist=3
  cross-line     accuracy=96.34%  dist=14

[canvas-native]
  per-box        accuracy=97.65%  dist=9
  per-line       accuracy=98.43%  dist=6
  cross-line     accuracy=97.65%  dist=9
```

## How

The grouping code now tracks a `currentLineHeightSum` alongside `currentLine`.

When a box/result is added to the current line, the sum and average are updated incrementally:

```ts
currentLine.push(current);
currentLineHeightSum += current.box.height;
avgHeight = currentLineHeightSum / currentLine.length;
```

When grouping starts a new line, the sum is reset to that item’s height:

```ts
currentLine = [current];
currentLineHeightSum = current.box.height;
avgHeight = current.box.height;
```

This preserves the existing threshold calculation:

```ts
const threshold = avgHeight * 0.5;
```

but avoids rescanning the full current line after each append.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [x] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [x] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser — WebAssembly fallback (Safari, older Firefox)
- [ ] Browser — WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [ ] macOS (Apple Silicon)
- [x] Linux (x86-64)
- [ ] Windows

### Related

N/A
