### PR TITLE
fix: use pinned official OCR model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ await service.destroy();
 ## Why ppu-paddle-ocr?
 
 - **Lightweight** — minimal dependencies, optimized for performance.
-- **Pre-packed models** — PP-OCRv5 mobile models (English) are fetched and cached automatically on first run. Supports 40+ languages via [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models).
+- **Pre-packed models** — PP-OCRv6 ONNX models and dictionary are fetched from pinned PaddlePaddle upstream URLs and cached automatically on first run. Supports custom PaddleOCR models and dictionaries.
 - **Runs everywhere** — Node.js, Bun, Deno, web browsers, and browser extensions. The official SDK is browser-only.
 - **Customizable** — custom models, dictionaries, and per-call overrides.
 - **TypeScript** — full type definitions.
@@ -205,7 +205,7 @@ bunx ppu-paddle-ocr models --json
 
 Every `PaddleOptions` / `RecognizeOptions` field maps to a flag: `--strategy`, `--engine`, `--flatten`, `--no-cache`, `--image-height`, `--model-detection/-recognition/-dict`, detection tuning (`--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`), `--execution-providers`, and for `batch`/`stream` `--concurrency`. Output is controlled by `--json`, `--pretty`, `-o/--output`, `-q/--quiet`, and `--verbose`.
 
-Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error. Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v5 models unless you override the `--model-*` flags.
+Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error. Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the pinned default PP-OCRv6 models unless you override the `--model-*` flags.
 
 ## Batch Recognition
 
@@ -396,19 +396,19 @@ const swPath = import.meta.resolve("ppu-paddle-ocr/coi-serviceworker.js");
 
 ### Default Models
 
-The default **PP-OCRv5 mobile** models are optimized for English and served in ONNX Runtime's `.ort` FlatBuffers format (3–5× faster session creation than `.onnx`):
+The default **PP-OCRv6** models are fetched from pinned PaddlePaddle upstream sources:
 
-| Component   | File                               |
-| :---------- | :--------------------------------- |
-| Detection   | `PP-OCRv5_mobile_det_infer.ort`    |
-| Recognition | `en_PP-OCRv5_mobile_rec_infer.ort` |
-| Dictionary  | `ppocrv5_en_dict.txt`              |
+| Component   | Source                                                  |
+| :---------- | :------------------------------------------------------ |
+| Detection   | `PaddlePaddle/PP-OCRv6_medium_det_onnx` on Hugging Face |
+| Recognition | `PaddlePaddle/PP-OCRv6_small_rec_onnx` on Hugging Face  |
+| Dictionary  | `ppocrv6_dict.txt` from the official PaddleOCR repo     |
 
-Portable `.onnx` variants are available at [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models) — point `model.detection` / `model.recognition` at the `.onnx` URLs.
+The default URLs are pinned by commit for reproducible output. You can still point `model.detection`, `model.recognition`, and `model.charactersDictionary` at your own paths or URLs.
 
 ### Cache Location (Node / Bun)
 
-Models are cached under `~/.cache/ppu-paddle-ocr`:
+Models are cached under `~/.cache/ppu-paddle-ocr`. Cache filenames include a short hash of the full URL, so official sources with generic names such as `inference.onnx` do not collide:
 
 | OS      | Path                                        |
 | :------ | :------------------------------------------ |
@@ -641,7 +641,7 @@ Absolute timings are thermal-sensitive on fanless hardware (Apple Silicon): sust
 
 ### Batch vs. concurrent `recognize()`
 
-`bench/batch.bench.ts` compares the ways to OCR many images, tracking peak RSS alongside time. Default models (v5), median over 7 rounds of 16 images each, Apple M1 / Bun 1.3.14, opencv, `noCache`:
+`bench/batch.bench.ts` compares the ways to OCR many images, tracking peak RSS alongside time. Benchmark snapshot below used the previous PP-OCRv5 default set, median over 7 rounds of 16 images each, Apple M1 / Bun 1.3.14, opencv, `noCache`:
 
 ```bash
 task                          median      ±stddev        min        max   peak RSS

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -7,11 +7,11 @@ and how data flows through it. It complements the API reference in the
 ## What it is
 
 ppu-paddle-ocr is a library (with an optional CLI and HTTP service) that runs
-PaddleOCR PP-OCRv5 models for text detection and recognition. A developer
-imports it into their own Node, Bun, Deno, or browser code and calls it
-in-process. Inference runs locally through ONNX Runtime. The library does not
-phone home; the only outbound traffic is the one-time model download (or none,
-if models are supplied locally).
+PaddleOCR ONNX models for text detection and recognition. A developer imports
+it into their own Node, Bun, Deno, or browser code and calls it in-process.
+Inference runs locally through ONNX Runtime. The library does not phone home;
+the only outbound traffic is the one-time default model download from pinned
+PaddlePaddle upstream URLs (or none, if models are supplied locally).
 
 ## Lifecycle
 

--- a/src/core/base-paddle-ocr.service.ts
+++ b/src/core/base-paddle-ocr.service.ts
@@ -49,13 +49,16 @@ export type AnyOcrResult = PaddleOcrResult | FlattenedPaddleOcrResult;
 /** Accepted source for a single image in a batch. */
 export type BatchRecognizeInput = ArrayBuffer | CoreCanvas | string;
 
-/** Base URL for downloading default PaddleOCR model files from GitHub. */
-export const MODEL_BASE_URL =
-  "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
-
-/** Base URL for downloading default PaddleOCR dictionary files from GitHub. */
-export const DICT_BASE_URL =
-  "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
+/** Pinned upstream refs for the default PaddleOCR model artifacts. */
+export const DEFAULT_MODEL_REFS: Readonly<{
+  detection: string;
+  recognition: string;
+  charactersDictionary: string;
+}> = {
+  detection: "dc79536db3be55f11cd8dfc68493321836f11e75",
+  recognition: "2f0724790c8b57946c89cc45d2fa79e405781f51",
+  charactersDictionary: "ef346e0b402934477489001a4d253a20dbeb72a5",
+};
 
 /** Default model URLs used when no custom paths are provided. */
 export const DEFAULT_MODEL_URLS: Readonly<{
@@ -63,9 +66,9 @@ export const DEFAULT_MODEL_URLS: Readonly<{
   recognition: string;
   charactersDictionary: string;
 }> = {
-  detection: `${MODEL_BASE_URL}/detection/PP-OCRv5_mobile_det_infer.ort`,
-  recognition: `${MODEL_BASE_URL}/recognition/multi/en/v5/en_PP-OCRv5_mobile_rec_infer.ort`,
-  charactersDictionary: `${DICT_BASE_URL}/recognition/multi/en/v5/ppocrv5_en_dict.txt`,
+  detection: `https://huggingface.co/PaddlePaddle/PP-OCRv6_medium_det_onnx/resolve/${DEFAULT_MODEL_REFS.detection}/inference.onnx`,
+  recognition: `https://huggingface.co/PaddlePaddle/PP-OCRv6_small_rec_onnx/resolve/${DEFAULT_MODEL_REFS.recognition}/inference.onnx`,
+  charactersDictionary: `https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/${DEFAULT_MODEL_REFS.charactersDictionary}/ppocr/utils/dict/ppocrv6_dict.txt`,
 };
 
 /**
@@ -131,7 +134,9 @@ export abstract class BasePaddleOcrService {
         imageBuffer = image;
       } else {
         if (typeof (image as unknown as Record<string, unknown>).toBuffer === "function") {
-          const canvasWithBuffer = image as { toBuffer: (format: string) => Buffer };
+          const canvasWithBuffer = image as {
+            toBuffer: (format: string) => Buffer;
+          };
           const buffer = canvasWithBuffer.toBuffer("image/png");
           imageBuffer = buffer.buffer.slice(
             buffer.byteOffset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "./core/base-paddle-ocr.service.js";
-export { DEFAULT_MODEL_URLS } from "./core/base-paddle-ocr.service.js";
+export { DEFAULT_MODEL_REFS, DEFAULT_MODEL_URLS } from "./core/base-paddle-ocr.service.js";
 export type { BatchItemResult } from "./core/batch.js";
 export { PaddleOcrService } from "./processor/paddle-ocr.service.js";
 

--- a/src/processor/model-cache.ts
+++ b/src/processor/model-cache.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
+import { createHash } from "crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -11,11 +12,25 @@ import { fetchArrayBufferWithRetry } from "../utils.js";
 export const CACHE_DIR: string = path.join(os.homedir(), ".cache", "ppu-paddle-ocr");
 
 /**
+ * Returns a deterministic cache filename for a remote resource.
+ *
+ * Some official model repos publish generic names such as `inference.onnx`;
+ * including a short hash of the full URL avoids collisions while keeping the
+ * original filename readable for humans inspecting the cache directory.
+ */
+export function getCachedResourceFileName(url: string): string {
+  const parsed = new URL(url);
+  const fileName = path.basename(parsed.pathname);
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 12);
+  return `${hash}-${fileName}`;
+}
+
+/**
  * Downloads a resource from `url` and writes it to {@link CACHE_DIR}, or reads
  * from the cache if the file already exists.
  */
 export async function fetchAndCacheResource(url: string, verbose?: boolean): Promise<ArrayBuffer> {
-  const fileName = path.basename(new URL(url).pathname);
+  const fileName = getCachedResourceFileName(url);
   const cachePath = path.join(CACHE_DIR, fileName);
 
   if (existsSync(cachePath)) {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -28,7 +28,7 @@ export type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "../core/base-paddle-ocr.service.js";
-export { DEFAULT_MODEL_URLS } from "../core/base-paddle-ocr.service.js";
+export { DEFAULT_MODEL_REFS, DEFAULT_MODEL_URLS } from "../core/base-paddle-ocr.service.js";
 export type { BatchItemResult } from "../core/batch.js";
 export { PaddleOcrService } from "./paddle-ocr.service.web.js";
 

--- a/tests/batch-recognize.test.ts
+++ b/tests/batch-recognize.test.ts
@@ -10,11 +10,11 @@ let single: string;
 
 beforeAll(async () => {
   await PaddleOcrService.downloadModels();
-  // Uses the library's default models (v5).
+  // Uses the library's default models.
   service = new PaddleOcrService();
   await service.initialize();
   single = (await service.recognize(imageBuffer)).text;
-});
+}, 120000);
 
 afterAll(async () => {
   await service?.destroy();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { DEFAULT_MODEL_URLS } from "../src/core/base-paddle-ocr.service.js";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { expandPatterns, isMissingLocalFile, loadImageInput } from "../src/cli/io.js";
 import {
@@ -42,7 +43,7 @@ beforeAll(async () => {
   workdir = mkdtempSync(join(tmpdir(), "ppu-cli-"));
   badImage = join(workdir, "not-an-image.png");
   writeFileSync(badImage, "this is not a PNG");
-});
+}, 120000);
 
 afterAll(() => {
   if (workdir && existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
@@ -257,7 +258,7 @@ describe("utility commands", () => {
     const { code, out } = await run(["models", "--json"]);
     expect(code).toBe(0);
     const info = JSON.parse(out) as { models: { detection: string }; engine: string };
-    expect(info.models.detection).toContain("PP-OCRv5");
+    expect(info.models.detection).toBe(DEFAULT_MODEL_URLS.detection);
     expect(info.engine).toBe("opencv");
   });
 

--- a/tests/dictionary.test.ts
+++ b/tests/dictionary.test.ts
@@ -2,10 +2,17 @@ import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:te
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_MODEL_URLS } from "../src/core/base-paddle-ocr.service.js";
+import { getCachedResourceFileName } from "../src/processor/model-cache.js";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { levenshteinDistance, parseDictionary } from "../src/utils.js";
 
-const CACHED_DICT_PATH = join(homedir(), ".cache", "ppu-paddle-ocr", "ppocrv5_en_dict.txt");
+const CACHED_DICT_PATH = join(
+  homedir(),
+  ".cache",
+  "ppu-paddle-ocr",
+  getCachedResourceFileName(DEFAULT_MODEL_URLS.charactersDictionary)
+);
 const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/receipt.jpg`).arrayBuffer();
 const groundTruth = (
   await Bun.file(`${import.meta.dir}/../assets/receipt-ground-truth.txt`).text()
@@ -29,7 +36,7 @@ beforeAll(async () => {
 
   dictBufferWithBlank = new TextEncoder().encode(dictWithBlank).buffer as ArrayBuffer;
   dictBufferWithoutBlank = new TextEncoder().encode(dictWithoutBlank).buffer as ArrayBuffer;
-});
+}, 120000);
 
 describe("parseDictionary", () => {
   test("preserves leading blank line", () => {
@@ -63,7 +70,7 @@ describe("parseDictionary", () => {
   });
 });
 
-describe("Dict load path: initialize() with default v5 model", () => {
+describe("Dict load path: initialize() with default model", () => {
   let service: PaddleOcrService;
 
   afterEach(async () => {
@@ -89,7 +96,7 @@ describe("Dict load path: initialize() with default v5 model", () => {
   }, 30000);
 });
 
-describe("Dict load path: changeTextDictionary() on default v5 model", () => {
+describe("Dict load path: changeTextDictionary() on default model", () => {
   let service: PaddleOcrService;
 
   beforeEach(async () => {
@@ -97,7 +104,7 @@ describe("Dict load path: changeTextDictionary() on default v5 model", () => {
       model: { charactersDictionary: dictBufferWithBlank },
     });
     await service.initialize();
-  });
+  }, 60000);
 
   afterEach(async () => {
     await service.destroy();
@@ -116,7 +123,7 @@ describe("Dict load path: changeTextDictionary() on default v5 model", () => {
   }, 30000);
 });
 
-describe("Dict load path: per-call options.dictionary on default v5 model", () => {
+describe("Dict load path: per-call options.dictionary on default model", () => {
   let service: PaddleOcrService;
 
   beforeAll(async () => {
@@ -124,7 +131,7 @@ describe("Dict load path: per-call options.dictionary on default v5 model", () =
       model: { charactersDictionary: dictBufferWithBlank },
     });
     await service.initialize();
-  });
+  }, 60000);
 
   test("override with dict containing leading blank line", async () => {
     const result = await service.recognize(imageBuffer, {

--- a/tests/engine-parity.test.ts
+++ b/tests/engine-parity.test.ts
@@ -5,10 +5,10 @@ import type { ProcessingEngine } from "../src/interface.js";
 const imgFile = Bun.file(`${import.meta.dir}/../assets/receipt.jpg`);
 const imageBuffer = await imgFile.arrayBuffer();
 
-// Exercise the library's default models (v5).
+// Exercise the library's default models.
 beforeAll(async () => {
   await PaddleOcrService.downloadModels();
-});
+}, 120000);
 
 /**
  * Regression test suite for engine parity (opencv vs canvas-native).
@@ -33,7 +33,7 @@ describe("Processing engine parity (opencv vs canvas-native)", () => {
 
     await opencvService.initialize();
     await canvasService.initialize();
-  });
+  }, 60000);
 
   afterEach(async () => {
     await opencvService.destroy();

--- a/tests/fetch-retry.test.ts
+++ b/tests/fetch-retry.test.ts
@@ -3,6 +3,8 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { DEFAULT_MODEL_URLS } from "../src/core/base-paddle-ocr.service.js";
+import { getCachedResourceFileName } from "../src/processor/model-cache.js";
 import { fetchArrayBufferWithRetry } from "../src/utils.js";
 
 const realFetch = globalThis.fetch;
@@ -62,5 +64,16 @@ describe("fetchArrayBufferWithRetry", () => {
       fetchArrayBufferWithRetry("https://example.test/model.ort", { retries: 1 })
     ).rejects.toThrow(/network down/);
     expect(calls).toBe(2);
+  });
+});
+
+describe("model cache filenames", () => {
+  test("different official model URLs do not collide when basenames match", () => {
+    const detection = getCachedResourceFileName(DEFAULT_MODEL_URLS.detection);
+    const recognition = getCachedResourceFileName(DEFAULT_MODEL_URLS.recognition);
+
+    expect(detection).not.toBe(recognition);
+    expect(detection).toEndWith("-inference.onnx");
+    expect(recognition).toEndWith("-inference.onnx");
   });
 });

--- a/tests/fuzz.test.ts
+++ b/tests/fuzz.test.ts
@@ -19,7 +19,7 @@ describe("fuzz: OCR is robust to malformed image input", () => {
     // canvas-native engine: no @techstark/opencv-js init, faster per run.
     service = new PaddleOcrService({ processing: { engine: "canvas-native" } });
     await service.initialize();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (service) await service.destroy();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -15,7 +15,7 @@ const groundTruth = (await gtFile.text()).trim();
 
 beforeAll(async () => {
   await PaddleOcrService.downloadModels();
-});
+}, 120000);
 
 describe("PaddleOcrService Initialization", () => {
   let service: PaddleOcrService | null = null;
@@ -27,7 +27,7 @@ describe("PaddleOcrService Initialization", () => {
     }
   });
 
-  test("should initialize with default models from GitHub", async () => {
+  test("should initialize with default upstream models", async () => {
     // This test will be slow as it downloads models
     service = new PaddleOcrService();
     await service.initialize();
@@ -39,7 +39,7 @@ describe("PaddleOcrService Initialization", () => {
   }, 30000); // Increase timeout for download
 
   test("should initialize and recognize using explicit file paths", async () => {
-    // Uses the library's default models (v5).
+    // Uses the library's default models.
     service = new PaddleOcrService();
     await service.initialize();
 
@@ -80,10 +80,10 @@ describe("PaddleOcrService.recognize()", () => {
   let service: PaddleOcrService;
 
   beforeEach(async () => {
-    // Uses the library's default models (v5).
+    // Uses the library's default models.
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterEach(async () => {
     await service.destroy();
@@ -198,10 +198,10 @@ describe("ImageProcessor try/finally safety", () => {
   let service: PaddleOcrService;
 
   beforeEach(async () => {
-    // Uses the library's default models (v5).
+    // Uses the library's default models.
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterEach(async () => {
     await service.destroy();

--- a/tests/strategies-options.test.ts
+++ b/tests/strategies-options.test.ts
@@ -2,9 +2,10 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 
 import { DEFAULT_MODEL_URLS } from "../src/core/base-paddle-ocr.service.js";
+import { CACHE_DIR, getCachedResourceFileName } from "../src/processor/model-cache.js";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 
 const imgFile = Bun.file(`${import.meta.dir}/../assets/receipt.jpg`);
@@ -12,7 +13,7 @@ const imageBuffer = await imgFile.arrayBuffer();
 
 beforeAll(async () => {
   await PaddleOcrService.downloadModels();
-});
+}, 120000);
 
 describe("recognition strategies", () => {
   let service: PaddleOcrService;
@@ -121,7 +122,7 @@ describe("batch streaming, concurrency, and cancellation", () => {
   beforeAll(async () => {
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (service) await service.destroy();
@@ -174,7 +175,7 @@ describe("input forms and caching", () => {
   beforeAll(async () => {
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (service) await service.destroy();
@@ -190,11 +191,13 @@ describe("input forms and caching", () => {
   }, 30000);
 
   test("accepts a per-call dictionary as an ArrayBuffer", async () => {
-    // v5 dictionary (437 entries → 438 with the CTC blank) matching the default
-    // v5 recognition model; the stale v4 models/en_dict.txt (96) would mismatch.
-    const dictBuffer = await Bun.file(
-      `${import.meta.dir}/../models/ppocrv5_en_dict.txt`
-    ).arrayBuffer();
+    const dictFile = readFileSync(
+      `${CACHE_DIR}/${getCachedResourceFileName(DEFAULT_MODEL_URLS.charactersDictionary)}`
+    );
+    const dictBuffer = dictFile.buffer.slice(
+      dictFile.byteOffset,
+      dictFile.byteOffset + dictFile.byteLength
+    ) as ArrayBuffer;
     const result = await service.recognize(imageBuffer, { dictionary: dictBuffer });
     expect(result.text).toBeString();
   }, 30000);
@@ -206,7 +209,7 @@ describe("batch over an async iterable", () => {
   beforeAll(async () => {
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (service) await service.destroy();
@@ -233,25 +236,21 @@ describe("runtime model and dictionary swapping", () => {
   beforeAll(async () => {
     service = new PaddleOcrService();
     await service.initialize();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (service) await service.destroy();
   });
 
-  test("swaps the detection model from a buffer (matches default v5)", async () => {
-    const det = await Bun.file(
-      `${import.meta.dir}/../models/PP-OCRv5_mobile_det_infer.onnx`
-    ).arrayBuffer();
+  test("swaps the detection model from a buffer", async () => {
+    const det = await fetch(DEFAULT_MODEL_URLS.detection).then((res) => res.arrayBuffer());
     await service.changeDetectionModel(det);
 
     const result = await service.recognize(imageBuffer, { noCache: true });
     expect(result.text.length).toBeGreaterThan(0);
   }, 40000);
 
-  test("swaps the recognition model from the default v5 URL", async () => {
-    // Use the default v5 recognition model (matches the loaded v5 dictionary);
-    // never the stale v4 fixture.
+  test("swaps the recognition model from the default URL", async () => {
     await service.changeRecognitionModel(DEFAULT_MODEL_URLS.recognition);
     const result = await service.recognize(imageBuffer, { noCache: true });
     expect(result.text.length).toBeGreaterThan(0);

--- a/tests/web-ocr.test.ts
+++ b/tests/web-ocr.test.ts
@@ -4,6 +4,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { getPlatform, setPlatform } from "ppu-ocv";
 
+import { DEFAULT_MODEL_URLS } from "../src/core/base-paddle-ocr.service.js";
 import type { PaddleOcrService } from "../src/web/paddle-ocr.service.web.js";
 import { installWebCanvas, uninstallWebCanvas } from "./web-canvas-polyfill.js";
 
@@ -96,10 +97,8 @@ describe("web OCR service (onnxruntime-web under the polyfilled runtime)", () =>
     service = new WebPaddleOcrService({ processing: { engine: "canvas-native" } });
     await service.initialize();
 
-    const det = await Bun.file(
-      `${import.meta.dir}/../models/PP-OCRv5_mobile_det_infer.onnx`
-    ).arrayBuffer();
-    await service.changeDetectionModel(det); // v5 detection, matches default
+    const det = await fetch(DEFAULT_MODEL_URLS.detection).then((res) => res.arrayBuffer());
+    await service.changeDetectionModel(det);
 
     const result = await service.recognize(imageBuffer, { noCache: true });
     expect(result.text.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- switch default OCR models to pinned official PaddlePaddle PP-OCRv6 upstream sources
- hash full model URLs in cache filenames to avoid generic basename collisions like inference.onnx
- update tests and docs for the new defaults and cold-cache behavior

## Verification
- bun run fmt
- bun run type-check
- bun run lint
- bun test (174 pass)