### PR TITLE
chore: refresh web demo pins to v6 and advertise React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ppu-paddle-ocr",
   "version": "6.0.0",
-  "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
+  "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",
     "browser-ocr",
@@ -38,7 +38,9 @@
     "typescript-ocr",
     "web-ocr",
     "docker-ocr",
-    "cli-ocr"
+    "cli-ocr",
+    "react-native",
+    "react-native-ocr"
   ],
   "author": "snowfluke",
   "license": "MIT",

--- a/playground/index.html
+++ b/playground/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Free interactive demo of ppu-paddle-ocr: run PaddleOCR (PP-OCRv5) text detection and recognition entirely in your browser with onnxruntime-web and WebGPU — no server, no upload. Lightweight, multilingual, TypeScript-first."
+      content="Free interactive demo of ppu-paddle-ocr: run PaddleOCR (PP-OCRv6) text detection and recognition entirely in your browser with onnxruntime-web and WebGPU — no server, no upload. Lightweight, multilingual, TypeScript-first."
     />
     <meta
       name="keywords"
-      content="ppu-paddle-ocr, PaddleOCR, PP-OCRv5, OCR, browser OCR, WebGPU OCR, ONNX Runtime Web, text detection, text recognition, JavaScript OCR, TypeScript OCR, client-side OCR, receipt OCR, document OCR"
+      content="ppu-paddle-ocr, PaddleOCR, PP-OCRv6, PP-OCRv5, OCR, browser OCR, WebGPU OCR, ONNX Runtime Web, text detection, text recognition, JavaScript OCR, TypeScript OCR, client-side OCR, receipt OCR, document OCR"
     />
     <meta name="author" content="PT Perkasa Pilar Utama" />
     <meta name="robots" content="index, follow" />
@@ -23,7 +23,7 @@
     />
     <meta
       property="og:description"
-      content="Run PaddleOCR (PP-OCRv5) detection + recognition fully client-side with WebGPU/WASM. Try it on your own images — no upload, no server."
+      content="Run PaddleOCR (PP-OCRv6) detection + recognition fully client-side with WebGPU/WASM. Try it on your own images — no upload, no server."
     />
     <meta property="og:url" content="https://ppu-paddle-ocr.snowfluke.workers.dev/" />
     <meta property="og:site_name" content="ppu-paddle-ocr" />
@@ -33,10 +33,10 @@
     <meta name="twitter:title" content="ppu-paddle-ocr — PaddleOCR in the Browser" />
     <meta
       name="twitter:description"
-      content="In-browser PaddleOCR (PP-OCRv5) with WebGPU. Detection + recognition, no server."
+      content="In-browser PaddleOCR (PP-OCRv6) with WebGPU. Detection + recognition, no server."
     />
 
-    <title>ppu-paddle-ocr — PaddleOCR (PP-OCRv5) in the Browser · Interactive Demo</title>
+    <title>ppu-paddle-ocr — PaddleOCR (PP-OCRv6) in the Browser · Interactive Demo</title>
 
     <!-- Structured data -->
     <script type="application/ld+json">
@@ -46,7 +46,7 @@
         "name": "ppu-paddle-ocr",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Web",
-        "description": "Lightweight PaddleOCR (PP-OCRv5) implementation that runs text detection and recognition in the browser via onnxruntime-web and WebGPU.",
+        "description": "Lightweight PaddleOCR (PP-OCRv6) implementation that runs text detection and recognition in the browser via onnxruntime-web and WebGPU.",
         "url": "https://ppu-paddle-ocr.snowfluke.workers.dev/",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
       }
@@ -1114,9 +1114,9 @@
           <div class="input-group">
             <label class="input-label">Strategy</label>
             <select id="cfg-rec-strategy" class="input-field">
-              <option value="per-box">per-box (most accurate)</option>
+              <option value="per-box">per-box (most accurate, SDK default)</option>
               <option value="per-line">per-line</option>
-              <option value="cross-line" selected>cross-line (fastest, default)</option>
+              <option value="cross-line" selected>cross-line (fastest)</option>
             </select>
           </div>
           <div class="input-group">
@@ -1225,8 +1225,8 @@
       {
         "imports": {
           "onnxruntime-web": "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/ort.all.bundle.min.mjs",
-          "ppu-ocv/web": "https://cdn.jsdelivr.net/npm/ppu-ocv@3.2.2/index.web.js",
-          "ppu-ocv/canvas-web": "https://cdn.jsdelivr.net/npm/ppu-ocv@3.2.2/index.canvas-web.js"
+          "ppu-ocv/web": "https://cdn.jsdelivr.net/npm/ppu-ocv@3.3.0/index.web.js",
+          "ppu-ocv/canvas-web": "https://cdn.jsdelivr.net/npm/ppu-ocv@3.3.0/index.canvas-web.js"
         }
       }
     </script>
@@ -1240,7 +1240,7 @@
         // Fallback to npm CDN
         console.warn("Local build failed to load:", e);
         console.log("Falling back to CDN...");
-        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@5.8.0/web/index.js");
+        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.0.0/web/index.js");
         PaddleOcrService = cdn.PaddleOcrService;
       }
 


### PR DESCRIPTION
## What

Refreshes the playground web demo and package metadata for the 6.0.0 / mobile
release:

- Bumps the demo's CDN pins — `ppu-paddle-ocr@5.8.0` → `@6.0.0` (CDN fallback
  import) and `ppu-ocv@3.2.2` → `@3.3.0` (import map).
- Relabels the demo's title/meta/SEO from PP-OCRv5 to PP-OCRv6 (the `@6.0.0`
  default), keeping PP-OCRv5 as a secondary keyword.
- Fixes the stale recognition-strategy labels in the demo.
- Adds `react-native` / `react-native-ocr` keywords and mentions mobile in the
  package description, now that the `./mobile` entry ships.

## Why

The pinned demo versions go stale every release (jsdelivr can otherwise serve a
cached build), so they're bumped to the current `ppu-paddle-ocr@6.0.0` and
`ppu-ocv@3.3.0`. Since `@6.0.0` defaults to PP-OCRv6, the demo's "PP-OCRv5"
copy was inaccurate. And the strategy dropdown labeled `cross-line` as the
"default", but the SDK default is now `per-box` — the demo keeps `cross-line`
selected as a deliberate in-browser speed choice, so the label was corrected
rather than the selection.

## How

- `playground/index.html`: import-map + CDN fallback version pins; `PP-OCRv5` →
  `PP-OCRv6` across `<title>`/meta/JSON-LD; strategy options relabeled
  (`per-box (most accurate, SDK default)`, `cross-line (fastest)`). `dist/` is
  gitignored and regenerated from this source by `build:pages` at deploy.
- `package.json`: keywords + description.

### Checklist

- [x] Tests pass locally (`bun test`) — unaffected (demo/metadata only)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark — not applicable (no library code changed)
- [ ] CHANGELOG — not applicable (demo/metadata only, no public API change)
- [x] README — unchanged (no public-facing option/default/setup change here)
- [ ] New tests — not applicable (no behavior change)

### Compatibility

- [x] Browser — the demo target (WebAssembly + WebGPU), unchanged
- [x] No library runtime code touched

### Related

- Follows #50 (React Native mobile support) — refreshes the public demo + package
  discoverability for the same release.
- The `@6.0.0` CDN fallback resolves once 6.0.0 is published to npm; the deployed
  demo bundles the local `lib/web` build and is unaffected until then.
