### PR TITLE
ci: warm model cache before tests in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,13 @@ jobs:
       - name: TypeScript type check
         run: bun run type-check
 
+      # Pinned bun 1.2.23 caps lifecycle-hook timeouts at the 5 s default, and
+      # the web tests read the v6 models straight from ~/.cache. Warm the cache
+      # here (default v6 + the v5 EN models the dictionary tests use) so the
+      # in-hook downloads are fast disk hits — mirrors ci.yml.
+      - name: Warm model cache
+        run: bun scripts/warm-test-models.ts
+
       - name: Run tests with coverage
         run: bun run test:coverage
 


### PR DESCRIPTION
## What

Adds the "Warm model cache" step to `publish.yml`, before the test step, mirroring
`ci.yml`.

## Why

The v6.0.0 publish failed at the **test gate** (before the npm-publish step, so
nothing was published). The publish workflow ran the whole-repo `bun test` on a
**cold model cache**, but `tests/web-ocr.test.ts`'s `beforeAll` reads the v6
`.ort` files straight from `~/.cache` — cold, that throws `ENOENT`, which corrupts
the global `ppu-ocv` canvas platform (`setPlatform`) and cascades into the node
recognize tests (`getPlatform` → "No canvas platform registered").

`ci.yml` already warms the cache before tests (added during the Bun 1.2.23 hook
fix), which is why PR CI was green while publish was not — `publish.yml` never got
the same step.

Reproduced on bun 1.2.23 with the cache moved aside (the exact `(unnamed)`
web-ocr `beforeAll` ENOENT failure); running the warm step first makes the same
files pass (35/35 on web-ocr + cli).

## How

`.github/workflows/publish.yml`: run `bun scripts/warm-test-models.ts` (default v6
+ the v5 EN models the dictionary tests use) between the type-check and test
steps — identical to `ci.yml`.

### Checklist

- [x] Tests pass locally (`bun test`) — and verified the cold→warm fix on bun 1.2.23
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean
- [ ] Benchmark — not applicable (CI workflow change)
- [ ] CHANGELOG — not applicable (CI-only, no package change)
- [x] README — unchanged
- [ ] New tests — not applicable

### Compatibility

- [x] CI-only change; no library runtime code touched

### Related

- Fixes the failed v6.0.0 publish run (test gate). After merge, re-cut the
  `v6.0.0` tag at the fixed commit and recreate the release to re-trigger publish.
