### PR TITLE
chore: bump serve to 0.1.5 to release a v6 image

### DIFF
--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -87,7 +87,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.1.3",
+      version: "0.1.5",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.1.3";
+export const API_VERSION = "0.1.5";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(


### PR DESCRIPTION
## What

Bumps the serve app to 0.1.5 and re-syncs its version fields.

## Why

The `Deploy serve image` workflow skips the build when `ghcr.io/.../serve:<version>` already exists (it reads the version from `apps/serve/package.json`). The version was still `0.1.4`, which is already published — so re-triggering the workflow was a no-op ("already exists — skipping"), producing the same image.

Bumping to `0.1.5` lets the workflow build + push a fresh image carrying the current v6 library (`apps/serve` vendors `ppu-paddle-ocr` from `src/` via tsconfig paths, so it tracks main, not npm). Also re-syncs `API_VERSION` and the OpenAPI `info.version`, which had drifted at `0.1.3`.

## How

- `apps/serve/package.json`: `0.1.4` → `0.1.5` (image tag + skip check)
- `apps/serve/src/core/api-response.ts`: `API_VERSION` `0.1.3` → `0.1.5`
- `apps/serve/src/app.ts`: OpenAPI `info.version` `0.1.3` → `0.1.5`

### Checklist

- [x] Tests pass locally (serve api tests 13/13; type-check, lint, fmt clean)
- [ ] Benchmark — not applicable
- [ ] CHANGELOG — not applicable (serve app version, not the library)
- [x] README — unchanged
- [ ] New tests — not applicable (version bump)

### Compatibility

- [x] No library runtime code touched; serve app only

### Related

- Unblocks the `Deploy serve image` workflow (skips at an already-published version). Re-run it after merge to push `serve:0.1.5` + `latest`.