### PR TITLE
chore: default web demo strategy to per-box

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1114,9 +1114,9 @@
           <div class="input-group">
             <label class="input-label">Strategy</label>
             <select id="cfg-rec-strategy" class="input-field">
-              <option value="per-box">per-box (most accurate, SDK default)</option>
+              <option value="per-box" selected>per-box (most accurate, default)</option>
               <option value="per-line">per-line</option>
-              <option value="cross-line" selected>cross-line (fastest)</option>
+              <option value="cross-line">cross-line (fastest)</option>
             </select>
           </div>
           <div class="input-group">
@@ -1316,7 +1316,7 @@
 
       // cross-line packs crops into uniform-width batches across lines (fewest
       // inferences) for the fastest recognition; overridable in the sidebar.
-      const DEFAULT_OPTIONS = { recognition: { strategy: "cross-line" } };
+      const DEFAULT_OPTIONS = { recognition: { strategy: "per-box" } };
 
       let loadedImage = null;
       let ocrService = null;


### PR DESCRIPTION
## What

Changes the playground web demo's default recognition strategy from `cross-line` to `per-box`.

## Why

`per-box` is the SDK default (since 6.0.0). The demo previously defaulted to `cross-line` as an in-browser speed pick, but it should showcase the library's actual default behavior.

## How

- Strategy dropdown: `selected` moved to the `per-box` option (relabeled "most accurate, default"); `cross-line` relabeled "(fastest)".
- `DEFAULT_OPTIONS` → `{ recognition: { strategy: "per-box" } }`, so the initial OCR run uses per-box.

Trade-off: the first in-browser result is slightly slower (per-box runs one inference per detected box vs cross-line's batched packing); users can still pick `cross-line` in the dropdown.

### Checklist

- [x] Lint + format are clean
- [ ] Tests / type-check — not applicable (static demo HTML)
- [ ] CHANGELOG — not applicable (demo only)
- [x] README — unchanged

### Compatibility

- [x] Demo-only change; no library code touched. `playground/dist/` is regenerated by `build:pages` at deploy.

### Related

- Follows the 6.0.0 per-box default; aligns the demo with the SDK.