### PR TITLE
fix: clamp merged line crop width to avoid skia surface overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.1] - 2026-07-20
+
 ### Changed
 
 - README: added an Ecosystem section linking the sibling PPU libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cloudflare playground now ships the complete browser build dependency tree.**
   Shared modules imported by `lib/web` are copied into the deployment, preventing
   local module MIME errors and unnecessary CDN fallback.
+- **`per-line`/`cross-line` no longer crash on dense pages with thin detected
+  regions ([#72](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr/issues/72)).**
+  `mergeLineCrop` stretches every box on a line to the
+  line's height; a degenerate box (an underline or table rule a few px tall)
+  multiplied its width by that stretch and the merged canvas width could
+  exceed the platform's maximum surface size, making `createCanvas` throw
+  `Create skia surface failed`. The per-box stretch is now clamped (max 4x)
+  and the merged width is capped at 16384px, shrinking proportionally when
+  exceeded. `run()` also awaits the strategy result inside its try/catch, so
+  a strategy failure degrades to an empty result instead of rejecting
+  `recognize()`.
 
 ## [6.1.0] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -862,14 +862,14 @@ On CPU, throughput is bound by ONNX Runtime's native thread pool (which already 
 
 ppu-paddle-ocr is part of a family of document-processing libraries for JavaScript runtimes, all from [PT Perkasa Pilar Utama](https://github.com/PT-Perkasa-Pilar-Utama):
 
-| Library                                                                                          | What it does                                                                                                    |
-| :----------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
-| [ppu-ocv](https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv)                                     | Chainable image processing on OpenCV.js, plus canvas utilities that run in Node, Bun, browsers, and extensions. |
-| [ppu-pdf](https://github.com/PT-Perkasa-Pilar-Utama/ppu-pdf)                                     | PDF text extraction (digital and scanned) with coordinates, line grouping, and page-to-canvas/PNG rendering.    |
-| [ppu-doclayout](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doclayout)                         | Document layout analysis with PaddlePaddle PP-DocLayout (tables, figures, text regions).                        |
-| [ppu-doc-correction](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doc-correction)               | Document image correction: page orientation, geometric unwarping (UVDoc), and text-line orientation.            |
-| [ppu-uniface](https://github.com/PT-Perkasa-Pilar-Utama/ppu-uniface)                             | Face detection, recognition, verification, alignment, and anti-spoofing (a port of Python's Uniface).           |
-| [ppu-yolo-onnx-inference](https://github.com/PT-Perkasa-Pilar-Utama/ppu-yolo-onnx-inference)     | YOLOv11 object detection in Bun/Node and browsers; no Python or PyTorch required.                               |
+| Library                                                                                      | What it does                                                                                                    |
+| :------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| [ppu-ocv](https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv)                                 | Chainable image processing on OpenCV.js, plus canvas utilities that run in Node, Bun, browsers, and extensions. |
+| [ppu-pdf](https://github.com/PT-Perkasa-Pilar-Utama/ppu-pdf)                                 | PDF text extraction (digital and scanned) with coordinates, line grouping, and page-to-canvas/PNG rendering.    |
+| [ppu-doclayout](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doclayout)                     | Document layout analysis with PaddlePaddle PP-DocLayout (tables, figures, text regions).                        |
+| [ppu-doc-correction](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doc-correction)           | Document image correction: page orientation, geometric unwarping (UVDoc), and text-line orientation.            |
+| [ppu-uniface](https://github.com/PT-Perkasa-Pilar-Utama/ppu-uniface)                         | Face detection, recognition, verification, alignment, and anti-spoofing (a port of Python's Uniface).           |
+| [ppu-yolo-onnx-inference](https://github.com/PT-Perkasa-Pilar-Utama/ppu-yolo-onnx-inference) | YOLOv11 object detection in Bun/Node and browsers; no Python or PyTorch required.                               |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -868,7 +868,6 @@ ppu-paddle-ocr is part of a family of document-processing libraries for JavaScri
 | [ppu-pdf](https://github.com/PT-Perkasa-Pilar-Utama/ppu-pdf)                                     | PDF text extraction (digital and scanned) with coordinates, line grouping, and page-to-canvas/PNG rendering.    |
 | [ppu-doclayout](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doclayout)                         | Document layout analysis with PaddlePaddle PP-DocLayout (tables, figures, text regions).                        |
 | [ppu-doc-correction](https://github.com/PT-Perkasa-Pilar-Utama/ppu-doc-correction)               | Document image correction: page orientation, geometric unwarping (UVDoc), and text-line orientation.            |
-| [ppu-orientation-corrector](https://github.com/PT-Perkasa-Pilar-Utama/ppu-orientation-corrector) | Straightens rotated images/canvases using MobileNetV3 via ONNX Runtime.                                         |
 | [ppu-uniface](https://github.com/PT-Perkasa-Pilar-Utama/ppu-uniface)                             | Face detection, recognition, verification, alignment, and anti-spoofing (a port of Python's Uniface).           |
 | [ppu-yolo-onnx-inference](https://github.com/PT-Perkasa-Pilar-Utama/ppu-yolo-onnx-inference)     | YOLOv11 object detection in Bun/Node and browsers; no Python or PyTorch required.                               |
 

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.2.0", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.2.1", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/bun.lock
+++ b/apps/serve/bun.lock
@@ -19,6 +19,9 @@
       },
     },
   },
+  "overrides": {
+    "adm-zip": "^0.6.0",
+  },
   "packages": {
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
 
@@ -104,7 +107,7 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -23,5 +23,8 @@
     "onnxruntime-node": "^1.27.0",
     "ppu-ocv": "^4.0.0",
     "typescript": "^7.0.2"
+  },
+  "overrides": {
+    "adm-zip": "^0.6.0"
   }
 }

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.2.0",
+      version: "0.2.1",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.2.0";
+export const API_VERSION = "0.2.1";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,9 @@
       ],
     },
   },
+  "overrides": {
+    "adm-zip": "^0.6.0",
+  },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -347,7 +350,7 @@
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
-    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -126,5 +126,8 @@
     "onnxruntime-web": {
       "optional": true
     }
+  },
+  "overrides": {
+    "adm-zip": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -1884,7 +1884,7 @@
         // Fallback to npm CDN
         console.warn("Local build failed to load:", e);
         console.log("Falling back to CDN...");
-        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.0.0/web/index.js");
+        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.1.1/web/index.js");
         PaddleOcrService = cdn.PaddleOcrService;
       }
 

--- a/src/core/base-recognition.service.ts
+++ b/src/core/base-recognition.service.ts
@@ -111,12 +111,17 @@ export class BaseRecognitionService {
 
       switch (strategy) {
         case "cross-line":
-          return runCrossLineStrategy(sourceCanvasForCrop, validBoxes, ctx, charactersDictionary);
+          return await runCrossLineStrategy(
+            sourceCanvasForCrop,
+            validBoxes,
+            ctx,
+            charactersDictionary
+          );
         case "per-line":
-          return runLineStrategy(sourceCanvasForCrop, validBoxes, ctx, charactersDictionary);
+          return await runLineStrategy(sourceCanvasForCrop, validBoxes, ctx, charactersDictionary);
         case "per-box":
         default:
-          return runPerBoxStrategy(
+          return await runPerBoxStrategy(
             sourceCanvasForCrop,
             validBoxes,
             ctx,

--- a/src/core/recognition/line-grouping.ts
+++ b/src/core/recognition/line-grouping.ts
@@ -126,10 +126,17 @@ export function groupBoxesIntoLines(
   return lines;
 }
 
+/** Max factor a box may be stretched horizontally when normalized to the line height. */
+const MAX_BOX_STRETCH = 4;
+/** Max width of a merged line canvas; safe on every skia/browser surface. */
+const MAX_MERGED_WIDTH = 16384;
+
 /**
  * Merges multiple same-line boxes into a single stitched canvas.
  *
  * All crops are stretched to a common height so character sizes are uniform.
+ * Degenerate boxes (far shorter than the line) have their stretch clamped so
+ * the merged width stays bounded.
  */
 export function mergeLineCrop(
   sourceCanvas: CoreCanvas,
@@ -150,22 +157,33 @@ export function mergeLineCrop(
   };
 
   const commonHeight = maxBottom - minY;
-  const commonWidth = lineBoxes.reduce(
-    (sum, b) => sum + Math.round(b.box.width * (commonHeight / b.box.height)),
-    0
+  // Thin boxes (underlines, table rules) grouped into a line would be
+  // stretched by commonHeight/height, multiplying their width; clamp the
+  // per-box stretch and the total so the merged canvas stays within
+  // platform surface limits.
+  let widths = lineBoxes.map(({ box }) =>
+    Math.max(1, Math.round(box.width * Math.min(commonHeight / box.height, MAX_BOX_STRETCH)))
   );
+  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
+  if (totalWidth > MAX_MERGED_WIDTH) {
+    const shrink = MAX_MERGED_WIDTH / totalWidth;
+    widths = widths.map((w) => Math.max(1, Math.round(w * shrink)));
+  }
+  const commonWidth = widths.reduce((sum, w) => sum + w, 0);
 
   const mergedCanvas = createCanvas(commonWidth, commonHeight);
   const ctx = mergedCanvas.getContext("2d");
 
   let offsetX = 0;
-  for (const { box } of lineBoxes) {
+  for (let i = 0; i < lineBoxes.length; i++) {
+    const entry = lineBoxes[i];
+    const stretchedWidth = widths[i];
+    if (!entry || stretchedWidth === undefined) continue;
+    const { box } = entry;
     const cropped = canvasOps.getToolkit().crop({
       bbox: { x0: box.x, y0: box.y, x1: box.x + box.width, y1: box.y + box.height },
       canvas: sourceCanvas,
     });
-    const scaleX = commonHeight / box.height;
-    const stretchedWidth = Math.round(box.width * scaleX);
     ctx.drawImage(cropped, 0, 0, box.width, box.height, offsetX, 0, stretchedWidth, commonHeight);
     offsetX += stretchedWidth;
   }

--- a/tests/line-grouping.test.ts
+++ b/tests/line-grouping.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { describe, expect, test } from "bun:test";
+import { Canvas } from "ppu-ocv";
+import { CanvasToolkit } from "ppu-ocv/canvas";
+
+import type { CanvasOps, CoreCanvas } from "../src/core/platform.js";
+import { groupBoxesIntoLines, mergeLineCrop } from "../src/core/recognition/line-grouping.js";
+
+const createCanvas = (width: number, height: number) =>
+  new Canvas(width, height) as unknown as CoreCanvas;
+
+const canvasOps = {
+  getToolkit: () => CanvasToolkit.getInstance(),
+} as unknown as CanvasOps;
+
+describe("mergeLineCrop", () => {
+  test("clamps degenerate thin boxes so merged width stays bounded (issue #72)", () => {
+    const source = createCanvas(3000, 100);
+    // A 40px-tall text box grouped with a wide 1px underline: unclamped, the
+    // underline would be stretched 40x (2000px -> 80000px) and overflow the
+    // surface limit.
+    const lineBoxes = [
+      { box: { x: 0, y: 10, width: 100, height: 40 }, index: 0 },
+      { box: { x: 120, y: 30, width: 2000, height: 1 }, index: 1 },
+    ];
+
+    const lines = groupBoxesIntoLines(lineBoxes);
+    expect(lines).toHaveLength(1);
+
+    const { mergedCanvas, mergedBox } = mergeLineCrop(source, lineBoxes, createCanvas, canvasOps);
+    expect(mergedCanvas.width).toBeLessThanOrEqual(16384);
+    expect(mergedCanvas.height).toBe(40);
+    expect(mergedBox).toEqual({ x: 0, y: 10, width: 2120, height: 40 });
+  });
+
+  test("keeps normal same-height boxes at their summed scaled width", () => {
+    const source = createCanvas(1000, 100);
+    const lineBoxes = [
+      { box: { x: 0, y: 0, width: 200, height: 40 }, index: 0 },
+      { box: { x: 250, y: 0, width: 300, height: 40 }, index: 1 },
+    ];
+
+    const { mergedCanvas } = mergeLineCrop(source, lineBoxes, createCanvas, canvasOps);
+    expect(mergedCanvas.width).toBe(500);
+    expect(mergedCanvas.height).toBe(40);
+  });
+});


### PR DESCRIPTION
## What

Fixes #72. `per-line` and `cross-line` recognition crashed with `Create skia surface failed` on dense pages containing thin detected regions (underlines, table rules). Also carries the v6.1.1 release prep: version bumps for the package, jsr, serve image (0.2.1), and the stale playground CDN pin.

## Why

`mergeLineCrop` stretches every box on a line to the line's common height. A degenerate box (a 2000x1 underline on a 40px line) gets its width multiplied by `commonHeight/height` (40x here, to 80000px), and past the platform's surface allocation limit `createCanvas` throws, killing the whole page's recognition. On top of that, `run()` returned the strategy promise un-awaited inside its try/catch, so the rejection bypassed the catch and `recognize()` threw instead of degrading to an empty result.

## How

Both guards live in `mergeLineCrop` (src/core/recognition/line-grouping.ts), the shared choke point for per-line and cross-line, so callers need no changes:

- Per-box stretch is clamped to 4x: real same-line text rarely differs more in height, and anything thinner is decoration with nothing to recognize.
- Total merged width is capped at 16384px, shrinking all crops proportionally when exceeded. The limit is not a hard skia constant (allocation failure threshold is platform dependent); 16384 is safe on every skia/browser surface.
- `run()` now `return await`s the three strategies so the existing catch actually handles failures.

The suggested height-similarity guard in `groupBoxesIntoLines` was deliberately skipped: the clamp already prevents the crash, while changing the grouping heuristic would alter output on every page and needs its own accuracy evaluation.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`) - clamp is O(boxes-per-line), same as before; default `per-box` path untouched
- [x] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [ ] README updated if the public API, defaults, or setup changed - no API change
- [x] New tests added for bugs fixed or features added

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- Closes #72
- Repro details and threshold measurements: https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr/issues/72#issuecomment-5023178991