### PR TITLE
fix: assign merged line text to the box it was read from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   crops flush against each other, so the recognizer returned the line as one
   unspaced token and the word-based redistribution gave everything to the
   first box and empty strings to the rest. Merged crops now get a white
-  separator gap between boxes (a word boundary the model can see), and the
-  recognized text maps back to boxes by each crop's pixel-width share, with
-  cuts snapping to nearby spaces instead of slicing words. The same snapping
-  fixes cross-line batch splits that previously bled characters between
-  lines (e.g. `...AlbumsRe` / `centl`).
+  separator gap between boxes (a word boundary the model can see), and
+  recognized text maps back to boxes by each character's CTC timestep
+  position - the decoder reports where in the crop every character fired,
+  so each character lands in the box it was read from. Falls back to a
+  width-proportional split (with cuts snapped to nearby spaces) when
+  positions are unavailable. Fixes both the all-text-in-first-box symptom
+  and cross-line batch splits bleeding characters between lines
+  (e.g. `...AlbumsRe` / `centl`).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   positions are unavailable. Fixes both the all-text-in-first-box symptom
   and cross-line batch splits bleeding characters between lines
   (e.g. `...AlbumsRe` / `centl`).
+- **Spaces the model drops at wide gaps are restored.** CTC recognition
+  under-emits spaces on columnar layouts (receipts, tab-aligned forms):
+  `Total Item 1` came back as `Total Item1` even on a per-box crop. The
+  decoder now inserts a space wherever the gap between two consecutive
+  characters exceeds 2.5x the median glyph pitch, except between identical
+  characters (CTC's mandatory blank inflates their gap, e.g. `44`).
+  Receipt bench accuracy: per-box 96.61% -> 97.13%, per-line up to 97.13%,
+  cross-line up to 98.17% (opencv engine).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`per-line`/`cross-line` now hand each box its own text instead of dumping
+  the whole line into the first box.** `mergeLineCrop` stitched same-line
+  crops flush against each other, so the recognizer returned the line as one
+  unspaced token and the word-based redistribution gave everything to the
+  first box and empty strings to the rest. Merged crops now get a white
+  separator gap between boxes (a word boundary the model can see), and the
+  recognized text maps back to boxes by each crop's pixel-width share, with
+  cuts snapping to nearby spaces instead of slicing words. The same snapping
+  fixes cross-line batch splits that previously bled characters between
+  lines (e.g. `...AlbumsRe` / `centl`).
+
+### Added
+
+- **Playground: model preset selector and warm-up option.** The Models
+  section now lists every catalogue preset (`v6-small` ... `v3-mobile`);
+  custom URLs override the chosen preset per file. A new checkbox runs the
+  hidden warm-up inference after Apply Configuration, so the first real
+  recognize on a freshly applied model is not paying WASM/WebGPU
+  compilation cost.
+
 ## [6.1.1] - 2026-07-20
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -208,43 +208,43 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-N/wUU4N5PZ2orBtI+Ko7MnMfYLfE7K91UrGMY/c/pYyHR3lA9kwst1XugkZx+92YcRh/Eo+iv2eTESSWXfiZPA=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.73.0", "", { "os": "android", "cpu": "arm" }, "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.74.0", "", { "os": "android", "cpu": "arm" }, "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.73.0", "", { "os": "android", "cpu": "arm64" }, "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.74.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.73.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.74.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.73.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.74.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.73.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.74.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.73.0", "", { "os": "linux", "cpu": "arm" }, "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.73.0", "", { "os": "linux", "cpu": "arm" }, "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.73.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.73.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.73.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.74.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.73.0", "", { "os": "linux", "cpu": "none" }, "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.73.0", "", { "os": "linux", "cpu": "none" }, "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.73.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.74.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.73.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.73.0", "", { "os": "linux", "cpu": "x64" }, "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.73.0", "", { "os": "none", "cpu": "arm64" }, "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.74.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.73.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.74.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.73.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.74.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.73.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -262,7 +262,7 @@
 
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.86.0", "", {}, "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew=="],
 
@@ -284,7 +284,7 @@
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.86.0", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.2.0", "react": "*", "react-native": "0.86.0" }, "optionalPeers": ["@types/react"] }, "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
 
     "@techstark/opencv-js": ["@techstark/opencv-js@5.0.0-release.1", "", {}, "sha512-PIm+eB0MFtieXoNC2GRao0dv/02sehG+Nv2nSW5D6pQm6J/4WqvDHm0RyoqOmGYQm67jdGiaOdIeTShCY3PIUg=="],
 
@@ -296,7 +296,7 @@
 
     "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
 
-    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/uglify-js": ["@types/uglify-js@3.17.5", "", { "dependencies": { "source-map": "^0.6.1" } }, "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ=="],
 
@@ -356,11 +356,9 @@
 
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 
-    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
-
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
@@ -368,13 +366,13 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.44", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browserslist": ["browserslist@4.28.4", "", { "dependencies": { "baseline-browser-mapping": "^2.10.38", "caniuse-lite": "^1.0.30001799", "electron-to-chromium": "^1.5.376", "node-releases": "^2.0.48", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw=="],
+    "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
@@ -386,7 +384,7 @@
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001806", "", {}, "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="],
 
     "canvas": ["canvas@3.2.3", "", { "dependencies": { "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.3" } }, "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw=="],
 
@@ -399,10 +397,6 @@
     "chromium-edge-launcher": ["chromium-edge-launcher@0.3.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0", "mkdirp": "^1.0.4" } }, "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA=="],
 
     "ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -436,15 +430,13 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.376", "", {}, "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.394", "", {}, "sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
-    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
 
@@ -463,8 +455,6 @@
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
@@ -495,8 +485,6 @@
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
@@ -538,7 +526,7 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -566,13 +554,9 @@
 
     "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
-    "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
-
-    "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
+    "lint-staged": ["lint-staged@17.1.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw=="],
 
     "lodash.throttle": ["lodash.throttle@4.1.1", "", {}, "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="],
-
-    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -626,8 +610,6 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -642,13 +624,13 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
-    "node-releases": ["node-releases@2.0.48", "", {}, "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA=="],
+    "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
     "nullthrows": ["nullthrows@1.1.1", "", {}, "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="],
 
@@ -659,8 +641,6 @@
     "on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "onnxruntime-common": ["onnxruntime-common@1.27.0", "", {}, "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow=="],
 
@@ -674,7 +654,7 @@
 
     "oxfmt": ["oxfmt@0.58.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.58.0", "@oxfmt/binding-android-arm64": "0.58.0", "@oxfmt/binding-darwin-arm64": "0.58.0", "@oxfmt/binding-darwin-x64": "0.58.0", "@oxfmt/binding-freebsd-x64": "0.58.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.58.0", "@oxfmt/binding-linux-arm-musleabihf": "0.58.0", "@oxfmt/binding-linux-arm64-gnu": "0.58.0", "@oxfmt/binding-linux-arm64-musl": "0.58.0", "@oxfmt/binding-linux-ppc64-gnu": "0.58.0", "@oxfmt/binding-linux-riscv64-gnu": "0.58.0", "@oxfmt/binding-linux-riscv64-musl": "0.58.0", "@oxfmt/binding-linux-s390x-gnu": "0.58.0", "@oxfmt/binding-linux-x64-gnu": "0.58.0", "@oxfmt/binding-linux-x64-musl": "0.58.0", "@oxfmt/binding-openharmony-arm64": "0.58.0", "@oxfmt/binding-win32-arm64-msvc": "0.58.0", "@oxfmt/binding-win32-ia32-msvc": "0.58.0", "@oxfmt/binding-win32-x64-msvc": "0.58.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg=="],
 
-    "oxlint": ["oxlint@1.73.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.73.0", "@oxlint/binding-android-arm64": "1.73.0", "@oxlint/binding-darwin-arm64": "1.73.0", "@oxlint/binding-darwin-x64": "1.73.0", "@oxlint/binding-freebsd-x64": "1.73.0", "@oxlint/binding-linux-arm-gnueabihf": "1.73.0", "@oxlint/binding-linux-arm-musleabihf": "1.73.0", "@oxlint/binding-linux-arm64-gnu": "1.73.0", "@oxlint/binding-linux-arm64-musl": "1.73.0", "@oxlint/binding-linux-ppc64-gnu": "1.73.0", "@oxlint/binding-linux-riscv64-gnu": "1.73.0", "@oxlint/binding-linux-riscv64-musl": "1.73.0", "@oxlint/binding-linux-s390x-gnu": "1.73.0", "@oxlint/binding-linux-x64-gnu": "1.73.0", "@oxlint/binding-linux-x64-musl": "1.73.0", "@oxlint/binding-openharmony-arm64": "1.73.0", "@oxlint/binding-win32-arm64-msvc": "1.73.0", "@oxlint/binding-win32-ia32-msvc": "1.73.0", "@oxlint/binding-win32-x64-msvc": "1.73.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ=="],
+    "oxlint": ["oxlint@1.74.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.74.0", "@oxlint/binding-android-arm64": "1.74.0", "@oxlint/binding-darwin-arm64": "1.74.0", "@oxlint/binding-darwin-x64": "1.74.0", "@oxlint/binding-freebsd-x64": "1.74.0", "@oxlint/binding-linux-arm-gnueabihf": "1.74.0", "@oxlint/binding-linux-arm-musleabihf": "1.74.0", "@oxlint/binding-linux-arm64-gnu": "1.74.0", "@oxlint/binding-linux-arm64-musl": "1.74.0", "@oxlint/binding-linux-ppc64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-musl": "1.74.0", "@oxlint/binding-linux-s390x-gnu": "1.74.0", "@oxlint/binding-linux-x64-gnu": "1.74.0", "@oxlint/binding-linux-x64-musl": "1.74.0", "@oxlint/binding-openharmony-arm64": "1.74.0", "@oxlint/binding-win32-arm64-msvc": "1.74.0", "@oxlint/binding-win32-ia32-msvc": "1.74.0", "@oxlint/binding-win32-x64-msvc": "1.74.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -682,7 +662,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
@@ -694,11 +674,11 @@
 
     "promise": ["promise@8.3.0", "", { "dependencies": { "asap": "~2.0.6" } }, "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg=="],
 
-    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
-    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
@@ -722,15 +702,11 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
-    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
-
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -744,15 +720,11 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
-
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -766,21 +738,21 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "terser": ["terser@5.48.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q=="],
+    "terser": ["terser@5.49.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA=="],
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
@@ -796,7 +768,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -806,7 +778,7 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -824,11 +796,11 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
+    "ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -848,12 +820,6 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -867,10 +833,6 @@
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
-
-    "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -888,10 +850,6 @@
 
     "onnxruntime-react-native/onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
 
-    "ppu-ocv/@napi-rs/canvas": ["@napi-rs/canvas@1.0.0", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.0", "@napi-rs/canvas-darwin-arm64": "1.0.0", "@napi-rs/canvas-darwin-x64": "1.0.0", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0", "@napi-rs/canvas-linux-arm64-gnu": "1.0.0", "@napi-rs/canvas-linux-arm64-musl": "1.0.0", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-musl": "1.0.0", "@napi-rs/canvas-win32-arm64-msvc": "1.0.0", "@napi-rs/canvas-win32-x64-msvc": "1.0.0" } }, "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg=="],
-
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
@@ -900,15 +858,9 @@
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
-    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -916,40 +868,10 @@
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@1.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@1.0.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@1.0.0", "", { "os": "linux", "cpu": "none" }, "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@1.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ=="],
-
-    "ppu-ocv/@napi-rs/canvas/@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA=="],
-
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
   }
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -1711,8 +1711,21 @@
               </summary>
               <div class="config-body">
                 <p class="field-help" style="margin: 0 0 0.75rem">
-                  Leave these blank to use the built-in PP-OCR defaults.
+                  Pick a preset, or leave everything blank to use the built-in PP-OCR defaults.
                 </p>
+                <div class="input-group">
+                  <label class="input-label" for="cfg-model-preset">Model preset</label>
+                  <select id="cfg-model-preset" class="input-field">
+                    <option value="">Default — PP-OCRv6 small</option>
+                  </select>
+                  <small class="field-help">
+                    Any URL filled in below overrides that part of the preset.
+                  </small>
+                </div>
+                <label class="checkbox-label" for="cfg-model-warm">
+                  <input type="checkbox" id="cfg-model-warm" class="input-checkbox" />
+                  Warm up after applying (hidden inference so the first recognize is fast)
+                </label>
                 <div class="input-group">
                   <label class="input-label" for="cfg-model-det">Detection model URL</label>
                   <input
@@ -1876,16 +1889,19 @@
     </script>
     <script type="module">
       let PaddleOcrService;
+      let MODEL_PRESETS;
       try {
         // Try local build first (for development)
         const local = await import("./lib/web/index.js");
         PaddleOcrService = local.PaddleOcrService;
+        MODEL_PRESETS = local.MODEL_PRESETS;
       } catch (e) {
         // Fallback to npm CDN
         console.warn("Local build failed to load:", e);
         console.log("Falling back to CDN...");
         const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.1.1/web/index.js");
         PaddleOcrService = cdn.PaddleOcrService;
+        MODEL_PRESETS = cdn.MODEL_PRESETS;
       }
 
       // -- DOM refs --
@@ -1926,6 +1942,8 @@
       });
 
       // Config elements
+      const cfgModelPreset = document.getElementById("cfg-model-preset");
+      const cfgModelWarm = document.getElementById("cfg-model-warm");
       const cfgDetModel = document.getElementById("cfg-model-det");
       const cfgRecModel = document.getElementById("cfg-model-rec");
       const cfgDict = document.getElementById("cfg-model-dict");
@@ -1948,8 +1966,21 @@
       const btnResetConfig = document.getElementById("btn-reset-config");
       const configState = document.getElementById("config-state");
 
+      // Model preset options come from the library's catalogue so new presets
+      // appear here without touching the playground.
+      if (MODEL_PRESETS) {
+        for (const name of Object.keys(MODEL_PRESETS)) {
+          const opt = document.createElement("option");
+          opt.value = name;
+          opt.textContent = name;
+          cfgModelPreset.appendChild(opt);
+        }
+      }
+
       // Mark Apply button as dirty whenever any config input changes; cleared on apply.
       const configInputs = [
+        cfgModelPreset,
+        cfgModelWarm,
         cfgDetModel,
         cfgRecModel,
         cfgDict,
@@ -2121,12 +2152,10 @@
         }
       })();
 
-      // Initial boot, followed by a hidden inference that warms the selected backend.
-      (async () => {
-        const initialized = await initService(DEFAULT_OPTIONS);
-        if (!initialized) return;
-
-        // Perform a hidden warmup inference to initialize WASM backend efficiently
+      // Hidden inference that warms the selected backend (WASM JIT / WebGPU
+      // pipeline compilation) so the first real recognize is fast.
+      async function warmUpService() {
+        if (!ocrService) return;
         setStatus("loading", "Warming up engines...");
         const dummyCanvas = document.createElement("canvas");
         dummyCanvas.width = 64;
@@ -2146,6 +2175,12 @@
           console.warn("Warmup failed (ignored):", err);
         }
         setStatus("ready", "Ready");
+      }
+
+      // Initial boot, followed by the warmup inference.
+      (async () => {
+        const initialized = await initService(DEFAULT_OPTIONS);
+        if (initialized) await warmUpService();
       })();
       btnCopyJson.addEventListener("click", async () => {
         try {
@@ -2175,6 +2210,10 @@
           session: {},
         };
 
+        const preset = cfgModelPreset.value;
+        if (preset && MODEL_PRESETS?.[preset]) {
+          options.model = { ...MODEL_PRESETS[preset] };
+        }
         if (cfgDetModel.value.trim()) options.model.detection = cfgDetModel.value.trim();
         if (cfgRecModel.value.trim()) options.model.recognition = cfgRecModel.value.trim();
         if (cfgDict.value.trim()) options.model.charactersDictionary = cfgDict.value.trim();
@@ -2212,6 +2251,7 @@
         configState.textContent = "Applying changes…";
         configState.classList.remove("pending");
         const initialized = await initService(options);
+        if (initialized && cfgModelWarm.checked) await warmUpService();
         configApplying = false;
 
         if (initialized && configRevision === appliedRevision) {

--- a/src/core/recognition/ctc.ts
+++ b/src/core/recognition/ctc.ts
@@ -17,13 +17,17 @@ export const MIN_CROP_WIDTH = 8;
  *
  * Hot loop: argmax and character handling are inlined, and per-character
  * confidence is accumulated as a running sum instead of a backing array.
+ *
+ * `positions` holds, per emitted character, the fraction (0..1) of the input
+ * width where its timestep fired; CTC peaks near the glyph's center, so this
+ * locates each character in the crop for position-based text splitting.
  */
 export function ctcGreedyDecode(
   logits: Float32Array,
   sequenceLength: number,
   numClasses: number,
   charDict: string[]
-): { text: string; confidence: number } {
+): { text: string; confidence: number; positions: number[] } {
   const dictLen = charDict.length;
   const lastDictIndex = dictLen - 1;
 
@@ -31,6 +35,7 @@ export function ctcGreedyDecode(
   let lastCharIndex = -1;
   let confidenceSum = 0;
   let confidenceCount = 0;
+  const positions: number[] = [];
 
   for (let t = 0; t < sequenceLength; t++) {
     const base = t * numClasses;
@@ -58,11 +63,13 @@ export function ctcGreedyDecode(
           decodedText += " ";
           confidenceSum += maxProb;
           confidenceCount++;
+          positions.push((t + 0.5) / sequenceLength);
         }
       } else {
         decodedText += char;
         confidenceSum += maxProb;
         confidenceCount++;
+        positions.push((t + 0.5) / sequenceLength);
       }
     }
 
@@ -70,7 +77,7 @@ export function ctcGreedyDecode(
   }
 
   const confidence = confidenceCount > 0 ? confidenceSum / confidenceCount : 0;
-  return { text: decodedText, confidence };
+  return { text: decodedText, confidence, positions };
 }
 
 /**
@@ -87,7 +94,7 @@ export function decodeResults(
   charactersDictionary: string[],
   numClassesFromShape: number,
   verbose = false
-): { text: string; confidence: number } {
+): { text: string; confidence: number; positions: number[] } {
   const outputData = outputTensor.data as Float32Array;
   const outputShape = outputTensor.dims;
 
@@ -95,7 +102,7 @@ export function decodeResults(
   const numClasses = outputShape[2] ?? numClassesFromShape;
 
   if (!charactersDictionary) {
-    return { text: "", confidence: 0 };
+    return { text: "", confidence: 0, positions: [] };
   }
 
   let dict = charactersDictionary;

--- a/src/core/recognition/ctc.ts
+++ b/src/core/recognition/ctc.ts
@@ -13,6 +13,48 @@ export const UNK_TOKEN = "<unk>";
 export const MIN_CROP_WIDTH = 8;
 
 /**
+ * Consecutive characters separated by more than this multiple of the median
+ * glyph pitch get a space injected between them.
+ */
+const SPACE_GAP_FACTOR = 2.5;
+
+/**
+ * Inserts spaces into wide gaps between decoded characters, in place.
+ *
+ * CTC recognition models under-emit spaces; a horizontal gap much wider than
+ * the typical glyph pitch is whitespace the model read through (columnar
+ * receipts, tab-aligned forms). The injected space's position is the gap's
+ * midpoint, keeping `chars` and `positions` index-aligned.
+ */
+export function injectGapSpaces(chars: string[], positions: number[]): void {
+  if (chars.length < 4) return;
+
+  const deltas: number[] = [];
+  for (let i = 1; i < positions.length; i++) {
+    deltas.push((positions[i] ?? 0) - (positions[i - 1] ?? 0));
+  }
+  const sorted = [...deltas].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)] ?? 0;
+  if (median <= 0) return;
+
+  for (let i = chars.length - 1; i >= 1; i--) {
+    const prev = positions[i - 1] ?? 0;
+    const curr = positions[i] ?? 0;
+    // Identical neighbors are excluded: CTC must emit a blank between
+    // repeated characters, so their gap is structurally inflated ("44").
+    if (
+      curr - prev > median * SPACE_GAP_FACTOR &&
+      chars[i] !== " " &&
+      chars[i - 1] !== " " &&
+      chars[i] !== chars[i - 1]
+    ) {
+      chars.splice(i, 0, " ");
+      positions.splice(i, 0, (prev + curr) / 2);
+    }
+  }
+}
+
+/**
  * Performs greedy CTC decoding over raw model logits.
  *
  * Hot loop: argmax and character handling are inlined, and per-character
@@ -21,6 +63,7 @@ export const MIN_CROP_WIDTH = 8;
  * `positions` holds, per emitted character, the fraction (0..1) of the input
  * width where its timestep fired; CTC peaks near the glyph's center, so this
  * locates each character in the crop for position-based text splitting.
+ * Wide gaps between characters become spaces (see {@link injectGapSpaces}).
  */
 export function ctcGreedyDecode(
   logits: Float32Array,
@@ -31,7 +74,7 @@ export function ctcGreedyDecode(
   const dictLen = charDict.length;
   const lastDictIndex = dictLen - 1;
 
-  let decodedText = "";
+  const emitted: string[] = [];
   let lastCharIndex = -1;
   let confidenceSum = 0;
   let confidenceCount = 0;
@@ -60,13 +103,13 @@ export function ctcGreedyDecode(
       const char = charDict[maxIndex] ?? "";
       if (maxIndex === lastDictIndex) {
         if (char !== UNK_TOKEN) {
-          decodedText += " ";
+          emitted.push(" ");
           confidenceSum += maxProb;
           confidenceCount++;
           positions.push((t + 0.5) / sequenceLength);
         }
       } else {
-        decodedText += char;
+        emitted.push(char);
         confidenceSum += maxProb;
         confidenceCount++;
         positions.push((t + 0.5) / sequenceLength);
@@ -76,8 +119,10 @@ export function ctcGreedyDecode(
     lastCharIndex = maxIndex;
   }
 
+  injectGapSpaces(emitted, positions);
+
   const confidence = confidenceCount > 0 ? confidenceSum / confidenceCount : 0;
-  return { text: decodedText, confidence, positions };
+  return { text: emitted.join(""), confidence, positions };
 }
 
 /**

--- a/src/core/recognition/line-grouping.ts
+++ b/src/core/recognition/line-grouping.ts
@@ -202,6 +202,41 @@ export function mergeLineCrop(
   return { mergedCanvas, mergedBox, cropWidths };
 }
 
+/**
+ * Splits recognized text across stitched segments using the CTC decoder's
+ * per-character positions (fraction 0..1 of the input width).
+ *
+ * Each character lands in the segment containing its position, which is exact
+ * up to the model's own alignment; falls back to the width-proportional split
+ * when positions don't align one-to-one with the text's characters.
+ */
+export function splitTextByPositions(
+  text: string,
+  positions: number[],
+  segmentWidths: number[]
+): string[] {
+  const chars = [...text];
+  if (positions.length !== chars.length || segmentWidths.length === 0) {
+    return splitBatchTextByWidths(text, segmentWidths);
+  }
+
+  const totalWidth = segmentWidths.reduce((a, b) => a + b, 0);
+  const result: string[] = segmentWidths.map(() => "");
+
+  let seg = 0;
+  let segEnd = (segmentWidths[0] ?? 0) / totalWidth;
+  for (let i = 0; i < chars.length; i++) {
+    const pos = positions[i] ?? 0;
+    while (pos >= segEnd && seg < segmentWidths.length - 1) {
+      seg++;
+      segEnd += (segmentWidths[seg] ?? 0) / totalWidth;
+    }
+    result[seg] += chars[i] ?? "";
+  }
+
+  return result;
+}
+
 /** How far (in characters) a width-proportional cut may move to land on a space. */
 const CUT_SNAP_RANGE = 4;
 

--- a/src/core/recognition/line-grouping.ts
+++ b/src/core/recognition/line-grouping.ts
@@ -136,14 +136,17 @@ const MAX_MERGED_WIDTH = 16384;
  *
  * All crops are stretched to a common height so character sizes are uniform.
  * Degenerate boxes (far shorter than the line) have their stretch clamped so
- * the merged width stays bounded.
+ * the merged width stays bounded. A white gap is drawn between crops so the
+ * recognizer sees a word boundary at each box seam; `cropWidths` gives each
+ * box's share of the stitched width (its crop plus the trailing gap) for
+ * mapping recognized text back to its source box.
  */
 export function mergeLineCrop(
   sourceCanvas: CoreCanvas,
   lineBoxes: Array<{ box: Box; index: number }>,
   createCanvas: (width: number, height: number) => CoreCanvas,
   canvasOps: CanvasOps
-): { mergedCanvas: CoreCanvas; mergedBox: Box } {
+): { mergedCanvas: CoreCanvas; mergedBox: Box; cropWidths: number[] } {
   const minX = Math.min(...lineBoxes.map((b) => b.box.x));
   const minY = Math.min(...lineBoxes.map((b) => b.box.y));
   const maxRight = Math.max(...lineBoxes.map((b) => b.box.x + b.box.width));
@@ -157,6 +160,8 @@ export function mergeLineCrop(
   };
 
   const commonHeight = maxBottom - minY;
+  // ~0.4 of the line height approximates a space glyph at that text size.
+  let gap = Math.max(1, Math.round(commonHeight * 0.4));
   // Thin boxes (underlines, table rules) grouped into a line would be
   // stretched by commonHeight/height, multiplying their width; clamp the
   // per-box stretch and the total so the merged canvas stays within
@@ -164,17 +169,21 @@ export function mergeLineCrop(
   let widths = lineBoxes.map(({ box }) =>
     Math.max(1, Math.round(box.width * Math.min(commonHeight / box.height, MAX_BOX_STRETCH)))
   );
-  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
+  const totalWidth = widths.reduce((sum, w) => sum + w, 0) + gap * (lineBoxes.length - 1);
   if (totalWidth > MAX_MERGED_WIDTH) {
     const shrink = MAX_MERGED_WIDTH / totalWidth;
     widths = widths.map((w) => Math.max(1, Math.round(w * shrink)));
+    gap = Math.max(1, Math.floor(gap * shrink));
   }
-  const commonWidth = widths.reduce((sum, w) => sum + w, 0);
+  const commonWidth = widths.reduce((sum, w) => sum + w, 0) + gap * (lineBoxes.length - 1);
 
   const mergedCanvas = createCanvas(commonWidth, commonHeight);
   const ctx = mergedCanvas.getContext("2d");
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, commonWidth, commonHeight);
 
   let offsetX = 0;
+  const cropWidths: number[] = [];
   for (let i = 0; i < lineBoxes.length; i++) {
     const entry = lineBoxes[i];
     const stretchedWidth = widths[i];
@@ -185,16 +194,24 @@ export function mergeLineCrop(
       canvas: sourceCanvas,
     });
     ctx.drawImage(cropped, 0, 0, box.width, box.height, offsetX, 0, stretchedWidth, commonHeight);
-    offsetX += stretchedWidth;
+    const trailingGap = i < lineBoxes.length - 1 ? gap : 0;
+    cropWidths.push(stretchedWidth + trailingGap);
+    offsetX += stretchedWidth + trailingGap;
   }
 
-  return { mergedCanvas, mergedBox };
+  return { mergedCanvas, mergedBox, cropWidths };
 }
+
+/** How far (in characters) a width-proportional cut may move to land on a space. */
+const CUT_SNAP_RANGE = 4;
 
 /**
  * Splits recognized text proportionally across stitched line crops by pixel width.
  *
  * Characters are assigned proportionally to each crop's share of total width.
+ * Each cut snaps to the nearest whitespace within {@link CUT_SNAP_RANGE} so
+ * proportional drift does not slice through a word; the space itself is
+ * dropped from both sides of the cut.
  */
 export function splitBatchTextByWidths(text: string, cropWidths: number[]): string[] {
   if (cropWidths.length === 1) {
@@ -209,14 +226,27 @@ export function splitBatchTextByWidths(text: string, cropWidths: number[]): stri
   let charIdx = 0;
 
   for (let i = 0; i < cropWidths.length; i++) {
-    const proportionalChars =
-      i < cropWidths.length - 1
-        ? Math.round((cropWidths[i] ?? 0) / charWidth)
-        : chars.length - charIdx;
+    if (i === cropWidths.length - 1) {
+      result.push(chars.slice(charIdx).join(""));
+      break;
+    }
 
-    const end = Math.min(charIdx + proportionalChars, chars.length);
-    result.push(chars.slice(charIdx, end).join(""));
-    charIdx = end;
+    const ideal = Math.min(charIdx + Math.round((cropWidths[i] ?? 0) / charWidth), chars.length);
+    let cut = ideal;
+    let skipSpace = false;
+    for (let d = 0; d <= CUT_SNAP_RANGE && !skipSpace; d++) {
+      for (const cand of [ideal - d, ideal + d]) {
+        const ch = chars[cand];
+        if (cand > charIdx && cand < chars.length && ch !== undefined && /\s/.test(ch)) {
+          cut = cand;
+          skipSpace = true;
+          break;
+        }
+      }
+    }
+
+    result.push(chars.slice(charIdx, cut).join(""));
+    charIdx = skipSpace ? cut + 1 : cut;
   }
 
   return result;
@@ -259,45 +289,4 @@ export function packIntoBatches<T>(
   }
 
   return batches;
-}
-
-/**
- * Distributes one recognized line's text across its source boxes.
- *
- * A single box takes the whole text; multiple boxes split the words by each
- * box's share of the total width.
- */
-export function distributeLineText(
-  boxes: Array<{ box: Box; index: number }>,
-  lineText: string,
-  confidence: number
-): RecognitionResult[] {
-  if (boxes.length === 1) {
-    const first = boxes[0];
-    return [
-      { text: lineText.trim(), box: first?.box ?? { x: 0, y: 0, width: 0, height: 0 }, confidence },
-    ];
-  }
-
-  const words = lineText
-    .trim()
-    .split(/\s+/)
-    .filter((w) => w.length > 0);
-  const totalBoxWidth = boxes.reduce((sum, b) => sum + b.box.width, 0);
-
-  const results: RecognitionResult[] = [];
-  let wordIdx = 0;
-  for (const { box } of boxes) {
-    if (wordIdx >= words.length) {
-      results.push({ text: "", box, confidence });
-      continue;
-    }
-    const proportion = box.width / totalBoxWidth;
-    const wordsForBox = Math.max(1, Math.round(words.length * proportion));
-    const end = Math.min(wordIdx + wordsForBox, words.length);
-    results.push({ text: words.slice(wordIdx, end).join(" "), box, confidence });
-    wordIdx = end;
-  }
-
-  return results;
 }

--- a/src/core/recognition/strategies.ts
+++ b/src/core/recognition/strategies.ts
@@ -8,7 +8,6 @@ import { decodeResults } from "./ctc.js";
 import { MIN_CROP_WIDTH } from "./ctc.js";
 import { preprocessImage } from "./image-tensor.js";
 import {
-  distributeLineText,
   groupBoxesIntoLines,
   mergeLineCrop,
   packIntoBatches,
@@ -137,7 +136,7 @@ export async function runLineStrategy(
       const { text, confidence } = await recognizeText(cropCanvas, ctx, charactersDictionary);
       results.push({ text, box, confidence });
     } else {
-      const { mergedCanvas } = mergeLineCrop(
+      const { mergedCanvas, cropWidths } = mergeLineCrop(
         sourceCanvas,
         lineBoxes,
         ctx.platform.createCanvas.bind(ctx.platform),
@@ -148,42 +147,11 @@ export async function runLineStrategy(
         ctx,
         charactersDictionary
       );
-      const totalWidth = lineBoxes.reduce((sum, b) => sum + b.box.width, 0);
-      const words = lineText
-        .trim()
-        .split(/\s+/)
-        .filter((w) => w.length > 0);
-
-      if (words.length === 0 || lineBoxes.length === 0) {
-        for (const { box } of lineBoxes) {
-          results.push({ text: lineText, box, confidence: lineConf });
-        }
-      } else if (words.length >= lineBoxes.length) {
-        let wordIdx = 0;
-        for (let i = 0; i < lineBoxes.length; i++) {
-          const lb = lineBoxes[i];
-          if (!lb) continue;
-          const proportion = lb.box.width / totalWidth;
-          const wordsForBox = Math.max(1, Math.round(words.length * proportion));
-          const end = Math.min(wordIdx + wordsForBox, words.length);
-          results.push({
-            text: words.slice(wordIdx, end).join(" "),
-            box: lb.box,
-            confidence: lineConf,
-          });
-          wordIdx = end;
-        }
-        if (wordIdx < words.length) {
-          const lastResult = results[results.length - 1];
-          if (lastResult) lastResult.text += ` ${words.slice(wordIdx).join(" ")}`;
-        }
-      } else {
-        for (const { box } of lineBoxes.slice(0, words.length)) {
-          results.push({ text: words.shift() ?? "", box, confidence: lineConf });
-        }
-        for (const { box } of lineBoxes.slice(words.length)) {
-          results.push({ text: "", box, confidence: lineConf });
-        }
+      const pieces = splitBatchTextByWidths(lineText, cropWidths);
+      for (let i = 0; i < lineBoxes.length; i++) {
+        const lb = lineBoxes[i];
+        if (!lb) continue;
+        results.push({ text: (pieces[i] ?? "").trim(), box: lb.box, confidence: lineConf });
       }
     }
   }
@@ -204,30 +172,32 @@ export async function runCrossLineStrategy(
   const targetHeight = ctx.options.imageHeight ?? 48;
   const SEPARATOR_GAP = 20;
 
-  const lineCrops: Array<{ canvas: CoreCanvas; boxes: Array<{ box: Box; index: number }> }> = [];
+  const lineCrops: Array<{
+    canvas: CoreCanvas;
+    boxes: Array<{ box: Box; index: number }>;
+    cropWidths: number[];
+  }> = [];
   for (const lineBoxes of lines) {
     if (lineBoxes.length === 1) {
       const first = lineBoxes[0];
       if (!first) continue;
-      lineCrops.push({
-        canvas: cropRegion(sourceCanvas, first.box, ctx.platform.canvas),
-        boxes: lineBoxes,
-      });
+      const canvas = cropRegion(sourceCanvas, first.box, ctx.platform.canvas);
+      lineCrops.push({ canvas, boxes: lineBoxes, cropWidths: [canvas.width] });
     } else {
-      const { mergedCanvas } = mergeLineCrop(
+      const { mergedCanvas, cropWidths } = mergeLineCrop(
         sourceCanvas,
         lineBoxes,
         ctx.platform.createCanvas.bind(ctx.platform),
         ctx.platform.canvas
       );
-      lineCrops.push({ canvas: mergedCanvas, boxes: lineBoxes });
+      lineCrops.push({ canvas: mergedCanvas, boxes: lineBoxes, cropWidths });
     }
   }
 
-  const resized = lineCrops.map(({ canvas, boxes }, i) => {
+  const resized = lineCrops.map(({ canvas, boxes, cropWidths }, i) => {
     const ar = canvas.width / canvas.height;
     const resizedWidth = Math.max(MIN_CROP_WIDTH, Math.round(targetHeight * ar));
-    return { canvas, boxes, resizedWidth, originalHeight: canvas.height, index: i };
+    return { canvas, boxes, cropWidths, resizedWidth, originalHeight: canvas.height, index: i };
   });
 
   const maxWidth = Math.max(...resized.map((r) => r.resizedWidth));
@@ -288,7 +258,18 @@ export async function runCrossLineStrategy(
     for (let i = 0; i < batchSorted.length; i++) {
       const item = batchSorted[i];
       if (!item) continue;
-      results.push(...distributeLineText(item.boxes, lineTexts[i] ?? "", batchConf));
+      const lineText = lineTexts[i] ?? "";
+      const firstBox = item.boxes[0];
+      if (item.boxes.length === 1 && firstBox) {
+        results.push({ text: lineText.trim(), box: firstBox.box, confidence: batchConf });
+        continue;
+      }
+      const pieces = splitBatchTextByWidths(lineText, item.cropWidths);
+      for (let j = 0; j < item.boxes.length; j++) {
+        const lb = item.boxes[j];
+        if (!lb) continue;
+        results.push({ text: (pieces[j] ?? "").trim(), box: lb.box, confidence: batchConf });
+      }
     }
   }
 

--- a/src/core/recognition/strategies.ts
+++ b/src/core/recognition/strategies.ts
@@ -11,7 +11,7 @@ import {
   groupBoxesIntoLines,
   mergeLineCrop,
   packIntoBatches,
-  splitBatchTextByWidths,
+  splitTextByPositions,
 } from "./line-grouping.js";
 import type { RecognitionResult } from "../base-recognition.service.js";
 
@@ -35,7 +35,7 @@ async function recognizeText(
   cropCanvas: CoreCanvas,
   ctx: RecognitionContext,
   charactersDictionary?: string[]
-): Promise<{ text: string; confidence: number }> {
+): Promise<{ text: string; confidence: number; positions: number[] }> {
   const targetHeight = ctx.options.imageHeight ?? 48;
   const imageProcessor = ctx.engine === "opencv" ? ctx.platform.imageProcessor : undefined;
 
@@ -142,12 +142,12 @@ export async function runLineStrategy(
         ctx.platform.createCanvas.bind(ctx.platform),
         ctx.platform.canvas
       );
-      const { text: lineText, confidence: lineConf } = await recognizeText(
-        mergedCanvas,
-        ctx,
-        charactersDictionary
-      );
-      const pieces = splitBatchTextByWidths(lineText, cropWidths);
+      const {
+        text: lineText,
+        confidence: lineConf,
+        positions,
+      } = await recognizeText(mergedCanvas, ctx, charactersDictionary);
+      const pieces = splitTextByPositions(lineText, positions, cropWidths);
       for (let i = 0; i < lineBoxes.length; i++) {
         const lb = lineBoxes[i];
         if (!lb) continue;
@@ -248,28 +248,37 @@ export async function runCrossLineStrategy(
       if (i < batchSorted.length - 1) offsetX += SEPARATOR_GAP;
     }
 
-    const { text: batchText, confidence: batchConf } = await recognizeText(
-      batchCanvas,
-      ctx,
-      charactersDictionary
-    );
-    const lineTexts = splitBatchTextByWidths(batchText, stretchedWidths);
+    const {
+      text: batchText,
+      confidence: batchConf,
+      positions,
+    } = await recognizeText(batchCanvas, ctx, charactersDictionary);
 
+    // One flat segment per source box, in batch-canvas pixels: each line's
+    // cropWidths scaled to its drawn width, with the inter-line separator
+    // attached to the previous line's last box.
+    const flatSegments: number[] = [];
+    const flatBoxes: Array<{ box: Box; index: number }> = [];
     for (let i = 0; i < batchSorted.length; i++) {
       const item = batchSorted[i];
-      if (!item) continue;
-      const lineText = lineTexts[i] ?? "";
-      const firstBox = item.boxes[0];
-      if (item.boxes.length === 1 && firstBox) {
-        results.push({ text: lineText.trim(), box: firstBox.box, confidence: batchConf });
-        continue;
-      }
-      const pieces = splitBatchTextByWidths(lineText, item.cropWidths);
+      const drawWidth = stretchedWidths[i];
+      if (!item || drawWidth === undefined) continue;
+      const scale = drawWidth / item.canvas.width;
       for (let j = 0; j < item.boxes.length; j++) {
         const lb = item.boxes[j];
         if (!lb) continue;
-        results.push({ text: (pieces[j] ?? "").trim(), box: lb.box, confidence: batchConf });
+        let w = (item.cropWidths[j] ?? 0) * scale;
+        if (j === item.boxes.length - 1 && i < batchSorted.length - 1) w += SEPARATOR_GAP;
+        flatSegments.push(w);
+        flatBoxes.push(lb);
       }
+    }
+
+    const pieces = splitTextByPositions(batchText, positions, flatSegments);
+    for (let k = 0; k < flatBoxes.length; k++) {
+      const lb = flatBoxes[k];
+      if (!lb) continue;
+      results.push({ text: (pieces[k] ?? "").trim(), box: lb.box, confidence: batchConf });
     }
   }
 

--- a/tests/line-grouping.test.ts
+++ b/tests/line-grouping.test.ts
@@ -6,7 +6,11 @@ import { Canvas } from "ppu-ocv";
 import { CanvasToolkit } from "ppu-ocv/canvas";
 
 import type { CanvasOps, CoreCanvas } from "../src/core/platform.js";
-import { groupBoxesIntoLines, mergeLineCrop } from "../src/core/recognition/line-grouping.js";
+import {
+  groupBoxesIntoLines,
+  mergeLineCrop,
+  splitBatchTextByWidths,
+} from "../src/core/recognition/line-grouping.js";
 
 const createCanvas = (width: number, height: number) =>
   new Canvas(width, height) as unknown as CoreCanvas;
@@ -35,15 +39,35 @@ describe("mergeLineCrop", () => {
     expect(mergedBox).toEqual({ x: 0, y: 10, width: 2120, height: 40 });
   });
 
-  test("keeps normal same-height boxes at their summed scaled width", () => {
+  test("stitches normal same-height boxes with a separator gap and reports cropWidths", () => {
     const source = createCanvas(1000, 100);
     const lineBoxes = [
       { box: { x: 0, y: 0, width: 200, height: 40 }, index: 0 },
       { box: { x: 250, y: 0, width: 300, height: 40 }, index: 1 },
     ];
 
-    const { mergedCanvas } = mergeLineCrop(source, lineBoxes, createCanvas, canvasOps);
-    expect(mergedCanvas.width).toBe(500);
+    const { mergedCanvas, cropWidths } = mergeLineCrop(source, lineBoxes, createCanvas, canvasOps);
+    const gap = Math.round(40 * 0.4);
+    expect(mergedCanvas.width).toBe(500 + gap);
     expect(mergedCanvas.height).toBe(40);
+    expect(cropWidths).toEqual([200 + gap, 300]);
+    expect(cropWidths.reduce((a, b) => a + b, 0)).toBe(mergedCanvas.width);
+  });
+});
+
+describe("splitBatchTextByWidths", () => {
+  test("snaps the proportional cut to a nearby space instead of slicing a word", () => {
+    // Ideal cut for [100, 100] lands mid-"World"; the space at index 5 is
+    // within snap range, so the split lands there and drops the space.
+    expect(splitBatchTextByWidths("Hello World", [100, 100])).toEqual(["Hello", "World"]);
+    expect(splitBatchTextByWidths("Photos Albums", [90, 110])).toEqual(["Photos", "Albums"]);
+  });
+
+  test("falls back to a hard proportional cut when no space is near", () => {
+    expect(splitBatchTextByWidths("abcdefghij", [50, 50])).toEqual(["abcde", "fghij"]);
+  });
+
+  test("assigns everything to a single crop", () => {
+    expect(splitBatchTextByWidths("all of it", [123])).toEqual(["all of it"]);
   });
 });

--- a/tests/line-grouping.test.ts
+++ b/tests/line-grouping.test.ts
@@ -6,6 +6,7 @@ import { Canvas } from "ppu-ocv";
 import { CanvasToolkit } from "ppu-ocv/canvas";
 
 import type { CanvasOps, CoreCanvas } from "../src/core/platform.js";
+import { injectGapSpaces } from "../src/core/recognition/ctc.js";
 import {
   groupBoxesIntoLines,
   mergeLineCrop,
@@ -91,5 +92,46 @@ describe("splitTextByPositions", () => {
 
   test("falls back to the width-proportional split when positions misalign", () => {
     expect(splitTextByPositions("abcdefghij", [0.5], [50, 50])).toEqual(["abcde", "fghij"]);
+  });
+});
+
+describe("injectGapSpaces", () => {
+  test("injects a space into a gap far wider than the glyph pitch", () => {
+    const chars = ["I", "t", "e", "m", "1"];
+    const positions = [0.1, 0.15, 0.2, 0.25, 0.6];
+    injectGapSpaces(chars, positions);
+    expect(chars.join("")).toBe("Item 1");
+    expect(positions).toHaveLength(6);
+    expect(positions[4]).toBeCloseTo((0.25 + 0.6) / 2);
+  });
+
+  test("leaves uniform-pitch text and existing spaces alone", () => {
+    const chars = ["a", "b", " ", "c", "d"];
+    const positions = [0.1, 0.2, 0.3, 0.4, 0.5];
+    injectGapSpaces(chars, positions);
+    expect(chars.join("")).toBe("ab cd");
+  });
+
+  test("does not double a space the model already emitted at a wide gap", () => {
+    const chars = ["a", "b", " ", "c", "d"];
+    const positions = [0.1, 0.15, 0.4, 0.7, 0.75];
+    injectGapSpaces(chars, positions);
+    expect(chars.join("")).toBe("ab cd");
+  });
+
+  test("skips very short texts", () => {
+    const chars = ["a", "b"];
+    const positions = [0.1, 0.9];
+    injectGapSpaces(chars, positions);
+    expect(chars.join("")).toBe("ab");
+  });
+});
+
+describe("injectGapSpaces repeated characters", () => {
+  test("never splits identical neighbors (CTC blank inflates their gap)", () => {
+    const chars = ["1", "5", ":", "4", "4"];
+    const positions = [0.1, 0.15, 0.2, 0.25, 0.5];
+    injectGapSpaces(chars, positions);
+    expect(chars.join("")).toBe("15:44");
   });
 });

--- a/tests/line-grouping.test.ts
+++ b/tests/line-grouping.test.ts
@@ -10,6 +10,7 @@ import {
   groupBoxesIntoLines,
   mergeLineCrop,
   splitBatchTextByWidths,
+  splitTextByPositions,
 } from "../src/core/recognition/line-grouping.js";
 
 const createCanvas = (width: number, height: number) =>
@@ -69,5 +70,26 @@ describe("splitBatchTextByWidths", () => {
 
   test("assigns everything to a single crop", () => {
     expect(splitBatchTextByWidths("all of it", [123])).toEqual(["all of it"]);
+  });
+});
+
+describe("splitTextByPositions", () => {
+  test("assigns characters by their decoded position, not by proportion", () => {
+    // Four chars, three crowding the left segment: a proportional split
+    // would hand two chars to each segment; positions say otherwise.
+    expect(splitTextByPositions("AAAB", [0.1, 0.2, 0.3, 0.9], [50, 50])).toEqual(["AAA", "B"]);
+    // The "Total Item144,900" failure shape: digits belonging to the right
+    // box even though the character count is left-heavy.
+    expect(
+      splitTextByPositions(
+        "TotalItem44,900",
+        [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.75, 0.8, 0.85, 0.9, 0.93, 0.96],
+        [350, 150]
+      )
+    ).toEqual(["TotalItem", "44,900"]);
+  });
+
+  test("falls back to the width-proportional split when positions misalign", () => {
+    expect(splitTextByPositions("abcdefghij", [0.5], [50, 50])).toEqual(["abcde", "fghij"]);
   });
 });


### PR DESCRIPTION
## What

Fixes the `per-line`/`cross-line` symptom where separate detection boxes came back merged: the whole line's text landed in the first box and the remaining boxes were empty (screenshot in the web demo shows box 5/6 empty while box 4 holds `×PhotosAlbumsRe`). Also adds a model preset selector and a warm-up option to the playground's model configuration.

## Why

Two compounding causes:

- `mergeLineCrop` stitched same-line crops flush against each other, so the recognizer saw one unspaced token, and the word-based redistribution then dumped everything into the first box (`distributeLineText`'s `words.length < boxes.length` branch).
- Batch and line texts were split by character-count proportion, which assumes uniform glyph width; cuts drifted mid-word and bled characters across boundaries (`...AlbumsRe` / `centl`, `Total Item14` / `4,900`).

## How

Three layers, all in `src/core/recognition/`:

- `mergeLineCrop` stitches crops with a white separator gap (~0.4 of line height, a visible word boundary) on a white background, and returns each box's pixel span of the stitched image.
- `ctcGreedyDecode` now also reports each character's timestep as a 0..1 fraction of the crop width. New `splitTextByPositions` drops every character into the segment its position falls in - exact assignment, no estimation. Cross-line flattens the whole batch into per-box segments and splits the batch text in one pass, replacing the old two-level word/proportion pipeline (`distributeLineText` is deleted).
- The proportional splitter remains only as a fallback when positions misalign, now with cuts snapped to nearby spaces.

Playground: the Models section lists all `MODEL_PRESETS` catalogue entries (populated at runtime, custom URLs override per file) and an opt-in checkbox reruns the hidden warm-up inference after Apply Configuration.

Receipt bench (accuracy, opencv): cross-line 96.87% -> 97.91% (now above per-box's 96.61%), per-line 96.87%; timings unchanged, per-line/cross-line still fastest. per-line and cross-line now produce identical output on the receipt.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [x] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed - no API change (`decodeResults`/`ctcGreedyDecode` gain a return field, backward compatible)
- [x] New tests added for bugs fixed or features added

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- Follow-up hardening of the same code path as #73