### PR TITLE
chore: prepare v6.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.2] - 2026-07-21
+
 ### Fixed
 
 - **`per-line`/`cross-line` now hand each box its own text instead of dumping

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.2.1", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.2.2", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.2.1",
+      version: "0.2.2",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.2.1";
+export const API_VERSION = "0.2.2";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -1899,7 +1899,7 @@
         // Fallback to npm CDN
         console.warn("Local build failed to load:", e);
         console.log("Falling back to CDN...");
-        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.1.1/web/index.js");
+        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.1.2/web/index.js");
         PaddleOcrService = cdn.PaddleOcrService;
         MODEL_PRESETS = cdn.MODEL_PRESETS;
       }


### PR DESCRIPTION
## What

Version bumps for the v6.1.2 release: root `package.json` and `jsr.json` to 6.1.2, serve app to 0.2.2, playground CDN fallback pin to 6.1.2, and the CHANGELOG Unreleased section promoted to `[6.1.2] - 2026-07-21`.

## Why

v6.1.2 ships the merged-line text redistribution fixes (#74): separator gaps in stitched crops, CTC position-based text-to-box mapping, and gap-space restoration, plus the playground preset selector and warm-up option. The serve image gets its per-release patch bump; the CLI needs no change since it reads its version from package.json at runtime.

Also evaluated whether the default recognition strategy should move from `per-box` to `per-line`/`cross-line` now that the merged strategies improved: SROIE bench (40 receipts, token-F1) on this exact build says no - per-box wins both accuracy (74.46% F1 vs 71.93/67.44) and speed (573 ms/img vs 614/822). Default stays `per-box`.

## How

Same touchpoints as the v6.1.1 release: version fields in the two root manifests, the serve version in `apps/serve/package.json`, `app.ts` (/health), `api-response.ts` (API_VERSION), and the serve README examples, plus the jsdelivr pin in `playground/index.html`.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path - version bumps only
- [x] CHANGELOG updated (Unreleased promoted to 6.1.2)
- [ ] README updated if the public API, defaults, or setup changed - no changes
- [ ] New tests added for bugs fixed or features added - no code changes

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- Releases #74's fixes
- Follows the same release-prep shape as the v6.1.1 bump