### PR TITLE
chore: release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-07-22
+
 ### Changed
 
 - **Default model is PP-OCRv6 tiny** (was small): 2-4x faster, ~6 MB

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.2.2", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.3.0", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.2.2",
+      version: "0.3.0",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.2.2";
+export const API_VERSION = "0.3.0";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -2338,7 +2338,7 @@
             // Fallback to npm CDN
             console.warn("Local build failed to load:", e);
             console.log("Falling back to CDN...");
-            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.1.2/web/index.js");
+            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.2.0/web/index.js");
           }
         }
         PaddleOcrService = mod.PaddleOcrService;


### PR DESCRIPTION
## What

Release prep for v6.2.0: bumps `package.json` + `jsr.json` to 6.2.0,
serve to 0.3.0 (new `MIN_CONFIDENCE` / `MAX_SIDE_LENGTH` env vars make
it a minor), promotes the Unreleased changelog to `[6.2.0] - 2026-07-22`,
and points the playground CDN fallback pin at 6.2.0.

## Why

Ships the defaults overhaul from #76: PP-OCRv6 tiny as the default model
with the tuned pipeline (per-line, auto sizing, min area 20, confidence
filter, decode refinements) - 99.48% on the receipt benchmark at 2-4x
the previous speed - plus the selection matrix docs, hardened test
suite, and the revised playground.

## How

Every version touchpoint from the release map: root manifests
(lockstep-checked by the pre-commit hook), the four serve locations
(`apps/serve/package.json`, `/health` in `app.ts`, `API_VERSION` in
`api-response.ts`, README envelope examples), the playground pin, and
the changelog. The CLI reads `package.json` at runtime and needs no
edit.

After merge: sign the tag locally (`git tag -s v6.2.0`), push it, create
the GitHub release with the changelog section as notes (npm/jsr publish
auto-triggers), run `deploy-serve.yml` for the Docker image, deploy the
rebuilt playground dist, and push the wiki sync.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (version strings only)
- [x] CHANGELOG updated (Unreleased promoted to 6.2.0)
- [x] README updated if the public API, defaults, or setup changed
- [ ] New tests added (no behavior change)

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

- Ships #76
