### PR TITLE
docs: cover export and onnx conversion version gates in fine-tune kit

### DIFF
--- a/examples/fine-tune/README.md
+++ b/examples/fine-tune/README.md
@@ -98,7 +98,7 @@ paddle2onnx --model_dir fine-tune/output/tiny_infer \
 for PIR exports.
 
 > paddle2onnx 2.x refuses to run against paddle < 3.0 (`ValueError: The
-> paddlepaddle version should not be less than 3.0.0...`). If you trained on
+paddlepaddle version should not be less than 3.0.0...`). If you trained on
 > paddle 2.x, swap to a CPU paddle 3 for this one step — training and export
 > are already done, and conversion does not need a GPU:
 > `pip uninstall -y paddlepaddle-gpu paddlepaddle && pip install paddlepaddle==3.0.0 paddle2onnx`

--- a/examples/fine-tune/README.md
+++ b/examples/fine-tune/README.md
@@ -77,7 +77,34 @@ python tools/export_model.py -c fine-tune/configs/PP-OCRv6_tiny_rec_ft.yml \
      Global.save_inference_dir=fine-tune/output/tiny_infer
 ```
 
-Convert the inference model to ONNX with [`examples/convert-onnx.ipynb`](../convert-onnx.ipynb) (optionally quantize with [`examples/quantize-onnx.py`](../quantize-onnx.py)).
+> On PaddlePaddle < 3.0 this fails with a bare `AssertionError` in
+> `export_single_model`: the default export format (PIR) needs paddle >= 3.0.
+> Append `Global.export_with_pir=False` to the `-o` list to export the classic
+> format instead — everything downstream works with either.
+
+Convert to ONNX:
+
+```bash
+pip install paddle2onnx
+paddle2onnx --model_dir fine-tune/output/tiny_infer \
+  --model_filename inference.pdmodel \
+  --params_filename inference.pdiparams \
+  --save_file fine-tune/output/tiny_rec.onnx \
+  --opset_version 14 \
+  --enable_onnx_checker True
+```
+
+`--model_filename` is `inference.pdmodel` for the classic format, `inference.json`
+for PIR exports.
+
+> paddle2onnx 2.x refuses to run against paddle < 3.0 (`ValueError: The
+> paddlepaddle version should not be less than 3.0.0...`). If you trained on
+> paddle 2.x, swap to a CPU paddle 3 for this one step — training and export
+> are already done, and conversion does not need a GPU:
+> `pip uninstall -y paddlepaddle-gpu paddlepaddle && pip install paddlepaddle==3.0.0 paddle2onnx`
+
+See [`examples/convert-onnx.ipynb`](../convert-onnx.ipynb) for optional INT8
+quantization and `.ort` packaging.
 
 ## 5. Load it in ppu-paddle-ocr
 


### PR DESCRIPTION


<!--
Thanks for opening a PR against ppu-paddle-ocr! Please fill out the three
sections below. Keep it short - a couple of sentences each is fine for
small changes. Bigger changes deserve a bit more context.
-->

## What

Update the docs

<!--
What does this PR change? One or two sentences, in plain language.
If this fixes an issue, link it: "Fixes #123".

Examples:
- Adds WebGPU execution provider to the web build.
- Fixes crash when a detected box is smaller than MIN_CROP_WIDTH.
- Bumps `onnxruntime-node` peer from ^1.23 to ^1.26.
-->

## Why

Two footguns hit in a real fine-tune run: tools/export_model.py asserts on paddle < 3.0 unless Global.export_with_pir=False, and paddle2onnx 2.x refuses paddle < 3.0 entirely. Document both with the concrete escape hatches and the classic-vs-PIR --model_filename difference.

<!--
Why is this change worth making?

If it's a bug fix, describe the symptom the user was seeing and what the
root cause turned out to be. If it's a feature, explain the use case that
motivated it. If it's a performance change, include numbers (see the
Benchmark section below).

Avoid restating *what* you did - focus on *why* it's worth merging.
-->

## How

<!--
How does the change work? Point readers at the key files and the design
choices that aren't obvious from reading the diff. If you considered
other approaches, say why you picked this one.

For performance PRs, include the bench output (before vs. after) and
note whether accuracy is preserved on the receipt sample.
-->

### Checklist

- [ ] Tests pass locally (`bun test`)
- [ ] Types are clean (`bun run type-check`)
- [ ] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [ ] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [ ] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

### Compatibility

<!--
Tick the environments you've verified manually (CI covers the first two).
Leave the rest unticked if you haven't exercised them - reviewers will
know what still needs checking.
-->

- [ ] Node.js (via `onnxruntime-node`)
- [ ] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [ ] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

<!--
Optional: link related PRs, upstream issues, or docs.

- Closes #123
- Part of the perf work on #45
- Upstream: https://github.com/microsoft/onnxruntime/issues/...
-->
