### PR TITLE
fix: run the web build inside web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ort.env.wasm.wasmPaths` gets its CDN default inside workers too.** The
   default was gated on `typeof window !== "undefined"`, which is false in a
   worker, so CDN and unbundled worker setups 404ed on the WASM binaries
+- **The default WASM CDN URL now tracks the loaded `onnxruntime-web`.** It was
+  pinned to 1.26.0 while the package resolves 1.27.0, so anyone who did not set
+  `wasmPaths` handed a 1.27 loader 1.26 binaries. The version is read from
+  `ort.env.versions` at call time and can no longer drift
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The web build runs inside a Web Worker** ([#84](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr/issues/84)).
+  `createCanvas()` called `document.createElement("canvas")` and `isCanvas()`
+  evaluated `image instanceof HTMLCanvasElement`, and neither global exists in a
+  worker scope, so both threw a `ReferenceError`. Canvas creation now goes
+  through `ppu-ocv`, which prefers `OffscreenCanvas`, and the canvas check is
+  duck-typed. Manifest V3 extension service workers are covered by the same fix.
+  No shims needed on the caller's side
+- **`ort.env.wasm.wasmPaths` gets its CDN default inside workers too.** The
+  default was gated on `typeof window !== "undefined"`, which is false in a
+  worker, so CDN and unbundled worker setups 404ed on the WASM binaries
+
 ### Added
 
+- **`isWebWorker()` export on `ppu-paddle-ocr/web`** for host apps that need to
+  branch on the scope themselves
 - Recognition fine-tuning starter kit (`examples/fine-tune/`): per-tier
   PP-OCRv6 training configs, a dataset preparation script that builds
   train/val/test splits from images with line-level ground truth, and a

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ await service.destroy();
 
 - **Lightweight**, minimal dependencies, optimized for performance.
 - **Pre-packed models**, PP-OCRv6 tiny models (~6 MB, multilingual) are fetched and cached automatically on first run; the full-dictionary small/medium tiers and language-specific variants are one option away. Supports additional variants via [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models).
-- **Runs everywhere**, Node.js, Bun, Deno, web browsers, browser extensions, and React Native (iOS/Android). The official SDK is browser-only.
+- **Runs everywhere**, Node.js, Bun, Deno, web browsers, web workers, browser extensions, and React Native (iOS/Android). The official SDK is browser-only.
 - **Customizable**, custom models, dictionaries, and per-call overrides.
 - **TypeScript**, full type definitions.
 
@@ -89,6 +89,7 @@ The same package, the same API, every JavaScript runtime:
 | **Bun**                   | `bun add ppu-paddle-ocr onnxruntime-node`                                                                   | [npm package](https://www.npmjs.com/package/ppu-paddle-ocr)                                      |
 | **Deno**                  | `deno add jsr:@snowfluke/ppu-paddle-ocr`                                                                    | [JSR package](https://jsr.io/@snowfluke/ppu-paddle-ocr)                                          |
 | **Web browser**           | `npm install ppu-paddle-ocr onnxruntime-web` (import `/web` subpath)                                        | [Live demo](https://ppu-paddle-ocr.snowfluke.workers.dev/)                                       |
+| **Web worker**            | Same as web; the `/web` subpath runs in workers and MV3 service workers unchanged.                          | [Web Workers](#web-workers)                                                                      |
 | **Browser extension**     | Same as web; bundle `ppu-paddle-ocr/web` with your extension's bundler.                                     | [Example extension repo](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-extension)     |
 | **Mobile (React Native)** | `npm install ppu-paddle-ocr onnxruntime-react-native @shopify/react-native-skia` (import `/mobile` subpath) | [Example app](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-mobile-react-native-demo) |
 
@@ -541,7 +542,7 @@ const service = new PaddleOcrService({
 });
 ```
 
-> The WASM binaries are still required even when WebGPU is the primary provider (used for graph optimization and fallback ops). Set `ort.env.wasm.wasmPaths` before `initialize()` if you self-host them.
+> The WASM binaries are still required even when WebGPU is the primary provider (used for graph optimization and fallback ops). When `ort.env.wasm.wasmPaths` is unset, pages and workers fall back to the jsDelivr copy of the exact `onnxruntime-web` version you loaded, so the binaries and the loader never disagree. Set it yourself before `initialize()` to self-host.
 
 ### Multithreaded WASM (Cross-Origin Isolation)
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,47 @@ const result = await service.recognize(canvas);
 console.log(result.text);
 ```
 
+### Web Workers
+
+The web build runs unchanged inside a Web Worker, a shared worker, or a Manifest V3 extension service worker. Every intermediate canvas comes from `OffscreenCanvas`, so the pipeline never touches `document` or `HTMLCanvasElement` and needs no shims.
+
+Keep the service inside the worker and send image bytes across the boundary, so inference never blocks the main thread:
+
+```ts
+// worker.ts
+import { PaddleOcrService } from "ppu-paddle-ocr/web";
+
+const service = new PaddleOcrService();
+const ready = service.initialize();
+
+self.onmessage = async (event: MessageEvent<ArrayBuffer>) => {
+  await ready;
+  const result = await service.recognize(event.data);
+  self.postMessage(result);
+};
+```
+
+```ts
+// main.ts
+const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" });
+worker.onmessage = (event) => console.log(event.data.text);
+
+const bytes = await file.arrayBuffer();
+worker.postMessage(bytes, [bytes]); // transferred, not copied
+```
+
+`recognize()` also accepts an `OffscreenCanvas` directly, which is what `canvas.transferControlToOffscreen()` hands the worker.
+
+Notes:
+
+- WebGPU detection behaves the same way in a worker and falls back to WASM when `navigator.gpu` is absent.
+- Cross-origin isolation still governs WASM threading, see [Multithreaded WASM](#multithreaded-wasm-cross-origin-isolation). It is a property of the page, not of the worker.
+- `isWebWorker()` is exported if you need to branch on the scope yourself.
+
+```ts
+import { isWebWorker } from "ppu-paddle-ocr/web";
+```
+
 ### CDN (No Bundler)
 
 See the [live demo](https://ppu-paddle-ocr.snowfluke.workers.dev/) for a complete ESM/CDN setup.

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -289,6 +289,27 @@ The WASM binaries are still required even when WebGPU is the primary provider - 
 
 For CDN / no-bundler setups, point at the published ESM build directly (see the live demo at https://ppu-paddle-ocr.snowfluke.workers.dev/ for a complete reference).
 
+## Running in a Web Worker
+
+`ppu-paddle-ocr/web` runs unchanged in a dedicated worker, a shared worker, or an MV3 extension service worker. Every canvas it allocates is an `OffscreenCanvas`, so it never touches `document` or `HTMLCanvasElement`. No shims are needed. If a user is patching `self.document` or `self.HTMLCanvasElement` to make it work, that is a workaround for a bug that has since been fixed - tell them to drop it and update.
+
+Keep the service inside the worker and transfer image bytes in, so inference never blocks the main thread:
+
+```ts
+// worker.ts
+import { PaddleOcrService } from "ppu-paddle-ocr/web";
+
+const service = new PaddleOcrService();
+const ready = service.initialize();
+
+self.onmessage = async (event: MessageEvent<ArrayBuffer>) => {
+  await ready;
+  self.postMessage(await service.recognize(event.data));
+};
+```
+
+`recognize()` also accepts an `OffscreenCanvas` directly, which is what `transferControlToOffscreen()` hands the worker. `isWebWorker()` is exported for host code that needs to branch on the scope itself.
+
 ## The React Native (mobile) entry point
 
 `ppu-paddle-ocr/mobile` runs the same pipeline on iOS/Android via `onnxruntime-react-native` (native JSI) and `ppu-ocv/canvas-mobile` (Skia). Install `onnxruntime-react-native` and `@shopify/react-native-skia`, and use a dev client / `expo prebuild` (Expo Go can't load the native modules). Feed `recognize()` an `ArrayBuffer` - e.g. a bundled asset or a frame from `expo-camera` / `react-native-vision-camera`:

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -285,7 +285,7 @@ const service = new PaddleOcrService({
 });
 ```
 
-The WASM binaries are still required even when WebGPU is the primary provider - they're used for graph optimization and fallback ops. If the user is self-hosting onnxruntime-web's WASM files, they must set `ort.env.wasm.wasmPaths` **before** `initialize()`.
+The WASM binaries are still required even when WebGPU is the primary provider - they're used for graph optimization and fallback ops. When `ort.env.wasm.wasmPaths` is unset, the web build points it at the jsDelivr copy of the exact `onnxruntime-web` version the page loaded, so the binaries always match the loader. If the user is self-hosting those files, they must set `ort.env.wasm.wasmPaths` **before** `initialize()`.
 
 For CDN / no-bundler setups, point at the published ESM build directly (see the live demo at https://ppu-paddle-ocr.snowfluke.workers.dev/ for a complete reference).
 

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -84,7 +84,7 @@ export { DetectionService } from "./detection.service.web.js";
 export type { RecognitionResult } from "../core/base-recognition.service.js";
 export { RecognitionService } from "./recognition.service.web.js";
 
-export { getDefaultWebExecutionProviders, isWebGpuAvailable } from "./platform.web.js";
+export { getDefaultWebExecutionProviders, isWebGpuAvailable, isWebWorker } from "./platform.web.js";
 
 export {
   DEFAULT_DEBUGGING_OPTIONS,

--- a/src/web/platform.web.ts
+++ b/src/web/platform.web.ts
@@ -9,8 +9,19 @@ import type {
 } from "ppu-ocv/canvas";
 import type { CanvasOps, CoreCanvas, PlatformProvider } from "../core/platform.js";
 
-/** CDN copy of the ONNX Runtime WASM binaries, used when the host app picks no location. */
-const DEFAULT_WASM_PATHS = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
+/**
+ * CDN copy of the ONNX Runtime WASM binaries, used when the host app picks no
+ * location.
+ *
+ * The version comes from the runtime that is actually loaded rather than a pin,
+ * so the binaries always match the JS glue that fetches them. A pin goes stale
+ * on the next `onnxruntime-web` bump and then hands a 1.27 loader 1.26 binaries,
+ * which fails at session-build time.
+ */
+function defaultWasmPaths(): string {
+  const version = ort.env.versions.web ?? ort.env.versions.common;
+  return `https://cdn.jsdelivr.net/npm/onnxruntime-web@${version}/dist/`;
+}
 
 /**
  * 2D context options. `CanvasLike.getContext` is declared with one parameter in
@@ -39,7 +50,7 @@ export function isWebWorker(): boolean {
 export function applyDefaultWasmPaths(): void {
   const inBrowser = typeof window !== "undefined" || isWebWorker();
   if (!inBrowser || ort.env.wasm.wasmPaths) return;
-  ort.env.wasm.wasmPaths = DEFAULT_WASM_PATHS;
+  ort.env.wasm.wasmPaths = defaultWasmPaths();
 }
 
 applyDefaultWasmPaths();

--- a/src/web/platform.web.ts
+++ b/src/web/platform.web.ts
@@ -2,18 +2,47 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 import * as ort from "onnxruntime-web";
-import { CanvasProcessor, CanvasToolkit } from "ppu-ocv/canvas-web";
+import { CanvasProcessor, CanvasToolkit, getPlatform } from "ppu-ocv/canvas-web";
 import type {
   CanvasProcessor as CanvasProcessorType,
   CanvasToolkit as CanvasToolkitType,
 } from "ppu-ocv/canvas";
 import type { CanvasOps, CoreCanvas, PlatformProvider } from "../core/platform.js";
 
-// Provide an intelligent default for ONNX WASM paths to avoid 404s on CDN or unbundled usage.
-// Users can override this by explicitly setting ort.env.wasm.wasmPaths before initialization.
-if (typeof window !== "undefined" && !ort.env.wasm.wasmPaths) {
-  ort.env.wasm.wasmPaths = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
+/** CDN copy of the ONNX Runtime WASM binaries, used when the host app picks no location. */
+const DEFAULT_WASM_PATHS = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
+
+/**
+ * 2D context options. `CanvasLike.getContext` is declared with one parameter in
+ * `ppu-ocv`, so the attribute bag needs its own signature.
+ */
+type GetContext2D = (contextId: "2d", options?: { willReadFrequently?: boolean }) => unknown;
+
+/**
+ * True inside a Web Worker: dedicated, shared, or a Manifest V3 service worker.
+ *
+ * `WorkerGlobalScope` exists only in worker scopes, never on a page and never in
+ * Node/Bun/Deno. `window` is the mirror image of it: absent in workers, which is
+ * why probing for `window` alone reads a worker as a server runtime.
+ */
+export function isWebWorker(): boolean {
+  return typeof (globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope === "function";
 }
+
+/**
+ * Point ONNX Runtime at a CDN copy of its WASM binaries to avoid 404s on CDN or
+ * unbundled usage. Applies to pages and workers alike; an explicit
+ * `ort.env.wasm.wasmPaths` set by the host app always wins.
+ *
+ * Runs once on import. Exported so the environment probe stays testable.
+ */
+export function applyDefaultWasmPaths(): void {
+  const inBrowser = typeof window !== "undefined" || isWebWorker();
+  if (!inBrowser || ort.env.wasm.wasmPaths) return;
+  ort.env.wasm.wasmPaths = DEFAULT_WASM_PATHS;
+}
+
+applyDefaultWasmPaths();
 
 /** True when `navigator.gpu` is present and at least one adapter is available. */
 export async function isWebGpuAvailable(): Promise<boolean> {
@@ -42,22 +71,27 @@ export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
   public readonly pathSeparator = "/";
   public readonly ort = ort as unknown as PlatformProvider["ort"];
 
-  public createCanvas(_width: number, _height: number): CoreCanvas {
-    // CanvasToolkit in the web handles creating actual HTMLCanvasElement or OffscreenCanvas internally
-    // We just return a dummy canvas structure expected by ppu-ocv/web
-    const canvas = document.createElement("canvas");
-    canvas.width = _width;
-    canvas.height = _height;
-    canvas.getContext("2d", { willReadFrequently: true });
+  public createCanvas(width: number, height: number): CoreCanvas {
+    // Delegate to ppu-ocv's browser platform: it returns an OffscreenCanvas
+    // wherever the runtime has one and only falls back to document.createElement
+    // otherwise, so this works on a page and inside a Web Worker, which has no
+    // document at all.
+    const canvas = getPlatform().createCanvas(width, height);
+
+    // Warm the 2D context. getContext fixes its attributes on the first call and
+    // ignores them on every call after, and this pipeline is getImageData-heavy.
+    const getContext: GetContext2D = canvas.getContext.bind(canvas);
+    getContext("2d", { willReadFrequently: true });
+
     return canvas as unknown as CoreCanvas;
   }
 
   public isCanvas(image: unknown): image is CoreCanvas {
-    return !!(
-      image instanceof HTMLCanvasElement ||
-      (typeof OffscreenCanvas !== "undefined" && image instanceof OffscreenCanvas) ||
-      (image && typeof (image as Record<string, unknown>).getContext === "function")
-    );
+    // Duck-typed on purpose. HTMLCanvasElement is not exposed inside a Web
+    // Worker, so an instanceof probe throws a ReferenceError there instead of
+    // returning false. Every canvas this build accepts - HTMLCanvasElement,
+    // OffscreenCanvas, or a host-supplied equivalent - exposes getContext.
+    return !!image && typeof (image as Record<string, unknown>).getContext === "function";
   }
 
   public async loadResource(

--- a/tests/web-canvas-polyfill.ts
+++ b/tests/web-canvas-polyfill.ts
@@ -23,10 +23,19 @@ const KEYS = [
   "document",
 ] as const;
 
-export function installWebCanvas(): void {
+/** Options for {@link installWebCanvas}. */
+export type WebCanvasOptions = {
+  /**
+   * Install only the globals a Web Worker exposes: `OffscreenCanvas`,
+   * `ImageData`, and `createImageBitmap`, leaving `document` and
+   * `HTMLCanvasElement` undefined the way a real worker scope does.
+   */
+  worker?: boolean;
+};
+
+export function installWebCanvas(options: WebCanvasOptions = {}): void {
   const g = globalThis as unknown as Record<string, unknown>;
   g.OffscreenCanvas = Canvas;
-  g.HTMLCanvasElement = Canvas;
   g.ImageData = NapiImageData;
   g.createImageBitmap = async (blob: Blob) => {
     const buf = Buffer.from(await blob.arrayBuffer());
@@ -34,6 +43,10 @@ export function installWebCanvas(): void {
     img.close = () => {};
     return img;
   };
+
+  if (options.worker) return;
+
+  g.HTMLCanvasElement = Canvas;
   g.document = {
     createElement: (tag: string) => {
       if (tag === "canvas") return createCanvas(1, 1);

--- a/tests/web-support.test.ts
+++ b/tests/web-support.test.ts
@@ -136,10 +136,11 @@ describe("Web services do not import Node-specific modules", () => {
     expect(ocr).toContain("onnxruntime-web");
   });
 
-  test("web platform provider uses ppu-ocv/web", async () => {
+  test("web platform provider uses the browser canvas backend", async () => {
     const platform = await Bun.file("./src/web/platform.web.ts").text();
 
-    expect(platform).toContain("ppu-ocv/web");
+    expect(platform).toContain('from "ppu-ocv/canvas-web"');
+    expect(platform).not.toContain("@napi-rs/canvas");
   });
 });
 

--- a/tests/web-worker.test.ts
+++ b/tests/web-worker.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+/**
+ * Issue #84: the web build must run inside a Web Worker, where the only canvas
+ * is `OffscreenCanvas` - a worker scope exposes neither `document` nor
+ * `HTMLCanvasElement`, and touching either one throws a ReferenceError.
+ *
+ * This suite installs the `web-ocr.test.ts` polyfills minus those two DOM-only
+ * globals, so any web-path code that reaches for the DOM fails here.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import * as ort from "onnxruntime-web";
+import { getPlatform, setPlatform } from "ppu-ocv";
+
+import type { CanvasLike } from "ppu-ocv/web";
+import type { CoreCanvas, PlatformProvider } from "../src/core/platform.js";
+import type { Box } from "../src/interface.js";
+import type { PaddleOcrService } from "../src/web/paddle-ocr.service.web.js";
+import type { WebPlatformProvider } from "../src/web/platform.web.js";
+import { DEFAULT_MODEL } from "../src/model-catalogue.js";
+import { PaddleOcrService as NodePaddleOcrService } from "../src/processor/paddle-ocr.service.js";
+import { installWebCanvas, uninstallWebCanvas } from "./web-canvas-polyfill.js";
+
+// The web entry is imported dynamically inside beforeAll - never at module load -
+// so it cannot flip ppu-ocv's process-global platform before the previous one is
+// captured. The web platform is then registered explicitly rather than relying on
+// the import side effect, which only fires on the first import in the process.
+let WebPaddleOcrService: typeof PaddleOcrService;
+let WebPlatform: typeof WebPlatformProvider;
+let isWebWorker: () => boolean;
+let applyDefaultWasmPaths: () => void;
+let savedPlatform: ReturnType<typeof getPlatform>;
+
+// Default-model buffers read from the Node disk cache. Injecting them directly
+// keeps initialize() free of network calls.
+let detModel: ArrayBuffer;
+let recModel: ArrayBuffer;
+let dictionary: ArrayBuffer;
+
+const CACHE = join(homedir(), ".cache", "ppu-paddle-ocr");
+const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/tilted.png`).arrayBuffer();
+
+beforeAll(async () => {
+  await NodePaddleOcrService.downloadModels();
+  const cached = (url: string) =>
+    Bun.file(join(CACHE, url.slice(url.lastIndexOf("/") + 1))).arrayBuffer();
+  [detModel, recModel, dictionary] = await Promise.all([
+    cached(DEFAULT_MODEL.detection),
+    cached(DEFAULT_MODEL.recognition),
+    cached(DEFAULT_MODEL.charactersDictionary),
+  ]);
+
+  savedPlatform = getPlatform();
+  installWebCanvas({ worker: true });
+
+  const { webPlatform } = await import("ppu-ocv/canvas-web");
+  setPlatform(webPlatform);
+
+  ({ PaddleOcrService: WebPaddleOcrService } =
+    await import("../src/web/paddle-ocr.service.web.js"));
+  ({
+    WebPlatformProvider: WebPlatform,
+    isWebWorker,
+    applyDefaultWasmPaths,
+  } = await import("../src/web/platform.web.js"));
+}, 120_000);
+
+afterAll(() => {
+  if (!savedPlatform) return;
+  uninstallWebCanvas();
+  setPlatform(savedPlatform);
+});
+
+describe("worker scope", () => {
+  test("has OffscreenCanvas but no document, HTMLCanvasElement, or window", () => {
+    expect(typeof OffscreenCanvas).toBe("function");
+    expect(typeof document).toBe("undefined");
+    expect(typeof HTMLCanvasElement).toBe("undefined");
+    expect(typeof window).toBe("undefined");
+  });
+});
+
+describe("WebPlatformProvider.createCanvas", () => {
+  test("creates a canvas without document.createElement", () => {
+    const canvas = new WebPlatform().createCanvas(64, 32);
+
+    expect(canvas.width).toBe(64);
+    expect(canvas.height).toBe(32);
+  });
+
+  test("returns a canvas whose 2D context reads back what it draws", () => {
+    const canvas = new WebPlatform().createCanvas(8, 4);
+    const ctx = canvas.getContext("2d");
+
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, 8, 4);
+    const pixel = ctx.getImageData(0, 0, 1, 1).data;
+
+    expect([pixel[0], pixel[1], pixel[2], pixel[3]]).toEqual([255, 255, 255, 255]);
+  });
+
+  test("keeps a single context instance across calls, so the warmed attributes stick", () => {
+    const canvas = new WebPlatform().createCanvas(4, 4);
+
+    expect(canvas.getContext("2d")).toBe(canvas.getContext("2d"));
+  });
+});
+
+describe("WebPlatformProvider.isCanvas", () => {
+  test("accepts a canvas without evaluating HTMLCanvasElement", () => {
+    const platform = new WebPlatform();
+
+    expect(platform.isCanvas(platform.createCanvas(4, 4))).toBe(true);
+  });
+
+  test("accepts any host object exposing getContext", () => {
+    expect(new WebPlatform().isCanvas({ width: 1, height: 1, getContext: () => null })).toBe(true);
+  });
+
+  test.each([
+    ["an ArrayBuffer", new ArrayBuffer(8)],
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "canvas"],
+    ["a plain object", {}],
+  ])("rejects %s", (_label, value) => {
+    expect(new WebPlatform().isCanvas(value)).toBe(false);
+  });
+});
+
+describe("environment probes", () => {
+  const scope = globalThis as { WorkerGlobalScope?: unknown };
+  let savedWasmPaths: typeof ort.env.wasm.wasmPaths;
+
+  const enterWorkerScope = () => {
+    scope.WorkerGlobalScope = class {};
+  };
+
+  afterEach(() => {
+    delete scope.WorkerGlobalScope;
+    ort.env.wasm.wasmPaths = savedWasmPaths;
+  });
+
+  beforeAll(() => {
+    savedWasmPaths = ort.env.wasm.wasmPaths;
+  });
+
+  test("isWebWorker is false in Node/Bun, where WorkerGlobalScope does not exist", () => {
+    expect(isWebWorker()).toBe(false);
+  });
+
+  test("isWebWorker is true once WorkerGlobalScope exists", () => {
+    enterWorkerScope();
+
+    expect(isWebWorker()).toBe(true);
+  });
+
+  test("applyDefaultWasmPaths points a worker at the CDN copy", () => {
+    enterWorkerScope();
+    ort.env.wasm.wasmPaths = undefined;
+
+    applyDefaultWasmPaths();
+
+    expect(String(ort.env.wasm.wasmPaths)).toContain("onnxruntime-web");
+  });
+
+  test("applyDefaultWasmPaths never overrides a path the host app chose", () => {
+    enterWorkerScope();
+    ort.env.wasm.wasmPaths = "/vendor/ort/";
+
+    applyDefaultWasmPaths();
+
+    expect(ort.env.wasm.wasmPaths).toBe("/vendor/ort/");
+  });
+
+  test("applyDefaultWasmPaths leaves Node/Bun alone, where the files are on disk", () => {
+    ort.env.wasm.wasmPaths = undefined;
+
+    applyDefaultWasmPaths();
+
+    expect(ort.env.wasm.wasmPaths).toBeUndefined();
+  });
+});
+
+describe("crop encoding", () => {
+  test("encodes through convertToBlob, the only encoder an OffscreenCanvas has", async () => {
+    const { cropDetectedBoxes } = await import("../src/core/detection/crop-boxes.js");
+    const png = new Uint8Array([137, 80, 78, 71]);
+    const offscreen = {
+      width: 4,
+      height: 4,
+      convertToBlob: async () => new Blob([png], { type: "image/png" }),
+    };
+    const platform = {
+      pathSeparator: "/",
+      canvas: { getToolkit: () => ({ crop: () => offscreen }) },
+    } as unknown as PlatformProvider;
+    const boxes: Box[] = [{ x: 0, y: 0, width: 4, height: 4 }];
+
+    const crops = await cropDetectedBoxes(platform, offscreen as unknown as CoreCanvas, boxes, {
+      crop: true,
+    });
+
+    expect(crops).toHaveLength(1);
+    expect(new Uint8Array(crops[0])).toEqual(png);
+  });
+});
+
+describe("full OCR pipeline in a worker scope", () => {
+  let service: PaddleOcrService;
+
+  beforeAll(async () => {
+    service = new WebPaddleOcrService({
+      model: { detection: detModel, recognition: recModel, charactersDictionary: dictionary },
+      processing: { engine: "canvas-native" },
+    });
+    await service.initialize();
+  }, 120_000);
+
+  afterAll(async () => {
+    await service?.destroy();
+  });
+
+  test("recognizes an ArrayBuffer", async () => {
+    const result = await service.recognize(imageBuffer, { noCache: true });
+
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.lines.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  test("recognizes an OffscreenCanvas passed straight in", async () => {
+    const canvas = await new WebPlatform().canvas.prepareCanvas(imageBuffer);
+
+    const result = await service.recognize(canvas as unknown as CanvasLike, { noCache: true });
+
+    expect(result.text.length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/tests/web-worker.test.ts
+++ b/tests/web-worker.test.ts
@@ -167,6 +167,19 @@ describe("environment probes", () => {
     expect(String(ort.env.wasm.wasmPaths)).toContain("onnxruntime-web");
   });
 
+  test("applyDefaultWasmPaths matches the CDN copy to the loaded runtime version", () => {
+    enterWorkerScope();
+    ort.env.wasm.wasmPaths = undefined;
+
+    applyDefaultWasmPaths();
+
+    // A pinned version would drift from the installed one and serve binaries
+    // the JS glue cannot load.
+    expect(String(ort.env.wasm.wasmPaths)).toBe(
+      `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ort.env.versions.web}/dist/`
+    );
+  });
+
   test("applyDefaultWasmPaths never overrides a path the host app chose", () => {
     enterWorkerScope();
     ort.env.wasm.wasmPaths = "/vendor/ort/";


### PR DESCRIPTION
## What

Makes `ppu-paddle-ocr/web` run inside a Web Worker, a shared worker, or a Manifest V3 extension service worker with no shims. Also fixes the default ONNX Runtime WASM CDN url, which pointed at a version the package no longer installs.

Fixes #84, reported by @Unbreathable.

## Why

A worker scope exposes neither `document` nor `HTMLCanvasElement`. Two lines in the web platform provider reached for both:

- `createCanvas()` called `document.createElement("canvas")`, so a worker threw `ReferenceError: document is not defined`
- `isCanvas()` evaluated `image instanceof HTMLCanvasElement`, so a worker threw `ReferenceError: HTMLCanvasElement is not defined` before the duck-typed fallback on the very next line could answer

@Unbreathable was patching `self.document` and `self.HTMLCanvasElement` by hand to get around it, with a working demo at livetitle.liphium.com. Running inference off the main thread is the normal way to keep a page interactive, and the library already had everything it needed: `ppu-ocv`'s browser platform prefers `OffscreenCanvas`, and every canvas allocated inside `CanvasProcessor` and `CanvasToolkit` already came from there. Only the platform provider bypassed it and touched the DOM directly.

Two quieter bugs turned up on the way:

- The `ort.env.wasm.wasmPaths` default was gated on `typeof window !== "undefined"`, which is false in a worker, so CDN and unbundled worker setups 404ed on the WASM binaries.
- That default pinned `onnxruntime-web@1.26.0` while the package resolves `1.27.0`. Anyone who did not set `wasmPaths` themselves handed a 1.27 loader 1.26 binaries, on a page as much as in a worker.

## How

`src/web/platform.web.ts` is the whole fix.

- `createCanvas()` delegates to `getPlatform().createCanvas()`, the same `ppu-ocv` browser platform the rest of the pipeline already uses. It returns an `OffscreenCanvas` wherever the runtime has one and falls back to `document.createElement` otherwise. The `willReadFrequently` warm-up stays, since `getContext` fixes its attributes on the first call and this pipeline is `getImageData`-heavy.
- `isCanvas()` is duck-typed on `getContext`. That is not a widening: `HTMLCanvasElement` and `OffscreenCanvas` both expose `getContext`, so the two `instanceof` probes accepted nothing the fallback did not already accept. They only added a throw.
- `applyDefaultWasmPaths()` applies to any browser scope, page or worker, and builds the url from `ort.env.versions` at call time so the binaries and the loader cannot drift apart again.
- `isWebWorker()` is exported for host code that needs to branch on the scope.

One behaviour change on the main thread: canvases from `platform.createCanvas()` are now `OffscreenCanvas` instead of a detached `HTMLCanvasElement`. The pipeline was already mixing the two, since everything from `CanvasProcessor` was offscreen, so this makes it uniform. PNG encoding already preferred `convertToBlob`, and `saveDebugImage` is a no-op on web, so nothing downstream depends on the DOM flavour.

`tests/web-worker.test.ts` runs the suite under worker-only globals: `OffscreenCanvas`, `ImageData`, and `createImageBitmap`, with `document`, `HTMLCanvasElement`, and `window` deliberately absent. 20 tests covering canvas creation, the canvas type guard, the scope probes, the `convertToBlob` crop path, and two end-to-end `recognize()` calls. I stashed the source fix and confirmed every one of them fails against the old code with the exact errors from the issue.

One existing assertion in `web-support.test.ts` was matching a code comment that this PR deletes, so it now checks the real invariant instead: the web provider imports `ppu-ocv/canvas-web` and never `@napi-rs/canvas`.

Not benchmarked: the hot path gains one function call and loses two `instanceof` checks.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

Worker behaviour is covered by the test suite under simulated worker globals, not yet by a run in a real browser worker. @Unbreathable, if you have a moment to point livetitle at this branch with the shim removed, that would close the loop.

### Related

- Closes #84
- Wiki pages "WebGPU and Browser", "Troubleshooting", and "Home" updated to match
