### PR TITLE
chore: add a one-shot release version bump tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for taking the time to contribute. This document covers how to set up 
 - [How tests run](#how-tests-run)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
 - [Submitting a Pull Request](#submitting-a-pull-request)
+- [Cutting a release](#cutting-a-release)
 - [Reporting Issues](#reporting-issues)
 - [Community](#community)
 
@@ -140,6 +141,41 @@ bun bench/batch.bench.ts   # batch vs concurrent recognize(), peak RSS
 PRs are rebase-merged to keep each logically distinct commit on `main`. Keep your
 commit history clean - squash fixup commits locally before review, and make every
 commit message follow the project's Conventional Commits format.
+
+## Cutting a release
+
+Maintainers only. The version lives in more places than the two manifests, so
+`bun bump` rewrites all of them in one pass and commits the result:
+
+```bash
+git checkout -b release/6.4.0
+bun bump minor            # or major, patch, fix, or an explicit 6.4.0
+```
+
+| Touchpoint                 | What it does                                       |
+| :------------------------- | :------------------------------------------------- |
+| `package.json`, `jsr.json` | the published version, kept in lockstep            |
+| `playground/index.html`    | the CDN fallback pin, which otherwise goes stale   |
+| `CHANGELOG.md`             | promotes `## [Unreleased]` to a dated heading      |
+| `apps/serve` (4 files)     | the REST envelope version, patch-bumped by default |
+
+The CLI reads `package.json` at runtime, so it needs no edit.
+
+Options: `--serve <spec>` gives the serve app its own bump level, `--serve none`
+leaves it alone, and `--no-commit` writes the files without staging them. The
+command refuses to run on `main` and refuses to promote an empty `[Unreleased]`
+section, so write the release notes first.
+
+After the release PR merges:
+
+```bash
+git tag -s v6.4.0 -m "v6.4.0" && git push origin v6.4.0
+gh release create v6.4.0 --title "6.4.0" --notes "<the CHANGELOG section>"
+gh workflow run deploy-serve.yml
+```
+
+Publishing to npm and JSR is triggered by the GitHub release, so the signed tag
+has to be pushed first. Sync the wiki for any user-visible API change.
 
 ## Reporting Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,10 @@ Thank you for taking the time to contribute. This document covers how to set up 
 
 The recommended development environment is Linux-based. macOS works fine too; Windows users may encounter path differences in some scripts.
 
-Bun is the primary runtime and package manager. The CI pipeline pins Bun at **1.2.23** due to a known SIGILL/segfault in the 1.3.x test runner - use the same version locally to avoid false failures:
+Bun is the primary runtime and package manager. Every CI workflow pins Bun at **1.3.14**; earlier versions carried test-runner bugs that produced false failures on Linux. Use the same version locally:
 
 ```bash
-curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.23"
+curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
 ```
 
 Pre-commit hooks are set up via Husky and run automatically after `bun install`. They enforce formatting and linting before every commit.
@@ -152,12 +152,12 @@ git checkout -b release/6.4.0
 bun bump minor            # or major, patch, fix, or an explicit 6.4.0
 ```
 
-| Touchpoint                 | What it does                                       |
-| :------------------------- | :------------------------------------------------- |
-| `package.json`, `jsr.json` | the published version, kept in lockstep            |
-| `playground/index.html`    | the CDN fallback pin, which otherwise goes stale   |
-| `CHANGELOG.md`             | promotes `## [Unreleased]` to a dated heading      |
-| `apps/serve` (4 files)     | the REST envelope version, patch-bumped by default |
+| Touchpoint                 | What it does                                                                                    |
+| :------------------------- | :---------------------------------------------------------------------------------------------- |
+| `package.json`, `jsr.json` | the published version, kept in lockstep                                                         |
+| `playground/index.html`    | the CDN fallback pin, which otherwise goes stale                                                |
+| `CHANGELOG.md`             | promotes `## [Unreleased]` to a dated heading, sorting its sections into Keep a Changelog order |
+| `apps/serve` (4 files)     | the REST envelope version, patch-bumped by default                                              |
 
 The CLI reads `package.json` at runtime, so it needs no edit.
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "scripts": {
     "task": "bun scripts/task.ts",
+    "bump": "bun scripts/bump.ts",
     "build": "bun task build",
     "build:test": "bun task build && bun test",
     "build:publish": "bun task build && bun task report-size && bun task publish",

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,313 @@
+/// <reference types='bun-types' />
+/**
+ * One-shot release version bump.
+ *
+ *   bun bump minor
+ *   bun bump 6.4.0 --serve minor
+ *   bun bump patch --no-commit
+ *
+ * Rewrites every version touchpoint, promotes the CHANGELOG's Unreleased
+ * section into a dated release heading, and commits the result. The CLI reads
+ * package.json at runtime, so it carries no version string of its own.
+ */
+import { $, file, write } from "bun";
+import { join } from "node:path";
+
+/** The semver shape this project uses: three numbers, no prerelease tags. */
+const VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/** A version-bearing spot in a file. Capture group 1 is the version to rewrite. */
+type Touchpoint = { path: string; pattern: RegExp };
+
+const LIBRARY_TOUCHPOINTS: Touchpoint[] = [
+  { path: "package.json", pattern: /"version":\s*"(\d+\.\d+\.\d+)"/ },
+  { path: "jsr.json", pattern: /"version":\s*"(\d+\.\d+\.\d+)"/ },
+  { path: "playground/index.html", pattern: /ppu-paddle-ocr@(\d+\.\d+\.\d+)/g },
+];
+
+/** The serve app versions its REST envelope separately from the library. */
+const SERVE_TOUCHPOINTS: Touchpoint[] = [
+  { path: "apps/serve/package.json", pattern: /"version":\s*"(\d+\.\d+\.\d+)"/ },
+  { path: "apps/serve/src/app.ts", pattern: /version:\s*"(\d+\.\d+\.\d+)"/ },
+  { path: "apps/serve/src/core/api-response.ts", pattern: /API_VERSION = "(\d+\.\d+\.\d+)"/ },
+  { path: "apps/serve/README.md", pattern: /"version":\s*"(\d+\.\d+\.\d+)"/g },
+];
+
+const CHANGELOG = "CHANGELOG.md";
+const UNRELEASED = "## [Unreleased]";
+
+/** One rewritten file. */
+export type VersionChange = {
+  /** Path relative to the repo root. */
+  path: string;
+  /** Version the file carried before the bump. */
+  from: string;
+  /** Version the file carries now. */
+  to: string;
+};
+
+/** What a bump did, for reporting and for building the commit message. */
+export type BumpResult = {
+  /** New library version. */
+  version: string;
+  /** Library version before the bump. */
+  previous: string;
+  /** New serve version, or null when the serve bump was skipped. */
+  serveVersion: string | null;
+  /** Release date stamped into the CHANGELOG heading. */
+  date: string;
+  /** Every file rewritten, in the order they were written. */
+  changes: VersionChange[];
+  /** Non-fatal oddities, such as a touchpoint that had drifted out of sync. */
+  warnings: string[];
+};
+
+/** Inputs for {@link bumpVersions}. */
+export type BumpOptions = {
+  /** Repo root to rewrite. */
+  root: string;
+  /** `major`, `minor`, `patch` (or `fix`), or an explicit `x.y.z`. */
+  spec: string;
+  /** Same grammar as `spec`, plus `none` to leave the serve app alone. Defaults to `patch`. */
+  serve?: string;
+  /** Release date for the CHANGELOG heading. Defaults to today, in local time. */
+  today?: Date;
+};
+
+/** `true` when `candidate` sorts strictly after `current`. */
+function isNewer(candidate: string, current: string): boolean {
+  const next = candidate.split(".").map(Number);
+  const now = current.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (next[i] !== now[i]) return next[i] > now[i];
+  }
+  return false;
+}
+
+/** Resolve a bump spec against the current version. */
+export function nextVersion(current: string, spec: string): string {
+  const parsed = current.match(VERSION);
+  if (!parsed) throw new Error(`Cannot parse the current version "${current}"`);
+
+  const major = Number(parsed[1]);
+  const minor = Number(parsed[2]);
+  const patch = Number(parsed[3]);
+
+  if (spec === "major") return `${major + 1}.0.0`;
+  if (spec === "minor") return `${major}.${minor + 1}.0`;
+  if (spec === "patch" || spec === "fix") return `${major}.${minor}.${patch + 1}`;
+
+  if (!VERSION.test(spec)) {
+    throw new Error(`Expected major, minor, patch, or an x.y.z version, got "${spec}"`);
+  }
+  if (!isNewer(spec, current)) {
+    throw new Error(`Version ${spec} is not newer than the current ${current}`);
+  }
+  return spec;
+}
+
+/** Local calendar date as `YYYY-MM-DD`. `toISOString` would report UTC and can slip a day. */
+export function releaseDate(when: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${when.getFullYear()}-${pad(when.getMonth() + 1)}-${pad(when.getDate())}`;
+}
+
+/** Insert a dated release heading under `## [Unreleased]`, leaving that heading in place. */
+export function promoteChangelog(text: string, version: string, date: string): string {
+  const heading = `## [${version}]`;
+  if (text.includes(heading)) {
+    throw new Error(`${CHANGELOG} already has a ${heading} section`);
+  }
+
+  const start = text.indexOf(UNRELEASED);
+  if (start === -1) {
+    throw new Error(`${CHANGELOG} has no ${UNRELEASED} section to promote`);
+  }
+
+  const rest = text.slice(start + UNRELEASED.length);
+  const nextHeading = rest.search(/^## \[/m);
+  const notes = (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim();
+  if (notes.length === 0) {
+    throw new Error(`${CHANGELOG} ${UNRELEASED} section is empty - write the release notes first`);
+  }
+
+  return `${text.slice(0, start + UNRELEASED.length)}\n\n${heading} - ${date}${rest}`;
+}
+
+/** Rewrite every version this pattern matches, reporting the first one it found. */
+function swapVersion(text: string, pattern: RegExp, to: string): { text: string; from: string } {
+  let from = "";
+  const rewritten = text.replace(pattern, (match: string, current: string) => {
+    from ||= current;
+    return match.replace(current, to);
+  });
+  if (from === "") throw new Error(`No version matching ${pattern} found`);
+  return { text: rewritten, from };
+}
+
+/** Read a touchpoint, failing loudly rather than silently skipping a missing file. */
+async function readFile(root: string, path: string): Promise<string> {
+  const handle = file(join(root, path));
+  if (!(await handle.exists())) throw new Error(`Missing version touchpoint: ${path}`);
+  return handle.text();
+}
+
+/** Current version of a manifest, used as the base for a relative bump. */
+async function readManifestVersion(root: string, path: string): Promise<string> {
+  const match = (await readFile(root, path)).match(/"version":\s*"(\d+\.\d+\.\d+)"/);
+  if (!match?.[1]) throw new Error(`No version field in ${path}`);
+  return match[1];
+}
+
+/** Plan the rewrite of one touchpoint group, warning when a file had drifted. */
+function planEdits(
+  sources: Map<string, string>,
+  touchpoints: Touchpoint[],
+  to: string,
+  expected: string,
+  warnings: string[]
+): { path: string; text: string; change: VersionChange }[] {
+  return touchpoints.map((touchpoint) => {
+    const source = sources.get(touchpoint.path) ?? "";
+    const { text, from } = swapVersion(source, touchpoint.pattern, to);
+    if (from !== expected) {
+      warnings.push(`${touchpoint.path} was on ${from}, not ${expected} - rewritten to ${to}`);
+    }
+    return { path: touchpoint.path, text, change: { path: touchpoint.path, from, to } };
+  });
+}
+
+/**
+ * Rewrite every version touchpoint under `root`.
+ *
+ * Everything is read and validated before anything is written, so a bad spec or
+ * an empty changelog leaves the tree untouched.
+ */
+export async function bumpVersions(options: BumpOptions): Promise<BumpResult> {
+  const { root, spec, serve = "patch", today = new Date() } = options;
+
+  const previous = await readManifestVersion(root, "package.json");
+  const version = nextVersion(previous, spec);
+  const date = releaseDate(today);
+  const warnings: string[] = [];
+
+  const bumpServe = serve !== "none";
+  const touchpoints = bumpServe
+    ? [...LIBRARY_TOUCHPOINTS, ...SERVE_TOUCHPOINTS]
+    : LIBRARY_TOUCHPOINTS;
+
+  const sources = new Map<string, string>();
+  for (const touchpoint of [...touchpoints, { path: CHANGELOG, pattern: VERSION }]) {
+    sources.set(touchpoint.path, await readFile(root, touchpoint.path));
+  }
+
+  const edits = planEdits(sources, LIBRARY_TOUCHPOINTS, version, previous, warnings);
+
+  edits.push({
+    path: CHANGELOG,
+    text: promoteChangelog(sources.get(CHANGELOG) ?? "", version, date),
+    change: { path: CHANGELOG, from: UNRELEASED, to: `[${version}] - ${date}` },
+  });
+
+  let serveVersion: string | null = null;
+  if (bumpServe) {
+    const servePrevious = await readManifestVersion(root, "apps/serve/package.json");
+    serveVersion = nextVersion(servePrevious, serve);
+    edits.push(...planEdits(sources, SERVE_TOUCHPOINTS, serveVersion, servePrevious, warnings));
+  }
+
+  for (const edit of edits) {
+    await write(join(root, edit.path), edit.text);
+  }
+
+  return {
+    version,
+    previous,
+    serveVersion,
+    date,
+    changes: edits.map((edit) => edit.change),
+    warnings,
+  };
+}
+
+/** Commit message for a completed bump, wrapped for `git log`. */
+export function commitMessage(result: BumpResult): string {
+  const lines = [
+    `chore: bump version to ${result.version}`,
+    "",
+    `Moves the Unreleased changelog into ${result.version} and points the`,
+    "playground CDN fallback at the new version.",
+  ];
+  if (result.serveVersion) {
+    lines.push("", `Serve goes to ${result.serveVersion} so the image publishes against it.`);
+  }
+  return lines.join("\n");
+}
+
+/** Stage exactly what the bump rewrote and commit it. */
+export async function commitBump(root: string, result: BumpResult): Promise<void> {
+  const paths = result.changes.map((change) => change.path);
+  await $`git add ${paths}`.cwd(root).quiet();
+  await $`git commit -F - < ${Buffer.from(commitMessage(result))}`.cwd(root).quiet();
+}
+
+/** Keep release commits off main, which is protected and merges only via PR. */
+export async function assertNotOnMain(root: string): Promise<void> {
+  const branch = (await $`git rev-parse --abbrev-ref HEAD`.cwd(root).text()).trim();
+  if (branch === "main") {
+    throw new Error("Refusing to commit a release on main. Branch first, e.g. release/x.y.z");
+  }
+}
+
+const HELP = `Usage: bun bump <major|minor|patch|fix|x.y.z> [options]
+
+Options:
+  --serve <spec>  Serve app bump: same grammar, or "none" to skip. Default: patch
+  --no-commit     Rewrite the files but leave them unstaged`;
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const spec = args[0];
+  if (!spec || spec === "--help" || spec === "-h") {
+    console.log(HELP);
+    process.exit(spec ? 0 : 1);
+  }
+
+  const serveIndex = args.indexOf("--serve");
+  const serve = serveIndex === -1 ? undefined : args[serveIndex + 1];
+  const commit = !args.includes("--no-commit");
+  const root = join(import.meta.dir, "..");
+
+  if (commit) await assertNotOnMain(root);
+
+  const result = await bumpVersions({ root, spec, serve });
+
+  console.log(`\n${result.previous} -> ${result.version}`);
+  if (result.serveVersion) console.log(`serve -> ${result.serveVersion}`);
+  console.log("");
+  for (const change of result.changes) {
+    console.log(`  ${change.path.padEnd(36)} ${change.from} -> ${change.to}`);
+  }
+  for (const warning of result.warnings) console.log(`\n  warning: ${warning}`);
+
+  if (commit) {
+    await commitBump(root, result);
+    console.log(`\ncommitted: chore: bump version to ${result.version}`);
+  }
+
+  console.log(
+    `\nNext: open the release PR, then after merge\n` +
+      `  git tag -s v${result.version} -m "v${result.version}" && git push origin v${result.version}\n` +
+      `  gh release create v${result.version} --title "${result.version}" --notes "<CHANGELOG section>"\n` +
+      `  gh workflow run deploy-serve.yml`
+  );
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error: unknown) {
+    console.error(`\nbump failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -36,6 +36,9 @@ const SERVE_TOUCHPOINTS: Touchpoint[] = [
 const CHANGELOG = "CHANGELOG.md";
 const UNRELEASED = "## [Unreleased]";
 
+/** Keep a Changelog's section order. Anything else keeps its relative place at the end. */
+const SECTION_ORDER = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"];
+
 /** One rewritten file. */
 export type VersionChange = {
   /** Path relative to the repo root. */
@@ -112,7 +115,34 @@ export function releaseDate(when: Date): string {
   return `${when.getFullYear()}-${pad(when.getMonth() + 1)}-${pad(when.getDate())}`;
 }
 
-/** Insert a dated release heading under `## [Unreleased]`, leaving that heading in place. */
+/** Where a `### Heading` block sorts. A preamble stays on top, unknown headings sink. */
+function sectionRank(block: string): number {
+  if (!block.startsWith("### ")) return -1;
+  const name = (block.split("\n", 1)[0] ?? "").slice(4).trim();
+  const rank = SECTION_ORDER.indexOf(name);
+  return rank === -1 ? SECTION_ORDER.length : rank;
+}
+
+/**
+ * Sort the `###` blocks of one release into {@link SECTION_ORDER}, verbatim.
+ *
+ * The sort is stable, so repeated or unrecognised headings keep the order the
+ * author wrote them in.
+ */
+export function orderSections(notes: string): string {
+  return notes
+    .split(/^(?=### )/m)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .sort((a, b) => sectionRank(a) - sectionRank(b))
+    .join("\n\n");
+}
+
+/**
+ * Insert a dated release heading under `## [Unreleased]`, leaving that heading in
+ * place, and sort the promoted notes into Keep a Changelog's section order.
+ * Earlier releases are never touched.
+ */
 export function promoteChangelog(text: string, version: string, date: string): string {
   const heading = `## [${version}]`;
   if (text.includes(heading)) {
@@ -131,7 +161,9 @@ export function promoteChangelog(text: string, version: string, date: string): s
     throw new Error(`${CHANGELOG} ${UNRELEASED} section is empty - write the release notes first`);
   }
 
-  return `${text.slice(0, start + UNRELEASED.length)}\n\n${heading} - ${date}${rest}`;
+  const earlier = nextHeading === -1 ? "" : rest.slice(nextHeading);
+  const body = earlier ? `${orderSections(notes)}\n\n${earlier}` : `${orderSections(notes)}\n`;
+  return `${text.slice(0, start + UNRELEASED.length)}\n\n${heading} - ${date}\n\n${body}`;
 }
 
 /** Rewrite every version this pattern matches, reporting the first one it found. */

--- a/tests/bump.test.ts
+++ b/tests/bump.test.ts
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+/**
+ * Unit tests for the release bump tool. Every case runs against a throwaway
+ * fixture tree in the OS temp dir, never against the real repo.
+ */
+import { $ } from "bun";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  assertNotOnMain,
+  bumpVersions,
+  commitBump,
+  commitMessage,
+  nextVersion,
+  promoteChangelog,
+  releaseDate,
+} from "../scripts/bump.js";
+
+const CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- something worth releasing
+
+## [6.1.0] - 2026-07-13
+
+### Added
+
+- older news
+`;
+
+const EMPTY_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+## [6.1.0] - 2026-07-13
+
+### Added
+
+- older news
+`;
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+type FixtureOptions = {
+  version?: string;
+  serve?: string;
+  playgroundPin?: string;
+  changelog?: string;
+};
+
+/** Build a minimal tree with the same version touchpoints as the repo. */
+async function fixture(options: FixtureOptions = {}): Promise<string> {
+  const {
+    version = "6.2.0",
+    serve = "0.3.0",
+    playgroundPin = version,
+    changelog = CHANGELOG,
+  } = options;
+
+  const root = await mkdtemp(join(tmpdir(), "ppu-bump-"));
+  roots.push(root);
+
+  const write = (path: string, text: string) => Bun.write(join(root, path), text);
+  await Promise.all([
+    write("package.json", `{\n  "name": "ppu-paddle-ocr",\n  "version": "${version}"\n}\n`),
+    write("jsr.json", `{\n  "name": "@snowfluke/ppu-paddle-ocr",\n  "version": "${version}"\n}\n`),
+    write(
+      "playground/index.html",
+      `import "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/ort.mjs";\n` +
+        `await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@${playgroundPin}/web/index.js");\n`
+    ),
+    write("CHANGELOG.md", changelog),
+    write(
+      "apps/serve/package.json",
+      `{\n  "name": "ppu-paddle-ocr-serve",\n  "version": "${serve}"\n}\n`
+    ),
+    write(
+      "apps/serve/README.md",
+      `{ "status": "success", "version": "${serve}" }\n` +
+        `{ "status": "error", "version": "${serve}" }\n`
+    ),
+    write("apps/serve/src/app.ts", `const doc = { info: { version: "${serve}" } };\n`),
+    write("apps/serve/src/core/api-response.ts", `export const API_VERSION = "${serve}";\n`),
+  ]);
+
+  return root;
+}
+
+const read = (root: string, path: string) => Bun.file(join(root, path)).text();
+
+describe("nextVersion", () => {
+  test.each([
+    ["major", "7.0.0"],
+    ["minor", "6.3.0"],
+    ["patch", "6.2.1"],
+    ["fix", "6.2.1"],
+    ["6.4.0", "6.4.0"],
+  ])("%s resolves to %s", (spec, expected) => {
+    expect(nextVersion("6.2.0", spec)).toBe(expected);
+  });
+
+  test("compares components, so 6.10.0 is newer than 6.9.0", () => {
+    expect(nextVersion("6.9.0", "6.10.0")).toBe("6.10.0");
+  });
+
+  test.each([["6.2.0"], ["6.1.9"], ["5.9.9"]])("rejects %s as not newer than 6.2.0", (spec) => {
+    expect(() => nextVersion("6.2.0", spec)).toThrow("not newer");
+  });
+
+  test("rejects a spec that is neither a level nor a version", () => {
+    expect(() => nextVersion("6.2.0", "6.3")).toThrow("Expected major, minor, patch");
+  });
+
+  test("rejects an unparsable current version", () => {
+    expect(() => nextVersion("6.2.0-rc.1", "minor")).toThrow("Cannot parse");
+  });
+});
+
+describe("releaseDate", () => {
+  test("stamps the local calendar date", () => {
+    expect(releaseDate(new Date(2026, 7, 3, 14, 30))).toBe("2026-08-03");
+  });
+
+  test("does not slip a day in positive UTC offsets", () => {
+    // 00:30 local on new year's day is still the previous year in UTC.
+    expect(releaseDate(new Date(2026, 0, 1, 0, 30))).toBe("2026-01-01");
+  });
+});
+
+describe("promoteChangelog", () => {
+  test("inserts a dated heading and keeps Unreleased on top", () => {
+    const promoted = promoteChangelog(CHANGELOG, "6.3.0", "2026-08-03");
+
+    expect(promoted).toContain("## [Unreleased]\n\n## [6.3.0] - 2026-08-03\n\n### Fixed");
+    expect(promoted).toContain("## [6.1.0] - 2026-07-13");
+  });
+
+  test("refuses an empty Unreleased section", () => {
+    expect(() => promoteChangelog(EMPTY_CHANGELOG, "6.3.0", "2026-08-03")).toThrow("is empty");
+  });
+
+  test("refuses a version that already has a section", () => {
+    expect(() => promoteChangelog(CHANGELOG, "6.1.0", "2026-08-03")).toThrow("already has");
+  });
+
+  test("refuses a changelog with no Unreleased section", () => {
+    expect(() => promoteChangelog("# Changelog\n", "6.3.0", "2026-08-03")).toThrow("no ## [Unrele");
+  });
+});
+
+describe("bumpVersions", () => {
+  test("rewrites every library touchpoint", async () => {
+    const root = await fixture();
+
+    const result = await bumpVersions({ root, spec: "minor", today: new Date(2026, 7, 3) });
+
+    expect(result.previous).toBe("6.2.0");
+    expect(result.version).toBe("6.3.0");
+    expect(await read(root, "package.json")).toContain(`"version": "6.3.0"`);
+    expect(await read(root, "jsr.json")).toContain(`"version": "6.3.0"`);
+    expect(await read(root, "playground/index.html")).toContain("ppu-paddle-ocr@6.3.0");
+    expect(await read(root, "CHANGELOG.md")).toContain("## [6.3.0] - 2026-08-03");
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("leaves other pinned packages in the playground alone", async () => {
+    const root = await fixture();
+
+    await bumpVersions({ root, spec: "minor" });
+
+    expect(await read(root, "playground/index.html")).toContain("onnxruntime-web@1.26.0");
+  });
+
+  test("patch-bumps the serve app in all four places by default", async () => {
+    const root = await fixture();
+
+    const result = await bumpVersions({ root, spec: "minor" });
+
+    expect(result.serveVersion).toBe("0.3.1");
+    expect(await read(root, "apps/serve/package.json")).toContain(`"version": "0.3.1"`);
+    expect(await read(root, "apps/serve/src/app.ts")).toContain(`version: "0.3.1"`);
+    expect(await read(root, "apps/serve/src/core/api-response.ts")).toContain(
+      `API_VERSION = "0.3.1"`
+    );
+    expect((await read(root, "apps/serve/README.md")).match(/0\.3\.1/g)).toHaveLength(2);
+  });
+
+  test("accepts its own spec for the serve app", async () => {
+    const root = await fixture();
+
+    const result = await bumpVersions({ root, spec: "patch", serve: "minor" });
+
+    expect(result.serveVersion).toBe("0.4.0");
+  });
+
+  test("skips the serve app entirely on none", async () => {
+    const root = await fixture();
+
+    const result = await bumpVersions({ root, spec: "minor", serve: "none" });
+
+    expect(result.serveVersion).toBeNull();
+    expect(await read(root, "apps/serve/package.json")).toContain(`"version": "0.3.0"`);
+    expect(result.changes.map((change) => change.path)).not.toContain("apps/serve/package.json");
+  });
+
+  test("warns about a drifted touchpoint and pulls it back in line", async () => {
+    const root = await fixture({ playgroundPin: "6.0.0" });
+
+    const result = await bumpVersions({ root, spec: "minor" });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("playground/index.html was on 6.0.0");
+    expect(await read(root, "playground/index.html")).toContain("ppu-paddle-ocr@6.3.0");
+  });
+
+  test("writes nothing when the changelog has no release notes", async () => {
+    const root = await fixture({ changelog: EMPTY_CHANGELOG });
+
+    expect(bumpVersions({ root, spec: "minor" })).rejects.toThrow("is empty");
+    expect(await read(root, "package.json")).toContain(`"version": "6.2.0"`);
+  });
+
+  test("names the file that is missing", async () => {
+    const root = await fixture();
+    await rm(join(root, "jsr.json"));
+
+    expect(bumpVersions({ root, spec: "minor" })).rejects.toThrow("Missing version touchpoint");
+  });
+});
+
+describe("commitMessage", () => {
+  test("mentions the serve bump only when there was one", async () => {
+    const root = await fixture();
+
+    const withServe = commitMessage(await bumpVersions({ root, spec: "minor" }));
+    const withoutServe = commitMessage(
+      await bumpVersions({ root: await fixture(), spec: "minor", serve: "none" })
+    );
+
+    expect(withServe.split("\n")[0]).toBe("chore: bump version to 6.3.0");
+    expect(withServe).toContain("Serve goes to 0.3.1");
+    expect(withoutServe).not.toContain("Serve goes to");
+  });
+
+  test("keeps every line inside the 80 column cap", async () => {
+    const message = commitMessage(await bumpVersions({ root: await fixture(), spec: "minor" }));
+
+    for (const line of message.split("\n")) expect(line.length).toBeLessThanOrEqual(80);
+  });
+});
+
+/** Fixture tree that is also a git repo, with a base commit in place. */
+async function gitFixture(options: FixtureOptions = {}): Promise<string> {
+  const root = await fixture(options);
+  await $`git init -q -b main`.cwd(root).quiet();
+  await $`git config user.email test@example.com`.cwd(root).quiet();
+  await $`git config user.name Test`.cwd(root).quiet();
+  await $`git config commit.gpgsign false`.cwd(root).quiet();
+  await $`git add -A`.cwd(root).quiet();
+  await $`git commit -q -m base`.cwd(root).quiet();
+  return root;
+}
+
+describe("assertNotOnMain", () => {
+  test("refuses to run on main", async () => {
+    const root = await gitFixture();
+
+    expect(assertNotOnMain(root)).rejects.toThrow("Refusing to commit a release on main");
+  });
+
+  test("allows a release branch", async () => {
+    const root = await gitFixture();
+    await $`git checkout -q -b release/6.3.0`.cwd(root).quiet();
+
+    expect(assertNotOnMain(root)).resolves.toBeUndefined();
+  });
+});
+
+describe("commitBump", () => {
+  test("stages exactly the rewritten files and leaves the tree clean", async () => {
+    const root = await gitFixture();
+
+    const result = await bumpVersions({ root, spec: "minor" });
+    await commitBump(root, result);
+
+    const subject = (await $`git log -1 --format=%s`.cwd(root).text()).trim();
+    const committed = (await $`git show --name-only --format= HEAD`.cwd(root).text())
+      .trim()
+      .split("\n")
+      .sort();
+
+    expect(subject).toBe("chore: bump version to 6.3.0");
+    expect(committed).toEqual(result.changes.map((change) => change.path).sort());
+    expect((await $`git status --porcelain`.cwd(root).text()).trim()).toBe("");
+  });
+});

--- a/tests/bump.test.ts
+++ b/tests/bump.test.ts
@@ -147,6 +147,74 @@ describe("promoteChangelog", () => {
     expect(promoted).toContain("## [6.1.0] - 2026-07-13");
   });
 
+  test("sorts the promoted notes into Keep a Changelog order", () => {
+    const source = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- a fix
+
+### Added
+
+- an addition
+
+## [6.1.0] - 2026-07-13
+
+### Fixed
+
+- older news
+`;
+
+    const promoted = promoteChangelog(source, "6.3.0", "2026-08-03");
+
+    expect(promoted).toContain(
+      "## [6.3.0] - 2026-08-03\n\n### Added\n\n- an addition\n\n### Fixed\n\n- a fix\n\n## [6.1.0]"
+    );
+  });
+
+  test("leaves earlier releases in the order they were written", () => {
+    const source = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- new
+
+## [6.1.0] - 2026-07-13
+
+### Fixed
+
+- old fix
+
+### Added
+
+- old addition
+`;
+
+    const promoted = promoteChangelog(source, "6.3.0", "2026-08-03");
+
+    expect(promoted).toContain("## [6.1.0] - 2026-07-13\n\n### Fixed\n\n- old fix\n\n### Added");
+  });
+
+  test("keeps a section it does not recognise, after the ones it does", () => {
+    const source = "# Changelog\n\n## [Unreleased]\n\n### Notes\n\n- note\n\n### Added\n\n- new\n";
+
+    const promoted = promoteChangelog(source, "6.3.0", "2026-08-03");
+
+    expect(promoted).toContain("### Added\n\n- new\n\n### Notes\n\n- note");
+  });
+
+  test("keeps a preamble above the sections", () => {
+    const source = "# Changelog\n\n## [Unreleased]\n\nHeads up.\n\n### Added\n\n- new\n";
+
+    const promoted = promoteChangelog(source, "6.3.0", "2026-08-03");
+
+    expect(promoted).toContain("## [6.3.0] - 2026-08-03\n\nHeads up.\n\n### Added");
+  });
+
   test("refuses an empty Unreleased section", () => {
     expect(() => promoteChangelog(EMPTY_CHANGELOG, "6.3.0", "2026-08-03")).toThrow("is empty");
   });


### PR DESCRIPTION
## What

Adds `bun bump`, a maintainer command that rewrites every version touchpoint,
promotes the CHANGELOG, and commits the result in one pass. Also corrects the
stale Bun pin in `CONTRIBUTING.md` and documents the release procedure there.

```
$ bun bump minor

6.2.0 -> 6.3.0
serve -> 0.3.1

  package.json                         6.2.0 -> 6.3.0
  jsr.json                             6.2.0 -> 6.3.0
  playground/index.html                6.2.0 -> 6.3.0
  CHANGELOG.md                         ## [Unreleased] -> [6.3.0] - 2026-08-03
  apps/serve/package.json              0.3.0 -> 0.3.1
  apps/serve/src/app.ts                0.3.0 -> 0.3.1
  apps/serve/src/core/api-response.ts  0.3.0 -> 0.3.1
  apps/serve/README.md                 0.3.0 -> 0.3.1

committed: chore: bump version to 6.3.0
```

## Why

The release version lives in eight places across four directories, and the list
only existed in a maintainer's head. It has already cost us: the playground CDN
pin went stale from 6.0.0 through 6.1.0 because bumping it is easy to forget,
and the pre-commit hook exists at all because `package.json` and `jsr.json`
drifted apart.

The CHANGELOG had a second, quieter drift. The file header claims the Keep a
Changelog format, but the sections landed in whatever order the release was
written in: 6.2.0 reads Changed/Added/Fixed, 6.1.2 reads Fixed/Added. Promoting
a release is the natural moment to normalise that.

## How

`scripts/bump.ts`, wired as the `bump` script so `bun bump <spec>` works.

The spec is `major`, `minor`, `patch` (or `fix`), or an explicit `x.y.z`.
Everything is read and validated before anything is written, so a bad spec or an
empty `[Unreleased]` leaves the tree untouched.

Guards, because a release is a bad time to discover a problem:

- Refuses to commit on `main`.
- Refuses to promote an empty `[Unreleased]` section.
- Rejects an explicit version that is not newer, comparing components so 6.10.0
  beats 6.9.0.
- Warns when a touchpoint had drifted out of sync rather than silently rewriting
  it, and still pulls it back in line.
- Stamps the local calendar date. `toISOString` reports UTC and would date the
  release yesterday from UTC+7.

`--serve <spec|none>` gives the serve app its own bump level or skips it, and
`--no-commit` writes the files without staging. The CLI needs no edit at all;
`readVersion()` reads `package.json` at runtime.

The CHANGELOG sort only touches the section being promoted. Earlier releases are
left exactly as written, content is verbatim, the sort is stable so repeated or
unrecognised headings keep the author's order, and a preamble above the first
`###` stays on top.

Verified three ways:

1. 34 unit tests against throwaway fixture trees, including a real temp git repo
   for the commit and branch-guard paths.
2. A live run in a clone of this repo, which produced the 8-file commit and left
   a clean tree.
3. A diff of its output against the hand-cut 6.3.0 release in #86:
   byte-identical on all seven files it owns, CHANGELOG included.

`CONTRIBUTING.md` also gains a "Cutting a release" section, and its setup
instructions now say Bun 1.3.14. CI moved there in f1fcdde, but the doc still
told contributors to install 1.2.23 and blamed a 1.3.x test-runner bug that no
longer applies - 1.2.23 is in fact the version that broke OpenCV.js init on
Linux.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (tooling only, no runtime code)
- [ ] CHANGELOG updated (maintainer tooling, nothing user-visible ships)
- [ ] README updated (documented in CONTRIBUTING instead)
- [x] New tests added for bugs fixed or features added

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

Nothing here ships to users; the script runs on the maintainer's machine.

### Related

- #86 cuts 6.3.0 by hand. This branch is independent of it, so whichever merges
  first, the other just rebases. No need to re-cut #86 with the tool - the
  output is identical.
