### PR TITLE
feat: add recognition.mainThreadYieldMs for responsive main-thread web OCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`recognition.mainThreadYieldMs` option** pauses before each recognition
+  inference to yield the event loop. On the web main thread the `/web` entry
+  defaults it to `10`, so a page running `recognize()` without a Web Worker
+  keeps painting and handling input between WASM inference blocks instead of
+  freezing for the whole image; consecutive `await`s alone only queue
+  microtasks, which the renderer cannot interleave with. Defaults to `0`
+  (disabled) in workers, Node, Bun, and React Native, and an explicit caller
+  value always wins. Also exposed as `--main-thread-yield-ms` on the CLI. A
+  Web Worker remains the recommended home for OCR; this closes the gap for
+  script-tag/main-thread setups.
 - **`recognition.maxCropSourceSideLength` option** (default `2000`) caps the
   longest side of the canvas recognition crops are cut from, independent of
   and above `detection.maxSideLength` (which only resizes the detector's own

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ await service.destroy();
 - [Processing Engine](#processing-engine)
 - [Web / Browser Support](#web--browser-support)
   - [Using a Bundler](#using-a-bundler-vite-webpack-etc)
+  - [Main-Thread Usage (No Worker)](#main-thread-usage-no-worker)
   - [CDN (No Bundler)](#cdn-no-bundler)
   - [WebGPU Acceleration](#webgpu-acceleration)
   - [Multithreaded WASM (Cross-Origin Isolation)](#multithreaded-wasm-cross-origin-isolation)
@@ -289,16 +290,16 @@ bunx ppu-paddle-ocr models --json
 
 Every `PaddleOptions` / `RecognizeOptions` field maps to a flag:
 
-| Flags                                                                                                          | Applies to         | Purpose                                                                               |
-| :------------------------------------------------------------------------------------------------------------- | :----------------- | :------------------------------------------------------------------------------------ |
-| `--model <preset>`                                                                                             | all commands       | Catalogue preset (`v6-tiny`, `v6-small`, `v5-en-mobile`, ...); list: `models --json`  |
-| `--model-detection`, `--model-recognition`, `--model-dict`                                                     | all commands       | Raw paths/URLs; each overrides that part of the preset                                |
-| `--strategy`, `--flatten`, `--no-cache`, `--image-height`, `--min-confidence`, `--max-crop-source-side-length` | recognition        | Recognition behavior (strategy, flat output, confidence filter, crop-source cap, ...) |
-| `--engine`, `--execution-providers`                                                                            | all commands       | `opencv` \| `canvas-native`; ONNX providers (e.g. `cuda,cpu`)                         |
-| `--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`             | all incl. `detect` | Detection tuning (`--max-side-length` accepts `auto`)                                 |
-| `--save-crops <dir>`                                                                                           | `detect` only      | Write one PNG per detected box                                                        |
-| `--concurrency`                                                                                                | `batch`, `stream`  | Images processed in parallel                                                          |
-| `--json`, `--pretty`, `-o`/`--output`, `-q`/`--quiet`, `--verbose`                                             | all commands       | Output format and destination                                                         |
+| Flags                                                                                                                                    | Applies to         | Purpose                                                                               |
+| :--------------------------------------------------------------------------------------------------------------------------------------- | :----------------- | :------------------------------------------------------------------------------------ |
+| `--model <preset>`                                                                                                                       | all commands       | Catalogue preset (`v6-tiny`, `v6-small`, `v5-en-mobile`, ...); list: `models --json`  |
+| `--model-detection`, `--model-recognition`, `--model-dict`                                                                               | all commands       | Raw paths/URLs; each overrides that part of the preset                                |
+| `--strategy`, `--flatten`, `--no-cache`, `--image-height`, `--min-confidence`, `--max-crop-source-side-length`, `--main-thread-yield-ms` | recognition        | Recognition behavior (strategy, flat output, confidence filter, crop-source cap, ...) |
+| `--engine`, `--execution-providers`                                                                                                      | all commands       | `opencv` \| `canvas-native`; ONNX providers (e.g. `cuda,cpu`)                         |
+| `--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`                                       | all incl. `detect` | Detection tuning (`--max-side-length` accepts `auto`)                                 |
+| `--save-crops <dir>`                                                                                                                     | `detect` only      | Write one PNG per detected box                                                        |
+| `--concurrency`                                                                                                                          | `batch`, `stream`  | Images processed in parallel                                                          |
+| `--json`, `--pretty`, `-o`/`--output`, `-q`/`--quiet`, `--verbose`                                                                       | all commands       | Output format and destination                                                         |
 
 Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error.
 
@@ -511,6 +512,31 @@ Notes:
 ```ts
 import { isWebWorker } from "ppu-paddle-ocr/web";
 ```
+
+### Main-Thread Usage (No Worker)
+
+A worker is still the right home for OCR, but if you run `recognize()` directly
+on the page (a plain `<script>` setup, no bundler, no worker), WASM inference
+blocks the main thread and the tab freezes until the whole image is done.
+
+To keep the page responsive, the web entry pauses ~10 ms before each
+recognition inference on the main thread. The page paints and handles input
+between inferences instead of locking up for the full run. The trade-off is a
+slightly longer total time (roughly 10 ms per detected line).
+
+Tune or disable it via `recognition.mainThreadYieldMs`:
+
+```ts
+// Longer pauses, smoother page (heavier UI around the OCR call)
+const service = new PaddleOcrService({ recognition: { mainThreadYieldMs: 32 } });
+
+// Disable: fastest total time, page frozen while recognizing
+const service = new PaddleOcrService({ recognition: { mainThreadYieldMs: 0 } });
+```
+
+Inside a Web Worker this default is off (`0`), there is no UI to yield to.
+Detection's single inference still blocks briefly either way; only the
+per-line recognition loop yields.
 
 ### CDN (No Bundler)
 
@@ -858,14 +884,15 @@ Controls preprocessing and filtering during text detection.
 
 Controls recognition preprocessing and strategy.
 
-| Property                  |                   Type                    |   Default    | Description                                                                                                                                                              |
-| :------------------------ | :---------------------------------------: | :----------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `imageHeight`             |                 `number`                  |     `48`     | Fixed height for resized text line images (px).                                                                                                                          |
-| `strategy`                | `"per-box" \| "per-line" \| "cross-line"` | `"per-line"` | Recognition strategy (see above).                                                                                                                                        |
-| `crossLineWidthFactor`    |                 `number`                  |    `1.0`     | Batch width multiplier for `cross-line` strategy.                                                                                                                        |
-| `minimumConfidence`       |                 `number`                  |    `0.5`     | Drop items below this confidence (0 disables). Mirrors upstream `drop_score`; noise reads at 0.2-0.45, real text at 0.65+.                                               |
-| `charactersDictionary`    |                `string[]`                 |     `[]`     | Loaded character dictionary for result decoding.                                                                                                                         |
-| `maxCropSourceSideLength` |                 `number`                  |    `2000`    | Longest side (px) the recognition crop source is capped at; independent of `detection.maxSideLength`. Lower for speed on large sources, raise for full-resolution crops. |
+| Property                  |                   Type                    |           Default           | Description                                                                                                                                                              |
+| :------------------------ | :---------------------------------------: | :-------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `imageHeight`             |                 `number`                  |            `48`             | Fixed height for resized text line images (px).                                                                                                                          |
+| `strategy`                | `"per-box" \| "per-line" \| "cross-line"` |        `"per-line"`         | Recognition strategy (see above).                                                                                                                                        |
+| `crossLineWidthFactor`    |                 `number`                  |            `1.0`            | Batch width multiplier for `cross-line` strategy.                                                                                                                        |
+| `minimumConfidence`       |                 `number`                  |            `0.5`            | Drop items below this confidence (0 disables). Mirrors upstream `drop_score`; noise reads at 0.2-0.45, real text at 0.65+.                                               |
+| `charactersDictionary`    |                `string[]`                 |            `[]`             | Loaded character dictionary for result decoding.                                                                                                                         |
+| `maxCropSourceSideLength` |                 `number`                  |           `2000`            | Longest side (px) the recognition crop source is capped at; independent of `detection.maxSideLength`. Lower for speed on large sources, raise for full-resolution crops. |
+| `mainThreadYieldMs`       |                 `number`                  | `0` (web main thread: `10`) | Pause (ms) before each recognition inference so a browser page keeps painting; `0` disables. See [Main-Thread Usage](#main-thread-usage-no-worker).                      |
 
 ### `DebuggingOptions`
 

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -357,6 +357,7 @@ type PaddleOptions = {
     strategy?: "per-box" | "per-line" | "cross-line";
     crossLineWidthFactor?: number;
     maxCropSourceSideLength?: number; // default 2000 - speed/accuracy trade-off on large sources
+    mainThreadYieldMs?: number; // default 0; web main thread defaults to 10 to keep the page responsive
   };
   debugging?: { verbose?: boolean; debug?: boolean; debugFolder?: string };
   session?: InferenceSession.SessionOptions; // any onnxruntime SessionOptions

--- a/skill-ppu-paddle-ocr/references/configuration.md
+++ b/skill-ppu-paddle-ocr/references/configuration.md
@@ -65,6 +65,7 @@ Controls the recognition stage's preprocessing and batching strategy.
 | `minimumConfidence`       | `number`                                  | `0.5`        | Drop items below this confidence (0 disables); symbol-only items need +0.3.                                                                                    |
 | `charactersDictionary`    | `string[]`                                | `[]`         | Loaded dict for decoding. Set automatically by `initialize()`; don't override.                                                                                 |
 | `maxCropSourceSideLength` | `number`                                  | `2000`       | Longest side (px) for the canvas recognition crops are cut from. Independent of `detection.maxSideLength` (that only resizes the detector's own input tensor). |
+| `mainThreadYieldMs`       | `number`                                  | `0`          | Pause (ms) before each recognition inference. The web entry defaults it to `10` on the main thread (not in workers) so the page keeps painting; `0` disables.  |
 
 **When to tune:**
 
@@ -73,6 +74,7 @@ Controls the recognition stage's preprocessing and batching strategy.
 - `crossLineWidthFactor`: only meaningful with `cross-line`. Try `1.2`-`1.5` for slight throughput wins; `2.0+` starts to hurt accuracy on receipts.
 - `charactersDictionary`: this is set internally from `model.charactersDictionary` during `initialize()`. Setting it directly is a footgun - use `model.charactersDictionary` instead, or `recognize(image, { dictionary })` for one-off overrides.
 - `maxCropSourceSideLength`: this is a speed/accuracy trade-off, not a bug fix with one right answer - lower it (e.g. `1000`) if you'd rather trade some accuracy for speed on large sources; raise it (or set it near your largest expected input's longest side) if you want recognition to always crop at native resolution regardless of source size.
+- `mainThreadYieldMs`: only matters when running `ppu-paddle-ocr/web` on the page's main thread (no worker); raise it toward a frame budget (`16`-`32`) if the page still feels janky during OCR, set `0` for the fastest total time at the cost of a frozen tab. Prefer moving the service into a Web Worker over tuning this.
 
 ---
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -31,6 +31,8 @@ Recognition flags (recognize / batch / stream):
   --max-crop-source-side-length <n>
                                  longest side (px) the crop source is capped at (default 2000);
                                  lower is faster on large scans, higher keeps native-res crops
+  --main-thread-yield-ms <n>     pause (ms) before each recognition inference; keeps a browser
+                                 page responsive, no effect worth using in a CLI (default 0)
   --flatten                      flat results in reading order instead of grouped lines
   --no-cache                     bypass the in-memory result cache
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -27,6 +27,7 @@ export const PARSE_OPTIONS: NonNullable<ParseArgsConfig["options"]> = {
   "image-height": { type: "string" },
   "min-confidence": { type: "string" },
   "max-crop-source-side-length": { type: "string" },
+  "main-thread-yield-ms": { type: "string" },
   flatten: { type: "boolean" },
   "no-cache": { type: "boolean" },
   model: { type: "string" },
@@ -158,6 +159,7 @@ export function buildPaddleOptions(values: CliValues): PaddleOptions {
   const crossLineWidthFactor = num(values, "cross-line-width-factor");
   const minimumConfidence = num(values, "min-confidence");
   const maxCropSourceSideLength = num(values, "max-crop-source-side-length");
+  const mainThreadYieldMs = num(values, "main-thread-yield-ms");
   // `charactersDictionary: []` is the documented placeholder - initialize()
   // fills it from the recognition model's dictionary.
   options.recognition = {
@@ -167,6 +169,7 @@ export function buildPaddleOptions(values: CliValues): PaddleOptions {
     ...(crossLineWidthFactor !== undefined ? { crossLineWidthFactor } : {}),
     ...(minimumConfidence !== undefined ? { minimumConfidence } : {}),
     ...(maxCropSourceSideLength !== undefined ? { maxCropSourceSideLength } : {}),
+    ...(mainThreadYieldMs !== undefined ? { mainThreadYieldMs } : {}),
   };
 
   const eng = engine(values);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,15 @@ export const DEFAULT_RECOGNITION_OPTIONS: RecognitionOptions = {
   minimumConfidence: 0.5,
   charactersDictionary: [],
   maxCropSourceSideLength: 2000,
+  mainThreadYieldMs: 0,
 };
+
+/**
+ * Default `mainThreadYieldMs` applied by the web entry on the main thread
+ * (never in workers): one macrotask pause per recognition inference keeps
+ * the page painting and handling input while WASM blocks the thread.
+ */
+export const DEFAULT_WEB_MAIN_THREAD_YIELD_MS = 10;
 
 /** Default ONNX Runtime session options. */
 export const DEFAULT_SESSION_OPTIONS: SessionOptions = {

--- a/src/core/base-recognition.service.ts
+++ b/src/core/base-recognition.service.ts
@@ -321,6 +321,14 @@ export class BaseRecognitionService {
    * Runs the ONNX inference session with the prepared tensor
    */
   private async runInference(inputTensor: Tensor): Promise<Tensor> {
+    // A macrotask boundary before each inference lets a browser main thread
+    // paint and handle input between WASM blocks; plain `await`s only queue
+    // microtasks, which the renderer cannot interleave with.
+    const yieldMs = this.options.mainThreadYieldMs ?? 0;
+    if (yieldMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, yieldMs));
+    }
+
     const feeds = { x: inputTensor };
     const results = await this.session.run(feeds);
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -202,6 +202,22 @@ export type RecognitionOptions = {
    * @default 2000
    */
   maxCropSourceSideLength?: number;
+
+  /**
+   * Milliseconds to pause before each recognition inference, yielding the
+   * event loop so a browser page stays responsive. WASM inference blocks
+   * the thread it runs on, and consecutive `await`s resolve as microtasks -
+   * without a macrotask boundary between inferences, the page cannot paint
+   * or handle input until the whole image is done. `0` disables the pause.
+   *
+   * Only meaningful on the web main thread; a Web Worker is still the
+   * better home for OCR (see the README's Web Workers section), and Node,
+   * Bun, workers, and React Native have nothing to yield to.
+   *
+   * @default 0 - except `ppu-paddle-ocr/web` on the main thread, where it
+   * defaults to 10.
+   */
+  mainThreadYieldMs?: number;
 };
 
 /**

--- a/src/web/recognition.service.web.ts
+++ b/src/web/recognition.service.web.ts
@@ -2,12 +2,29 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 import type * as ort from "onnxruntime-web";
+import { DEFAULT_WEB_MAIN_THREAD_YIELD_MS } from "../constants.js";
 import { BaseRecognitionService } from "../core/base-recognition.service.js";
 import type { RecognitionResult } from "../core/base-recognition.service.js";
 import type { DebuggingOptions, RecognitionOptions } from "../interface.js";
-import { WebPlatformProvider } from "./platform.web.js";
+import { isWebWorker, WebPlatformProvider } from "./platform.web.js";
 
 export type { RecognitionResult };
+
+/**
+ * Applies the web main-thread default for `mainThreadYieldMs`: one macrotask
+ * pause per recognition inference keeps the page painting while WASM blocks
+ * the thread. Workers have no UI to yield to and keep the shared default (0),
+ * and an explicit caller value - including 0 - always wins.
+ *
+ * Exported so the main-thread/worker branch stays testable outside a browser.
+ */
+export function withMainThreadYieldDefault(
+  options: Partial<RecognitionOptions>,
+  onMainThread: boolean = typeof window !== "undefined" && !isWebWorker()
+): Partial<RecognitionOptions> {
+  if (!onMainThread) return options;
+  return { mainThreadYieldMs: DEFAULT_WEB_MAIN_THREAD_YIELD_MS, ...options };
+}
 
 /**
  * Service for detecting and recognizing text in images using Web implementation.
@@ -26,6 +43,12 @@ export class RecognitionService extends BaseRecognitionService {
     options: Partial<RecognitionOptions> = {},
     debugging: Partial<DebuggingOptions> = {}
   ) {
-    super(new WebPlatformProvider(), session, options, debugging, "canvas-native");
+    super(
+      new WebPlatformProvider(),
+      session,
+      withMainThreadYieldDefault(options),
+      debugging,
+      "canvas-native"
+    );
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -103,6 +103,18 @@ describe("option builders", () => {
     expect(() => buildPaddleOptions({ "max-crop-source-side-length": "abc" })).toThrow();
   });
 
+  test("--main-thread-yield-ms is registered and maps onto recognition", () => {
+    expect(PARSE_OPTIONS["main-thread-yield-ms"]).toEqual({ type: "string" });
+
+    const opts = buildPaddleOptions({ "main-thread-yield-ms": "16" });
+    expect(opts.recognition?.mainThreadYieldMs).toBe(16);
+
+    // Omitted leaves it unset so the library default (0, disabled) applies.
+    expect(buildPaddleOptions({}).recognition?.mainThreadYieldMs).toBeUndefined();
+
+    expect(() => buildPaddleOptions({ "main-thread-yield-ms": "abc" })).toThrow();
+  });
+
   test("buildPaddleOptions resolves --model presets, with --model-* overriding parts", () => {
     expect(buildPaddleOptions({ model: "v6-tiny" }).model).toEqual(V6_TINY_MODEL);
 

--- a/tests/main-thread-yield.test.ts
+++ b/tests/main-thread-yield.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
+import { levenshteinDistance } from "../src/utils.js";
+
+// A value nothing else in the runtime schedules, so counting timers with
+// exactly this delay isolates the yields our code inserts.
+const YIELD_MS = 7;
+
+const groundTruth = (
+  await Bun.file(`${import.meta.dir}/../assets/receipt-ground-truth.txt`).text()
+).trim();
+
+function accuracy(text: string): number {
+  const dist = levenshteinDistance(text.trim(), groundTruth);
+  return ((groundTruth.length - dist) / groundTruth.length) * 100;
+}
+
+describe("recognition.mainThreadYieldMs", () => {
+  beforeAll(async () => {
+    await PaddleOcrService.downloadModels();
+  }, 30000);
+
+  test("yields once per recognition inference and leaves results intact", async () => {
+    const service = new PaddleOcrService({
+      recognition: { charactersDictionary: [], mainThreadYieldMs: YIELD_MS },
+    });
+    await service.initialize();
+
+    const original = globalThis.setTimeout;
+    let yieldCount = 0;
+    globalThis.setTimeout = ((
+      handler: Parameters<typeof setTimeout>[0],
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      if (ms === YIELD_MS) yieldCount++;
+      return original(handler, ms, ...(rest as []));
+    }) as typeof setTimeout;
+
+    try {
+      const image = await Bun.file(`${import.meta.dir}/../assets/receipt.jpg`).arrayBuffer();
+      const result = await service.recognize(image, { noCache: true });
+
+      // per-line runs one inference per merged line, and every returned line
+      // implies at least one inference - so the yield must have fired at
+      // least that many times. If the option were not wired through to
+      // runInference, yieldCount would be 0.
+      expect(result.lines.length).toBeGreaterThan(0);
+      expect(yieldCount).toBeGreaterThanOrEqual(result.lines.length);
+
+      // Yielding must not change what gets recognized.
+      expect(accuracy(result.text)).toBeGreaterThan(90);
+    } finally {
+      globalThis.setTimeout = original;
+      await service.destroy();
+    }
+  }, 30000);
+});

--- a/tests/web-support.test.ts
+++ b/tests/web-support.test.ts
@@ -279,3 +279,26 @@ describe("WebGPU execution-provider detection", () => {
     }
   });
 });
+
+describe("mainThreadYieldMs web default", () => {
+  test("main thread gets the 10ms default, workers and servers stay disabled", async () => {
+    const { withMainThreadYieldDefault } = await import("../src/web/recognition.service.web.js");
+    const { DEFAULT_WEB_MAIN_THREAD_YIELD_MS } = await import("../src/constants.js");
+
+    expect(withMainThreadYieldDefault({}, true).mainThreadYieldMs).toBe(
+      DEFAULT_WEB_MAIN_THREAD_YIELD_MS
+    );
+    // Off the main thread the options pass through untouched, so the shared
+    // default (0, disabled) applies.
+    expect(withMainThreadYieldDefault({}, false).mainThreadYieldMs).toBeUndefined();
+    // Bun has no `window`, so the auto-detect resolves to "not main thread".
+    expect(withMainThreadYieldDefault({}).mainThreadYieldMs).toBeUndefined();
+  });
+
+  test("an explicit caller value wins, including an explicit 0", async () => {
+    const { withMainThreadYieldDefault } = await import("../src/web/recognition.service.web.js");
+
+    expect(withMainThreadYieldDefault({ mainThreadYieldMs: 0 }, true).mainThreadYieldMs).toBe(0);
+    expect(withMainThreadYieldDefault({ mainThreadYieldMs: 32 }, true).mainThreadYieldMs).toBe(32);
+  });
+});


### PR DESCRIPTION
## What

Adds `recognition.mainThreadYieldMs` (default `0`; the `/web` entry defaults it to `10` on the browser main thread), a pause before each recognition inference that yields the event loop so a page running `recognize()` without a Web Worker keeps painting and handling input instead of freezing for the whole image. Also exposed as `--main-thread-yield-ms` on the CLI.

## Why

On the main thread, WASM inference blocks the thread it runs on, and consecutive `await`s between inferences resolve as microtasks, which the renderer cannot interleave with. A script-tag setup with no worker therefore freezes the tab until the whole image is done.

This is a real adoption blocker: at least one downstream project ([cty-paddle-ocr](https://github.com/CraftThingy-Digital-Innovation/cty-paddle-ocr), a fork of the v3-era code) exists specifically to patch this, forcing sequential per-box processing with a `setTimeout` pause before each box. The rest of that fork's shims are already obsolete against the current `/web` entry; this option closes the one remaining gap so main-thread users can depend on the library directly.

## How

- `src/core/base-recognition.service.ts`: the pause lives in `runInference`, the single choke point all three strategies (`per-box`, `per-line`, `cross-line`) already funnel through. Strategies were already sequential, so the macrotask boundary was the only missing piece. `0` disables it and skips the timer entirely.
- `src/web/recognition.service.web.ts`: `withMainThreadYieldDefault` (exported for tests) injects the `10` default only when `typeof window !== "undefined" && !isWebWorker()`. Workers, Node, Bun, and React Native keep `0`. An explicit caller value, including an explicit `0`, always wins.
- `src/cli/options.ts` / `help.ts`: `--max-crop-source-side-length` sibling flag `--main-thread-yield-ms`, keeping the documented 1:1 option-to-flag mapping.
- Docs: README gets a "Main-Thread Usage (No Worker)" section (worker still recommended; detection's single inference still blocks briefly, only the recognition loop yields), plus rows in the `RecognitionOptions` and CLI flag tables; skill `SKILL.md` and `references/configuration.md` updated; CHANGELOG under `[Unreleased]`.

### Benchmark (`bun bench/index.bench.ts`, receipt.jpg, default `mainThreadYieldMs: 0` so this exercises the disabled path)

Two samples on this branch (honest note: both are the branch; the worktree could not also check out `main`, so the baseline is main's published README numbers, 134-140 ms opencv at the same defaults on the same machine class):

```
Sample 1:
[per-box][opencv][noCache]             122.7 ms
[per-line][opencv][noCache]            114.4 ms
[cross-line][opencv][noCache]          115.7 ms
[per-box][canvas-native][noCache]      133.7 ms
[per-line][canvas-native][noCache]     128.3 ms
[cross-line][canvas-native][noCache]   134.2 ms

Sample 2:
[per-box][opencv][noCache]             133.6 ms
[per-line][opencv][noCache]            132.6 ms
[cross-line][opencv][noCache]          138.3 ms
[per-box][canvas-native][noCache]      148.0 ms
[per-line][canvas-native][noCache]     141.8 ms
[cross-line][canvas-native][noCache]   150.0 ms
```

The spread between the two samples (~10-15%) dwarfs anything the disabled path could add: with the default `0`, the change is one numeric comparison per inference, no timer is ever scheduled. Accuracy is byte-identical to main's published numbers on all six strategy/engine combinations (99.48/99.48/94.26 opencv, 99.48/99.22/94.78 canvas-native), in both samples. The enabled path costs ~10 ms per recognized line on main-thread web runs only, which is the point.

### Checklist

- [x] Tests pass locally (`bun test`) - 260 pass, 0 fail (+4: a timer-spy test proving one yield fires per recognized line with accuracy intact, the CLI flag mapping case, and two unit tests for the main-thread/worker default branch)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint`, `bun run fmt`)
- [x] Benchmark run (`bun bench/index.bench.ts`, above)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated (new section + two table rows)
- [x] New tests added for the feature

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

The browser rows are unticked because the main-thread default is covered by unit tests on the extracted branch logic, not by a manual browser session; a quick check on the live demo page after merge would be a good sanity pass.

### Related

- Downstream motivation: https://github.com/CraftThingy-Digital-Innovation/cty-paddle-ocr
