### PR TITLE
chore: bump version to 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-08-10
+
 ### Added
 
 - **Standalone CLI binaries** for Linux x64/arm64, macOS Apple Silicon, and

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.3.1", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.3.2", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.3.1",
+      version: "0.3.2",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.3.1";
+export const API_VERSION = "0.3.2";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web worker, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -2338,7 +2338,7 @@
             // Fallback to npm CDN
             console.warn("Local build failed to load:", e);
             console.log("Falling back to CDN...");
-            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.3.0/web/index.js");
+            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.4.0/web/index.js");
           }
         }
         PaddleOcrService = mod.PaddleOcrService;


### PR DESCRIPTION
## What

Release prep for v6.4.0 via `bun bump minor`: version to 6.4.0 in `package.json`/`jsr.json`, playground CDN pin updated, serve bumped to 0.3.2 (4 touchpoints), and CHANGELOG `[Unreleased]` promoted to `## [6.4.0] - 2026-08-10`.

## Why

Three merged feature PRs are ready to ship: #89 (main-thread yield for responsive web OCR), #91 (batched recognition ~35% faster at equal-or-better accuracy, vertical-crop rotation, space recovery, crop-source cap), and #90 (signed standalone CLI binaries, full and slim). Also carries the image-size SCA fix.

## How

Single `bun bump minor` commit; no hand edits. Type-check and CLI tests verified on the branch.

### Checklist

- [x] Types are clean (`bun run type-check`)
- [x] CHANGELOG promoted (bump does the keep-a-changelog sort)
- [x] Version touchpoints covered by `bun bump` (package.json, jsr.json, playground pin, serve x4)
- [ ] Post-merge (maintainer): signed tag, `gh release create`, `deploy-serve.yml`; verify the first-ever binary sign-and-attach run adds 16 assets

### Compatibility

Version-string changes only; no runtime code.
