### PR TITLE
fix: exclude the mobile entry from the JSR package

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
-    "./web": "./src/web/index.ts",
-    "./mobile": "./src/mobile/index.ts"
+    "./web": "./src/web/index.ts"
   },
   "publish": {
     "include": [
@@ -25,7 +24,8 @@
       "examples",
       "models",
       "out",
-      ".claude"
+      ".claude",
+      "src/mobile"
     ]
   }
 }


### PR DESCRIPTION
## What

Drops the `./mobile` export from `jsr.json` and excludes `src/mobile` from the JSR publish.

## Why

The v6.4.0 publish job failed at `bunx jsr publish`: deno's publish resolves every import, and `onnxruntime-react-native` is no longer resolvable since the SCA fix removed it from devDependencies (the vulnerable react-native/metro/image-size chain). React Native cannot consume JSR anyway, so the mobile entry is npm-only in practice; excluding it is the honest packaging, not a workaround.

## How

`jsr.json` only: remove the export, extend `publish.exclude`. Validated with `bunx jsr publish --dry-run` (completes cleanly; failed before the change). npm packaging unchanged; nothing reached npm or JSR from the failed run.

### Checklist

- [x] `bunx jsr publish --dry-run` passes
- [x] No runtime code changed - no tests/bench/README impact
- [ ] Post-merge: re-tag v6.4.0 on main and recreate the release to re-trigger publish
