### PR TITLE
docs: explain why the mobile entry is npm-only, not on JSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ await service.destroy();
 
 Notes:
 
+- **npm only, not JSR.** The mobile entry is published to npm but excluded from the JSR package: `onnxruntime-react-native` and `@shopify/react-native-skia` are native React Native modules that only resolve through npm/Metro, and JSR's Deno-based publish cannot resolve them (React Native itself cannot consume JSR packages). Install via npm/yarn/bun as shown above.
 - **Native modules required.** Both `onnxruntime-react-native` and `@shopify/react-native-skia` ship native code, so you need a dev client or `expo prebuild`, **Expo Go is not supported**. Targets RN >= 0.74 / Expo SDK >= 51 (Hermes).
 - **CPU inference.** Mobile runs on CPU by default; pass `session: { executionProviders: ["nnapi"] }` (Android) or `["coreml"]` (iOS) to opt into hardware acceleration. There is no WebGPU on React Native.
 - **Camera capture is out of scope.** Pass a decoded frame from `react-native-vision-camera` or `expo-camera` as an `ArrayBuffer`.


### PR DESCRIPTION
## What

Adds a bullet to the README's React Native section explaining why `ppu-paddle-ocr/mobile` is published to npm but excluded from JSR.

## Why

Requested by xirf in the PR #93 review: the exclusion shipped without a documented reason. The reason: `onnxruntime-react-native` and `@shopify/react-native-skia` are native React Native modules that only resolve through npm/Metro; JSR's Deno-based publish cannot resolve them, and React Native cannot consume JSR packages at all.

## How

One README bullet, no code. Formatter clean.

### Checklist

- [x] README updated
- [x] Lint + format clean
- Docs-only: tests/bench/CHANGELOG not applicable