### PR TITLE
docs: fix broken tables and restructure the dense README sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docs:** removed leftover rebase conflict remnants that duplicated the CLI
+  flag table and the `RecognitionOptions` table (README and the
+  `skill-ppu-paddle-ocr` configuration reference), which broke their rendering
+  on GitHub.
+
+### Changed
+
+- **Docs:** the README "CLI (global install)" and "Standalone Binaries"
+  sections now lead with the command; the notes moved into collapsible
+  sections. The CLI flag table is split into "Models and engine" and
+  "Behavior and output".
+
 ## [6.4.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sections now lead with the command; the notes moved into collapsible
   sections. The CLI flag table is split into "Models and engine" and
   "Behavior and output".
+- **Docs:** the README "Batch Recognition" section now opens with the basic
+  call and a "you want / use" lookup table, with each variant behind a short
+  labelled lead-in. The `"auto"` concurrency default on CPU is documented as
+  `4` instead of "a small default".
 
 ## [6.4.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call and a "you want / use" lookup table, with each variant behind a short
   labelled lead-in. The `"auto"` concurrency default on CPU is documented as
   `4` instead of "a small default".
+- **Docs:** README "Main-Thread Usage" now documents `mainThreadYieldMs` as a
+  value table, and states the yield cost per batched inference rather than per
+  detected line (it is one pause per `recBatchSize` crops). "Multithreaded
+  WASM" and "React Native" lead with the requirement; the JSR exclusion
+  rationale moved into a collapsible note. The `wasmPaths` note is no longer a
+  blockquote and shows the self-host assignment.
 
 ## [6.4.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CLI:** `help` listed `v6-small` as the default preset; the default is
+  `v6-tiny` (`DEFAULT_MODEL` in the model catalogue).
 - **Docs:** removed leftover rebase conflict remnants that duplicated the CLI
   flag table and the `RecognitionOptions` table (README and the
   `skill-ppu-paddle-ocr` configuration reference), which broke their rendering
@@ -30,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   WASM" and "React Native" lead with the requirement; the JSR exclusion
   rationale moved into a collapsible note. The `wasmPaths` note is no longer a
   blockquote and shows the self-host assignment.
+- **Docs:** README "Fine-Tuning on Your Data" splits the one-paragraph wall
+  into what the starter kit covers, and points at Image Preprocessing first.
+  Unwrapped the hard-wrapped PP-OCRv6 intro paragraph.
 
 ## [6.4.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -369,20 +369,37 @@ Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default 
 
 ## Batch Recognition
 
-`batchRecognize()` runs `recognize()` over many images with **bounded concurrency**, so memory stays in check: at most `concurrency` images are decoded and in flight at once. Results are returned **index-aligned** to the inputs regardless of completion order.
+`batchRecognize()` runs `recognize()` over many images with **bounded concurrency**: at most `concurrency` images are decoded and in flight at once, so memory stays in check. Results come back **index-aligned** to the inputs, whatever order they finish in.
 
 ```ts
 const results = await service.batchRecognize([buf1, buf2, buf3]);
 results.forEach((r, i) => console.log(i, r.text));
 ```
 
-Concurrency defaults to `"auto"`, `1` when an accelerator provider (CUDA, WebGPU) is configured (a shared session serializes device work anyway, and parallel runs would stack VRAM), and a small CPU default otherwise to overlap JS preprocessing with native inference. Override it explicitly when you know your hardware:
+| You want                            | Use                                   |
+| :---------------------------------- | :------------------------------------ |
+| More or fewer images in flight      | `{ concurrency: 8 }`                  |
+| One bad image not to kill the batch | `{ settle: true }`                    |
+| Progress or cancellation            | `{ onProgress, signal }`              |
+| Results as they finish              | `batchRecognizeStream()`              |
+| An input list too big for memory    | pass an `Iterable` or `AsyncIterable` |
+
+All `RecognizeOptions` (`flatten`, `strategy`, `dictionary`, `noCache`) are accepted too and apply to every image. Full surface: [`BatchRecognizeOptions`](#batchrecognizeoptions).
+
+**Concurrency.** Defaults to `"auto"`: `1` on an accelerator provider (CUDA, WebGPU), `4` on CPU. Set it when you know your hardware:
 
 ```ts
 await service.batchRecognize(images, { concurrency: 8, flatten: true });
 ```
 
-Use `settle: true` to keep going when an image fails, each slot becomes `{ status, value | reason }` instead of the call rejecting:
+<details>
+<summary>Why auto picks 1 on an accelerator</summary>
+
+A shared ONNX session serializes device work anyway, so parallel runs buy nothing and stack VRAM. On CPU the default overlaps JS preprocessing with native inference, which does help.
+
+</details>
+
+**Failures.** With `settle: true` the call never rejects; each slot becomes `{ status, value | reason }`:
 
 ```ts
 const results = await service.batchRecognize(images, { settle: true });
@@ -392,7 +409,7 @@ for (const r of results) {
 }
 ```
 
-Track progress and cancel with the usual primitives:
+**Progress and cancellation** use the usual primitives:
 
 ```ts
 const ac = new AbortController();
@@ -402,7 +419,7 @@ await service.batchRecognize(images, {
 });
 ```
 
-To consume results as they finish (and avoid buffering the whole batch), stream them, each item carries its input `index` for reordering:
+**Streaming.** `batchRecognizeStream()` yields each result as it finishes, so the whole batch is never buffered. Each item carries its input `index` for reordering:
 
 ```ts
 for await (const item of service.batchRecognizeStream(images)) {
@@ -410,7 +427,7 @@ for await (const item of service.batchRecognizeStream(images)) {
 }
 ```
 
-`batchRecognize` / `batchRecognizeStream` also accept any `Iterable` or `AsyncIterable` of inputs, so a directory walk or queue never has to be materialized in memory at once. All `RecognizeOptions` (`flatten`, `strategy`, `dictionary`, `noCache`) are accepted and applied to every image. See [`BatchRecognizeOptions`](#batchrecognizeoptions) for the full surface.
+Both methods accept any `Iterable` or `AsyncIterable` of inputs, so a directory walk or a queue never has to be materialized in memory at once.
 
 ## Recognition Strategies
 
@@ -933,7 +950,7 @@ Extends `RecognizeOptions` (applied to every image) for `batchRecognize()` / `ba
 
 | Property      |           Type           | Default  | Description                                                                              |
 | :------------ | :----------------------: | :------: | :--------------------------------------------------------------------------------------- |
-| `concurrency` |    `number \| "auto"`    | `"auto"` | Max images in flight. `"auto"` = `1` on an accelerator provider, small default on CPU.   |
+| `concurrency` |    `number \| "auto"`    | `"auto"` | Max images in flight. `"auto"` = `1` on an accelerator provider, `4` on CPU.             |
 | `settle`      |        `boolean`         | `false`  | When `true`, a failed image yields `{ status: "rejected", reason }` instead of throwing. |
 | `signal`      |      `AbortSignal`       |  `null`  | Cancels the batch; pending images are not scheduled and the call rejects.                |
 | `onProgress`  | `(done, total?) => void` |  `null`  | Called after each image settles, with the running count and total (if known).            |

--- a/README.md
+++ b/README.md
@@ -105,18 +105,22 @@ Omit `onnxruntime-node` or `onnxruntime-web` depending on your target environmen
 
 ### CLI (global install)
 
-To use the [command line](#command-line) without `bunx`/`npx`, install globally, this puts a `ppu-paddle-ocr` command on your `PATH`:
-
 ```bash
 npm install -g ppu-paddle-ocr onnxruntime-node      # or: bun add -g ppu-paddle-ocr onnxruntime-node
 ppu-paddle-ocr recognize receipt.jpg
 ```
 
-`onnxruntime-node` (~258MB of native binaries) is an optional peer dependency, install it alongside - the CLI needs it. Notes:
+This puts a `ppu-paddle-ocr` command on your `PATH`. See [Command Line](#command-line) for all commands.
 
+<details>
+<summary>Notes on the global install</summary>
+
+- **`onnxruntime-node` is required.** It is an optional peer dependency (~258MB of native binaries), so install it alongside the CLI.
 - **bun**: ensure `~/.bun/bin` is on your `PATH` (npm's global bin usually already is).
-- **Updates are manual**, re-run the install with `@latest` to upgrade. (`bunx`/`npx` always fetch the latest but can serve a stale cache; a global install pins the version and you own upgrades.)
-- It's still the Node/Bun build, a global install gives you a global command, not a standalone binary, so Node or Bun must be present. For a true standalone binary, see [Standalone Binaries](#standalone-binaries) below.
+- **Updates are manual.** Re-run the install with `@latest` to upgrade. (`bunx`/`npx` always fetch the latest but can serve a stale cache; a global install pins the version and you own upgrades.)
+- **Node or Bun must be present.** This is the Node/Bun build, not a standalone binary. For that, see [Standalone Binaries](#standalone-binaries) below.
+
+</details>
 
 ### Standalone Binaries
 
@@ -134,14 +138,22 @@ curl -L https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr/releases/latest
 | `ppu-paddle-ocr-darwin-arm64.tar.gz` | macOS on Apple Silicon                                         |
 | `ppu-paddle-ocr-windows-x64.zip`     | Windows x86-64 (contains the `.exe`)                           |
 
-Notes:
+Intel Macs and Alpine (musl) are not covered, onnxruntime ships no darwin-x64 or musl builds; use `npx`/`bunx` there.
+
+<details>
+<summary>Size, slim variant, and OS warnings</summary>
 
 - **Size and first run.** ~50 MB download, ~140-200 MB extracted (the executable embeds the Bun runtime, ONNX Runtime, and the canvas engine; `tar` preserves the executable bit). Models (~6 MB) still download to `~/.cache/ppu-paddle-ocr` on first run, exactly like the npm CLI.
 - **Slim variant.** Each target also ships a `-slim` archive (e.g. `ppu-paddle-ocr-linux-x64-slim.tar.gz`) that excludes the OpenCV engine: ~28 MB smaller extracted, though only ~5 MB smaller to download (the OpenCV payload compresses well). It always uses the `canvas-native` engine and rejects `--engine opencv`; accuracy on the reference receipt is near-identical (see [Benchmark](#benchmark)). Pick slim for disk and memory footprint; pick full if you want the opencv engine.
 - **macOS Gatekeeper.** The binaries are ad-hoc signed but not Apple-notarized. If macOS blocks a downloaded binary, clear the quarantine flag: `xattr -d com.apple.quarantine ./ppu-paddle-ocr-darwin-arm64` (or right-click, Open, once).
 - **Windows SmartScreen.** Unrecognized-app warning on first run: "More info", then "Run anyway".
-- **Intel Macs and Alpine (musl) are not covered**, onnxruntime ships no darwin-x64 or musl builds; use `npx`/`bunx` there.
-- **Verify a download** (checks run against the archive, before extraction; both are attached per release):
+
+</details>
+
+<details>
+<summary>Verify a download (Sigstore + SLSA)</summary>
+
+Both checks run against the archive, before extraction; both artifacts are attached per release.
 
 ```bash
 # Sigstore signature (bundle is attached next to each archive)
@@ -153,6 +165,8 @@ cosign verify-blob ppu-paddle-ocr-linux-x64.tar.gz \
 # GitHub build provenance (SLSA)
 gh attestation verify ppu-paddle-ocr-linux-x64.tar.gz --repo PT-Perkasa-Pilar-Utama/ppu-paddle-ocr
 ```
+
+</details>
 
 ## Core Usage
 
@@ -327,31 +341,31 @@ bunx ppu-paddle-ocr models --json
 
 Every `PaddleOptions` / `RecognizeOptions` field maps to a flag:
 
-| Flags                                                                                                                                                                                | Applies to         | Purpose                                                                               |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------- | :------------------------------------------------------------------------------------ |
-| `--model <preset>`                                                                                                                                                                   | all commands       | Catalogue preset (`v6-tiny`, `v6-small`, `v5-en-mobile`, ...); list: `models --json`  |
-| `--model-detection`, `--model-recognition`, `--model-dict`                                                                                                                           | all commands       | Raw paths/URLs; each overrides that part of the preset                                |
-| `--strategy`, `--flatten`, `--no-cache`, `--image-height`, `--min-confidence`, `--max-crop-source-side-length`, `--main-thread-yield-ms`                                             | recognition        | Recognition behavior (strategy, flat output, confidence filter, crop-source cap, ...) |
-| `--engine`, `--execution-providers`                                                                                                                                                  | all commands       | `opencv` \| `canvas-native`; ONNX providers (e.g. `cuda,cpu`)                         |
-| `--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`                                                                                   | all incl. `detect` | Detection tuning (`--max-side-length` accepts `auto`)                                 |
-| `--save-crops <dir>`                                                                                                                                                                 | `detect` only      | Write one PNG per detected box                                                        |
-| `--concurrency`                                                                                                                                                                      | `batch`, `stream`  | Images processed in parallel                                                          |
-| `--json`, `--pretty`, `-o`/`--output`, `-q`/`--quiet`, `--verbose`                                                                                                                   | all commands       | Output format and destination                                                         |
-| =======                                                                                                                                                                              |
-| Flags                                                                                                                                                                                | Applies to         | Purpose                                                                               |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------- | :------------------------------------------------------------------------------------ |
-| `--model <preset>`                                                                                                                                                                   | all commands       | Catalogue preset (`v6-tiny`, `v6-small`, `v5-en-mobile`, ...); list: `models --json`  |
-| `--model-detection`, `--model-recognition`, `--model-dict`                                                                                                                           | all commands       | Raw paths/URLs; each overrides that part of the preset                                |
-| `--strategy`, `--flatten`, `--no-cache`, `--image-height`, `--min-confidence`, `--max-crop-source-side-length`, `--rec-batch-size`, `--no-rotate-vertical-crops`, `--space-recovery` | recognition        | Recognition behavior (strategy, flat output, confidence filter, crop-source cap, ...) |
-| `--engine`, `--execution-providers`                                                                                                                                                  | all commands       | `opencv` \| `canvas-native`; ONNX providers (e.g. `cuda,cpu`)                         |
-| `--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std`                                                                                   | all incl. `detect` | Detection tuning (`--max-side-length` accepts `auto`)                                 |
-| `--save-crops <dir>`                                                                                                                                                                 | `detect` only      | Write one PNG per detected box                                                        |
-| `--concurrency`                                                                                                                                                                      | `batch`, `stream`  | Images processed in parallel                                                          |
-| `--json`, `--pretty`, `-o`/`--output`, `-q`/`--quiet`, `--verbose`                                                                                                                   | all commands       | Output format and destination                                                         |
+**Models and engine** (all commands):
+
+| Flags                                                                                              | Purpose                                                                              |
+| :------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| `--model <preset>`                                                                                 | Catalogue preset (`v6-tiny`, `v6-small`, `v5-en-mobile`, ...); list: `models --json` |
+| `--model-detection`, `--model-recognition`, `--model-dict`                                         | Raw paths/URLs; each overrides that part of the preset                               |
+| `--engine`, `--execution-providers`                                                                | `opencv` \| `canvas-native`; ONNX providers (e.g. `cuda,cpu`)                        |
+| `--max-side-length`, `--padding-vertical`, `--padding-horizontal`, `--min-area`, `--mean`, `--std` | Detection tuning (`--max-side-length` accepts `auto`)                                |
+
+**Behavior and output**:
+
+| Flags                                                                 | Applies to        | Purpose                                                      |
+| :-------------------------------------------------------------------- | :---------------- | :----------------------------------------------------------- |
+| `--strategy`, `--cross-line-width-factor`, `--flatten`, `--no-cache`  | recognition       | Grouping strategy, flat output, result cache                 |
+| `--image-height`, `--min-confidence`, `--max-crop-source-side-length` | recognition       | Input height, confidence filter, crop-source cap             |
+| `--rec-batch-size`, `--no-rotate-vertical-crops`, `--space-recovery`  | recognition       | Batch size, vertical-crop rotation, space recovery           |
+| `--main-thread-yield-ms`                                              | recognition       | Pause before each inference (browser only, no-op in the CLI) |
+| `--save-crops <dir>`                                                  | `detect` only     | Write one PNG per detected box                               |
+| `--concurrency`, `--settle`                                           | `batch`, `stream` | Images in flight, keep going past a failed image             |
+| `--json`, `--pretty`, `-o`/`--output`, `-q`/`--quiet`, `--verbose`    | all commands      | Output format and destination                                |
+| `--debug`, `--debug-folder <dir>`                                     | all commands      | Dump intermediate frames to disk                             |
 
 Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error.
 
-Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v6 tiny models unless you select a `--model` preset or override the `--model-*` flags.
+Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v6 small models unless you select a `--model` preset or override the `--model-*` flags.
 
 ## Batch Recognition
 
@@ -556,7 +570,9 @@ self.onmessage = async (event: MessageEvent<ArrayBuffer>) => {
 
 ```ts
 // main.ts
-const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" });
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
 worker.onmessage = (event) => console.log(event.data.text);
 
 const bytes = await file.arrayBuffer();
@@ -590,7 +606,9 @@ Tune or disable it via `recognition.mainThreadYieldMs`:
 
 ```ts
 // Longer pauses, smoother page (heavier UI around the OCR call)
-const service = new PaddleOcrService({ recognition: { mainThreadYieldMs: 32 } });
+const service = new PaddleOcrService({
+  recognition: { mainThreadYieldMs: 32 },
+});
 
 // Disable: fastest total time, page frozen while recognizing
 const service = new PaddleOcrService({ recognition: { mainThreadYieldMs: 0 } });
@@ -956,15 +974,6 @@ Controls recognition preprocessing and strategy.
 | `charactersDictionary`    |                `string[]`                 |            `[]`             | Loaded character dictionary for result decoding.                                                                                                                                             |
 | `maxCropSourceSideLength` |                 `number`                  |           `2000`            | Longest side (px) the recognition crop source is capped at; independent of `detection.maxSideLength`. Lower for speed on large sources, raise for full-resolution crops.                     |
 | `mainThreadYieldMs`       |                 `number`                  | `0` (web main thread: `10`) | Pause (ms) before each recognition inference so a browser page keeps painting; `0` disables. See [Main-Thread Usage](#main-thread-usage-no-worker).                                          |
-| =======                   |
-| Property                  |                   Type                    |           Default           | Description                                                                                                                                                                                  |
-| :------------------------ | :---------------------------------------: |        :----------:         | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `imageHeight`             |                 `number`                  |            `48`             | Fixed height for resized text line images (px).                                                                                                                                              |
-| `strategy`                | `"per-box" \| "per-line" \| "cross-line"` |        `"per-line"`         | Recognition strategy (see above).                                                                                                                                                            |
-| `crossLineWidthFactor`    |                 `number`                  |            `1.0`            | Batch width multiplier for `cross-line` strategy.                                                                                                                                            |
-| `minimumConfidence`       |                 `number`                  |            `0.5`            | Drop items below this confidence (0 disables). Mirrors upstream `drop_score`; noise reads at 0.2-0.45, real text at 0.65+.                                                                   |
-| `charactersDictionary`    |                `string[]`                 |            `[]`             | Loaded character dictionary for result decoding.                                                                                                                                             |
-| `maxCropSourceSideLength` |                 `number`                  |           `2000`            | Longest side (px) the recognition crop source is capped at; independent of `detection.maxSideLength`. Lower for speed on large sources, raise for full-resolution crops.                     |
 | `recBatchSize`            |                 `number`                  |             `6`             | Crops per batched recognition inference (width-bucketed, one tensor per chunk, ~35% faster at equal-or-better accuracy). `1` restores sequential; auto-forced to `1` for fixed-batch models. |
 | `rotateVerticalCrops`     |                 `boolean`                 |           `true`            | Rotate crops with height/width >= 1.5 by 90 degrees CCW before recognition, so vertical text lines read correctly without an orientation model.                                              |
 | `spaceRecovery`           |                 `boolean`                 |           `false`           | Emit inter-word spaces the greedy CTC decode drops when the space class is a strong runner-up. Helps Latin text; may add spurious spaces in dense symbol runs.                               |

--- a/README.md
+++ b/README.md
@@ -610,30 +610,25 @@ import { isWebWorker } from "ppu-paddle-ocr/web";
 
 ### Main-Thread Usage (No Worker)
 
-A worker is still the right home for OCR, but if you run `recognize()` directly
-on the page (a plain `<script>` setup, no bundler, no worker), WASM inference
-blocks the main thread and the tab freezes until the whole image is done.
+A worker is still the right home for OCR. Call `recognize()` directly on the page (a plain `<script>` setup, no bundler, no worker) and WASM inference blocks the main thread: the tab freezes until the whole image is done.
 
-To keep the page responsive, the web entry pauses ~10 ms before each
-recognition inference on the main thread. The page paints and handles input
-between inferences instead of locking up for the full run. The trade-off is a
-slightly longer total time (roughly 10 ms per detected line).
+So the web entry pauses ~10 ms before each recognition inference on the main thread. The page paints and handles input between inferences instead of locking up for the full run. The cost is one pause per batched inference, so roughly 10 ms per `recBatchSize` detected lines (6 by default).
 
-Tune or disable it via `recognition.mainThreadYieldMs`:
+Tune it with `recognition.mainThreadYieldMs`:
+
+| Value     | Effect                                                                           |
+| :-------- | :------------------------------------------------------------------------------- |
+| `0`       | No pause: fastest total time, page frozen while recognizing. Default in workers. |
+| `10`      | Default on the main thread.                                                      |
+| `16`-`32` | Longer pauses, smoother page. Use when heavy UI runs around the OCR call.        |
 
 ```ts
-// Longer pauses, smoother page (heavier UI around the OCR call)
 const service = new PaddleOcrService({
   recognition: { mainThreadYieldMs: 32 },
 });
-
-// Disable: fastest total time, page frozen while recognizing
-const service = new PaddleOcrService({ recognition: { mainThreadYieldMs: 0 } });
 ```
 
-Inside a Web Worker this default is off (`0`), there is no UI to yield to.
-Detection's single inference still blocks briefly either way; only the
-per-line recognition loop yields.
+An explicit value always wins, including `0`. Inside a Web Worker the default is `0`, there is no UI to yield to. Detection's single inference still blocks briefly either way; only the recognition loop yields.
 
 ### CDN (No Bundler)
 
@@ -665,15 +660,26 @@ const service = new PaddleOcrService({
 });
 ```
 
-> The WASM binaries are still required even when WebGPU is the primary provider (used for graph optimization and fallback ops). When `ort.env.wasm.wasmPaths` is unset, pages and workers fall back to the jsDelivr copy of the exact `onnxruntime-web` version you loaded, so the binaries and the loader never disagree. Set it yourself before `initialize()` to self-host.
+**The WASM binaries are always required**, even when WebGPU is the primary provider - ONNX Runtime uses them for graph optimization and fallback ops. When `ort.env.wasm.wasmPaths` is unset, pages and workers load the jsDelivr copy of the exact `onnxruntime-web` version you loaded, so the loader and the binaries never disagree. To self-host them, set it before `initialize()`:
+
+```ts
+ort.env.wasm.wasmPaths = "/ort/"; // your copy of the onnxruntime-web dist files
+```
 
 ### Multithreaded WASM (Cross-Origin Isolation)
 
-When the WASM backend is used (no WebGPU, or `executionProviders: ["wasm"]`), ONNX Runtime only runs multithreaded if the page is [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated), otherwise `numThreads` is pinned to 1. Cross-origin isolation requires the `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` response headers.
+This only matters on the WASM fallback path (no WebGPU, or `executionProviders: ["wasm"]`). WebGPU needs no isolation at all.
 
-**If you can set those headers server-side, do that**, it's the correct fix and needs nothing from this package. WebGPU does not need isolation at all, so this only matters on the WASM fallback path.
+ONNX Runtime runs WASM multithreaded only if the page is [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated); otherwise `numThreads` is pinned to 1. Isolation needs two response headers:
 
-For static hosts that can't set headers (e.g. GitHub Pages), the package ships an opt-in [coi-serviceworker](https://github.com/gzuidhof/coi-serviceworker) that injects the headers client-side. Copy it to your served root and load it from your page **before** anything else:
+```http
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+**If you can set those headers server-side, do that.** It is the correct fix and needs nothing from this package.
+
+For static hosts that cannot (e.g. GitHub Pages), the package ships an opt-in [coi-serviceworker](https://github.com/gzuidhof/coi-serviceworker) that injects the headers client-side. Copy it to your served root and load it **before** anything else:
 
 ```html
 <script src="/coi-serviceworker.js"></script>
@@ -686,7 +692,7 @@ Resolve the shipped copy from the package, e.g. in a build step:
 const swPath = import.meta.resolve("ppu-paddle-ocr/coi-serviceworker.js");
 ```
 
-> The service worker reloads the page once on first visit to apply the headers and rewrites all fetch responses. Don't use it if you already control your headers or run another service worker that conflicts.
+> The service worker reloads the page once on first visit to apply the headers, and rewrites all fetch responses. Don't use it if you already control your headers or run another service worker that conflicts.
 
 ## React Native (Mobile)
 
@@ -709,13 +715,25 @@ console.log(result.text);
 await service.destroy();
 ```
 
-Notes:
+**Requirements.** RN >= 0.74 / Expo SDK >= 51 (Hermes). Both peer packages ship native code, so you need a dev client or `expo prebuild`. **Expo Go is not supported.**
 
-- **npm only, not JSR.** The mobile entry is published to npm but excluded from the JSR package: `onnxruntime-react-native` and `@shopify/react-native-skia` are native React Native modules that only resolve through npm/Metro, and JSR's Deno-based publish cannot resolve them (React Native itself cannot consume JSR packages). Install via npm/yarn/bun as shown above.
-- **Native modules required.** Both `onnxruntime-react-native` and `@shopify/react-native-skia` ship native code, so you need a dev client or `expo prebuild`, **Expo Go is not supported**. Targets RN >= 0.74 / Expo SDK >= 51 (Hermes).
-- **CPU inference.** Mobile runs on CPU by default; pass `session: { executionProviders: ["nnapi"] }` (Android) or `["coreml"]` (iOS) to opt into hardware acceleration. There is no WebGPU on React Native.
-- **Camera capture is out of scope.** Pass a decoded frame from `react-native-vision-camera` or `expo-camera` as an `ArrayBuffer`.
-- A runnable Expo example lives in a separate repo: [ppu-paddle-ocr-mobile-react-native-demo](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-mobile-react-native-demo).
+**Hardware acceleration is opt-in**, mobile inference runs on CPU by default. There is no WebGPU on React Native:
+
+```ts
+// Android: ["nnapi"]. iOS: ["coreml"].
+new PaddleOcrService({ session: { executionProviders: ["nnapi"] } });
+```
+
+**Camera capture is out of scope.** Pass a decoded frame from `react-native-vision-camera` or `expo-camera` as an `ArrayBuffer`.
+
+A runnable Expo example lives in a separate repo: [ppu-paddle-ocr-mobile-react-native-demo](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-mobile-react-native-demo).
+
+<details>
+<summary>Why the mobile entry is on npm but not JSR</summary>
+
+`onnxruntime-react-native` and `@shopify/react-native-skia` are native React Native modules that only resolve through npm/Metro, and JSR's Deno-based publish cannot resolve them (React Native itself cannot consume JSR packages). So the mobile entry is excluded from the JSR package. Install via npm/yarn/bun as shown above.
+
+</details>
 
 ## Models and Language Support
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Every `PaddleOptions` / `RecognizeOptions` field maps to a flag:
 
 Recognized text goes to **stdout**; progress and logs go to **stderr**, so output pipes cleanly. Exit codes: `0` success, `1` runtime error, `2` usage error.
 
-Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v6 small models unless you select a `--model` preset or override the `--model-*` flags.
+Run `bunx ppu-paddle-ocr help` for the full reference. The CLI uses the default v6 tiny models unless you select a `--model` preset or override the `--model-*` flags.
 
 ## Batch Recognition
 
@@ -739,11 +739,7 @@ A runnable Expo example lives in a separate repo: [ppu-paddle-ocr-mobile-react-n
 
 ### PP-OCRv6 Models
 
-PP-OCRv6 ships a **single unified model family** covering 50+ languages
-(Simplified/Traditional Chinese, English, Japanese, 46+ Latin-script
-languages, Arabic, Indic, ...), no per-language model files needed. The
-package default is the **tiny** tier; which tier fits which workload is
-covered in [Choosing a Model and Configuration](#choosing-a-model-and-configuration).
+PP-OCRv6 ships a **single unified model family** covering 50+ languages (Simplified/Traditional Chinese, English, Japanese, 46+ Latin-script languages, Arabic, Indic, ...), no per-language model files needed. The package default is the **tiny** tier; which tier fits which workload is covered in [Choosing a Model and Configuration](#choosing-a-model-and-configuration).
 
 | Tier     | Det + rec params | Notes                                                         |
 | :------- | :--------------- | :------------------------------------------------------------ |
@@ -920,7 +916,13 @@ See the [ONNX conversion guide](./examples/convert-onnx.ipynb).
 
 ### Fine-Tuning on Your Data
 
-When stock accuracy on your documents is limited by domain quirks (dropped inter-word spaces, unusual fonts, ID-card hatching) rather than image quality, fine-tune the recognition model on your own labeled word crops. The [fine-tuning starter kit](./examples/fine-tune/README.md) has per-tier training configs (the tiny/small/medium YAMLs differ in neck, head, and dictionary, they are not interchangeable), a dataset preparation script that builds train/val/test splits from images with line-level ground truth, and the full train -> export -> ONNX -> `model.recognition` walkthrough.
+Fine-tune the recognition model when stock accuracy is limited by domain quirks - dropped inter-word spaces, unusual fonts, ID-card hatching - rather than by image quality. If the inputs are blurry, skewed, or warped, fix that first: see [Image Preprocessing](#image-preprocessing).
+
+The [fine-tuning starter kit](./examples/fine-tune/README.md) walks the whole path, from picking a tier to loading the result:
+
+- **Per-tier training configs.** The tiny, small, and medium YAMLs differ in neck, head, and dictionary. They are not interchangeable.
+- **A dataset preparation script** that builds train/val/test splits from images with line-level ground truth.
+- **The train -> export -> ONNX -> `model.recognition` walkthrough**, end to end.
 
 ## Configuration Reference
 

--- a/skill-ppu-paddle-ocr/references/configuration.md
+++ b/skill-ppu-paddle-ocr/references/configuration.md
@@ -65,14 +65,10 @@ Controls the recognition stage's preprocessing and batching strategy.
 | `minimumConfidence`       | `number`                                  | `0.5`        | Drop items below this confidence (0 disables); symbol-only items need +0.3.                                                                                    |
 | `charactersDictionary`    | `string[]`                                | `[]`         | Loaded dict for decoding. Set automatically by `initialize()`; don't override.                                                                                 |
 | `maxCropSourceSideLength` | `number`                                  | `2000`       | Longest side (px) for the canvas recognition crops are cut from. Independent of `detection.maxSideLength` (that only resizes the detector's own input tensor). |
-| <<<<<<< ours              |
 | `mainThreadYieldMs`       | `number`                                  | `0`          | Pause (ms) before each recognition inference. The web entry defaults it to `10` on the main thread (not in workers) so the page keeps painting; `0` disables.  |
-| =======                   |
 | `recBatchSize`            | `number`                                  | `6`          | Crops per batched inference (~35% faster, equal-or-better accuracy). `1` = sequential; auto-clamped on fixed-batch models.                                     |
 | `rotateVerticalCrops`     | `boolean`                                 | `true`       | Rotate tall crops (h/w >= 1.5) 90deg CCW before recognition - vertical lines, no model cost.                                                                   |
 | `spaceRecovery`           | `boolean`                                 | `false`      | Emit word spaces the CTC decode drops when the space class is a strong runner-up.                                                                              |
-
-> > > > > > > theirs
 
 **When to tune:**
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -40,7 +40,7 @@ Recognition flags (recognize / batch / stream):
   --no-cache                     bypass the in-memory result cache
 
 Model overrides:
-  --model <preset>               catalogue preset, e.g. v6-small (default), v6-tiny,
+  --model <preset>               catalogue preset, e.g. v6-tiny (default), v6-small,
                                  v5-en-mobile, v5-thai-mobile (see 'models --json')
   --model-detection <path|url>   override the preset's detection model
   --model-recognition <path|url> override the preset's recognition model


### PR DESCRIPTION
## What

Repairs two docs tables that a botched rebase left broken, fixes the CLI help's wrong default-model preset, and restructures the README sections that had grown into walls of notes.

- **Fix:** `ppu-paddle-ocr help` listed `v6-small` as the default `--model` preset. `DEFAULT_MODEL` is `V6_TINY_MODEL`.
- **Fix:** the CLI flag table and the `RecognitionOptions` table were each duplicated with a raw `=======` conflict marker between the copies, so both rendered as garbage on GitHub. The same remnant sat in `skill-ppu-paddle-ocr/references/configuration.md` with `<<<<<<< ours` / `theirs` markers.
- **Docs:** CLI (global install), Standalone Binaries, Batch Recognition, Main-Thread Usage, Multithreaded WASM, React Native, and Fine-Tuning now lead with the command or the requirement; the supporting notes moved into collapsible sections.

## Why

The two duplicated tables were unreadable on GitHub - the separator row rendered as a table cell full of dashes, and readers saw two contradictory copies of the same flag list. Neither copy was complete: one had `--main-thread-yield-ms`, the other had `--rec-batch-size`, `--no-rotate-vertical-crops`, and `--space-recovery`. They are merged, keeping every row from both sides.

The help-text default was a straight factual error: anyone reading `help` and expecting `v6-small` got tiny-tier accuracy without knowing it.

The rest is reading UX. Several sections opened with a paragraph of caveats before the command, or ran five code blocks deep with no signposting - so the reader had to scan the whole section to find the one line that applied to them.

## How

- `src/cli/help.ts`: `v6-tiny (default), v6-small` instead of the reverse.
- Merged each duplicated table into one; deleted the conflict markers.
- Sections restructured to lead with the command, then a lookup table where there is a choice to make, then variants behind short bold lead-ins. Rationale and long caveats moved into `<details>` blocks.
- Flag table split into "Models and engine" and "Behavior and output"; picks up `--settle`, `--debug`, `--debug-folder`, `--cross-line-width-factor`, which existed in `help.ts` but were missing from the README.
- Batch Recognition: documents the CPU auto-concurrency default as `4`, the value `resolveConcurrency` returns, instead of "a small default".
- Main-Thread Usage: the yield cost is per inference, not per detected line. With `recBatchSize` 6 that is ~10 ms per 6 lines. Corrected, and `mainThreadYieldMs` is now a value table.

No behavior change beyond the help string.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

Not benchmarked: no hot-path code changes. No new tests: the change is a usage string and prose.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

### Related

The conflict remnants came from an earlier rebase; the same markers are cleaned from the shipped skill docs in this PR.
