### PR TITLE
chore: release 6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.1] - 2026-08-21
+
 ### Changed
 
 - **Faster OpenCV-engine pipeline on Node/Bun** (default engine): detection

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.3.2", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.3.3", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.3.2",
+      version: "0.3.3",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.3.2";
+export const API_VERSION = "0.3.3";
 
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web worker, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -2338,7 +2338,7 @@
             // Fallback to npm CDN
             console.warn("Local build failed to load:", e);
             console.log("Falling back to CDN...");
-            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.4.0/web/index.js");
+            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.4.1/web/index.js");
           }
         }
         PaddleOcrService = mod.PaddleOcrService;


### PR DESCRIPTION
## What

Cuts release 6.4.1. `bun bump 6.4.1` rewrote every version touchpoint and promoted the `[Unreleased]` changelog section into a dated `[6.4.1] - 2026-08-21` heading. No source changes.

| Touchpoint | Change |
| :--- | :--- |
| `package.json`, `jsr.json` | 6.4.0 -> 6.4.1 |
| `playground/index.html` | CDN fallback pin -> `ppu-paddle-ocr@6.4.1` |
| `CHANGELOG.md` | `[Unreleased]` -> `[6.4.1] - 2026-08-21` |
| `apps/serve` (4 files) | REST envelope 0.3.2 -> 0.3.3 |

The CLI reads `package.json` at runtime, so it carries no version string.

## Why

Ships the OpenCV-engine perf work (#96) and the README/CLI corrections that have accumulated on `main` since 6.4.0. Patch rather than minor: no public API changed, no defaults moved, and output on the shipped models is bit-identical to 6.4.0.

The playground pin matters on its own. It imports an exact version from jsDelivr, and leaving it at 6.4.0 serves the previous build to everyone opening the demo after this release.

## How

Ran `bun bump 6.4.1` on a release branch, per the [Cutting a release](../blob/main/CONTRIBUTING.md#cutting-a-release) runbook. The serve app took its default patch bump, so the published image tracks the new library version; nothing under `apps/serve/` changed this cycle, so `--serve none` was the alternative.

### Checklist

- [x] Tests pass locally (`bun test` - 290 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [ ] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

No bench: this PR carries no source change. The perf numbers for the work being released were measured in #96 and independently reproduced in review. No README change: nothing public moved. No new tests: `tests/bump.test.ts` and `tests/playground.test.ts` already cover the touchpoints this PR edits, and both pass.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

`bun run build` also verified locally.

### Related

- Releases #96 (OpenCV-engine canvas round-trip removal) and #98 (README restructure, CLI default-preset fix).
- After merge: signed tag, `gh release create v6.4.1`, then `gh workflow run deploy-serve.yml`. The release triggers `cli-binaries.yml`, so the standalone executables land a few minutes later.
