### PR TITLE
fix: forward settle flag in buildBatchOptions

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -237,5 +237,6 @@ export function buildBatchOptions(values: CliValues): BatchRecognizeOptions {
   return {
     ...buildRecognizeOptions(values),
     ...(concurrency !== undefined ? { concurrency } : {}),
+    ...(values.settle ? { settle: true } : {}),
   };
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -146,10 +146,12 @@ describe("option builders", () => {
     expect(opts.model).toEqual({ ...V6_SMALL_MODEL, detection: "/custom-det.onnx" });
   });
 
-  test("buildBatchOptions parses concurrency", () => {
+  test("buildBatchOptions parses concurrency and settle", () => {
     expect(buildBatchOptions({ concurrency: "auto" }).concurrency).toBe("auto");
     expect(buildBatchOptions({ concurrency: "4" }).concurrency).toBe(4);
+    expect(buildBatchOptions({ settle: true }).settle).toBe(true);
     expect(buildBatchOptions({}).concurrency).toBeUndefined();
+    expect(buildBatchOptions({}).settle).toBeUndefined();
   });
 
   test("invalid flag values throw a usage error (exit code 2)", () => {


### PR DESCRIPTION
## Description
- Forwards `values.settle` in `BuildBatchOptions()`, ensuring CLI batch runs with `--settle` properly isolate individual item failures without aborting the entire batch.
- Adds test coverage for `BuildBatchOptions` with the `settle` flag.