### PR TITLE
fix: key the model cache on the full url, and point docs at the hugging face mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bandwidth budget behind it. Paths are identical on both hosts. The
   library's own defaults still resolve from GitHub.
 
+### Fixed
+
+- **Model cache collisions.** The Node/Bun cache keyed entries on the file name
+  alone, so two resources sharing a name (a custom model and a preset, or the
+  same path on two hosts) served each other's bytes. Entries now sit under a
+  digest of the full URL. Existing caches are not migrated: the first run after
+  upgrading re-downloads, and the old flat files can be removed with
+  `service.clearModelCache()`.
+
 ## [6.4.1] - 2026-08-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs:** the README now points manual model URLs at the Hugging Face
+  mirror (`https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`),
+  which serves models and dictionaries from one base with no Git LFS
+  bandwidth budget behind it. Paths are identical on both hosts. The
+  library's own defaults still resolve from GitHub.
+
 ## [6.4.1] - 2026-08-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ service.clearModelCache();
 
 ### Multilingual Support
 
-PP-OCRv5 supports 40+ languages across different script systems. Pre-converted ONNX models are available at [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models):
+PP-OCRv5 supports 40+ languages across different script systems. Pre-converted ONNX models are published on [Hugging Face](https://huggingface.co/snowfluke/ppu-paddle-ocr-models) and mirrored in [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models):
 
 - **Latin**: English, French, German, Italian, Spanish, Portuguese, and 40+ others
 - **Cyrillic**: Russian, Ukrainian, Bulgarian, Kazakh, Serbian, and 30+ related
@@ -826,23 +826,28 @@ const service = new PaddleOcrService({ model: V5_THAI_MOBILE_MODEL });
 const service = new PaddleOcrService({ model: V5_ARABIC_MOBILE_MODEL });
 ```
 
-**Manual URLs** (advanced):
+**Manual URLs** (advanced). Prefer the Hugging Face mirror: it serves models and dictionaries from one CDN-backed base, with no Git LFS bandwidth budget behind it.
 
 ```ts
-const MODEL_BASE =
-  "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
-const DICT_BASE =
-  "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
+const BASE = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
 
 // Thai
 const service = new PaddleOcrService({
   model: {
-    detection: `${MODEL_BASE}/detection/PP-OCRv5_mobile_det_infer.onnx`,
-    recognition: `${MODEL_BASE}/recognition/multi/th/v5/th_PP-OCRv5_mobile_rec_infer.onnx`,
-    charactersDictionary: `${DICT_BASE}/recognition/multi/th/v5/ppocrv5_th_dict.txt`,
+    detection: `${BASE}/detection/PP-OCRv5_mobile_det_infer.onnx`,
+    recognition: `${BASE}/recognition/multi/th/v5/th_PP-OCRv5_mobile_rec_infer.onnx`,
+    charactersDictionary: `${BASE}/recognition/multi/th/v5/ppocrv5_th_dict.txt`,
   },
 });
 ```
+
+Paths are identical on both hosts, so the base is the only part that changes:
+
+| Host                  | Base URL                                                                                      | Notes                                            |
+| :-------------------- | :-------------------------------------------------------------------------------------------- | :----------------------------------------------- |
+| Hugging Face          | `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`                         | Preferred. One base for models and dictionaries. |
+| GitHub (models)       | `https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main` | Git LFS, subject to a bandwidth budget.          |
+| GitHub (dictionaries) | `https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main`         | Plain files, not LFS.                            |
 
 ### Server Models (Higher Accuracy)
 

--- a/README.md
+++ b/README.md
@@ -791,6 +791,8 @@ Models are cached under `~/.cache/ppu-paddle-ocr`:
 | Linux   | `~/.cache/ppu-paddle-ocr`                   |
 | Windows | `C:\Users\<username>\.cache\ppu-paddle-ocr` |
 
+Each file lands in a subdirectory named after a digest of its source URL, so two models that share a file name never collide. Point a model at a different host and it downloads again rather than reading the old host's copy.
+
 ```ts
 // Warm the cache (e.g. in CI or Docker builds)
 PaddleOcrService.downloadModels();

--- a/src/processor/model-cache.ts
+++ b/src/processor/model-cache.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
+import { createHash } from "crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -11,12 +12,27 @@ import { fetchArrayBufferWithRetry } from "../utils.js";
 export const CACHE_DIR: string = path.join(os.homedir(), ".cache", "ppu-paddle-ocr");
 
 /**
+ * Cache path for `url`: the file name under a directory named after a digest
+ * of the whole URL.
+ *
+ * The digest is what keeps two resources that share a file name apart. Model
+ * file names repeat across hosts and directories, so keying on the name alone
+ * would serve one URL's bytes for another's request - a custom model shadowed
+ * by a preset, or a host swap that silently keeps reading the old host's copy.
+ */
+export function cachePathFor(url: string): string {
+  const fileName = path.basename(new URL(url).pathname);
+  const digest = createHash("sha256").update(url).digest("hex").slice(0, 12);
+  return path.join(CACHE_DIR, digest, fileName);
+}
+
+/**
  * Downloads a resource from `url` and writes it to {@link CACHE_DIR}, or reads
  * from the cache if the file already exists.
  */
 export async function fetchAndCacheResource(url: string, verbose?: boolean): Promise<ArrayBuffer> {
   const fileName = path.basename(new URL(url).pathname);
-  const cachePath = path.join(CACHE_DIR, fileName);
+  const cachePath = cachePathFor(url);
 
   if (existsSync(cachePath)) {
     if (verbose) console.log(`[PaddleOcrService] Loading cached resource from: ${cachePath}`);
@@ -32,9 +48,7 @@ export async function fetchAndCacheResource(url: string, verbose?: boolean): Pro
 
   const arrayBuffer = await fetchArrayBufferWithRetry(url);
 
-  if (!existsSync(CACHE_DIR)) {
-    mkdirSync(CACHE_DIR, { recursive: true });
-  }
+  mkdirSync(path.dirname(cachePath), { recursive: true });
   writeFileSync(cachePath, Buffer.from(arrayBuffer));
 
   return arrayBuffer;

--- a/tests/dictionary.test.ts
+++ b/tests/dictionary.test.ts
@@ -1,13 +1,12 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { V5_EN_MOBILE_MODEL } from "../src/model-catalogue.js";
+import { cachePathFor } from "../src/processor/model-cache.js";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { levenshteinDistance, parseDictionary } from "../src/utils.js";
 
 // The v5 EN dict lives in the model cache (downloaded by the top-level warmup below).
-const CACHED_V5_DICT_PATH = join(homedir(), ".cache", "ppu-paddle-ocr", "ppocrv5_en_dict.txt");
+const CACHED_V5_DICT_PATH = cachePathFor(V5_EN_MOBILE_MODEL.charactersDictionary);
 const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/receipt.jpg`).arrayBuffer();
 const groundTruth = (
   await Bun.file(`${import.meta.dir}/../assets/receipt-ground-truth.txt`).text()

--- a/tests/model-cache.test.ts
+++ b/tests/model-cache.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { dirname } from "path";
+
+import { CACHE_DIR, cachePathFor, fetchAndCacheResource } from "../src/processor/model-cache.js";
+
+/**
+ * The cache is keyed on the whole URL, not just the file name. Model file
+ * names repeat across hosts and directories, so a name-only key hands one
+ * URL's bytes to another URL's request.
+ *
+ * These use a local server rather than the real catalogue: the point is the
+ * key, not the models. Entries land in the real CACHE_DIR under their own
+ * digest directories, which afterAll removes.
+ */
+
+// Two resources that share a file name, the shape the catalogue produces:
+// the same model name under different directories.
+const FIRST = "detection/model.onnx";
+const SECOND = "recognition/model.onnx";
+const BODIES: Record<string, string> = {
+  [`/${FIRST}`]: "first-resource-bytes",
+  [`/${SECOND}`]: "second-resource-bytes",
+};
+
+let server: ReturnType<typeof Bun.serve>;
+let requests = 0;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const body = BODIES[new URL(request.url).pathname];
+      if (body === undefined) return new Response("not found", { status: 404 });
+      requests += 1;
+      return new Response(body);
+    },
+  });
+});
+
+afterAll(() => {
+  for (const path of Object.keys(BODIES)) {
+    rmSync(dirname(cachePathFor(`${server.url}${path.slice(1)}`)), {
+      recursive: true,
+      force: true,
+    });
+  }
+  server.stop(true);
+});
+
+const text = (buffer: ArrayBuffer) => new TextDecoder().decode(buffer);
+
+describe("model cache", () => {
+  test("keeps same-named resources from different URLs apart", async () => {
+    const first = await fetchAndCacheResource(`${server.url}${FIRST}`);
+    const second = await fetchAndCacheResource(`${server.url}${SECOND}`);
+
+    expect(text(first)).toBe("first-resource-bytes");
+    expect(text(second)).toBe("second-resource-bytes");
+    expect(requests).toBe(2);
+  });
+
+  test("serves a repeat request from disk", async () => {
+    const before = requests;
+    const again = await fetchAndCacheResource(`${server.url}${FIRST}`);
+
+    expect(text(again)).toBe("first-resource-bytes");
+    expect(requests).toBe(before);
+  });
+
+  test("writes under the cache directory, keeping the file name readable", () => {
+    const path = cachePathFor(`${server.url}${FIRST}`);
+
+    expect(path.startsWith(CACHE_DIR)).toBe(true);
+    expect(path.endsWith("model.onnx")).toBe(true);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("first-resource-bytes");
+  });
+
+  test("a different host for the same path is a different entry", () => {
+    expect(cachePathFor("https://a.example/m/model.onnx")).not.toBe(
+      cachePathFor("https://b.example/m/model.onnx")
+    );
+  });
+});

--- a/tests/strategies-options.test.ts
+++ b/tests/strategies-options.test.ts
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { DEFAULT_MODEL_URLS } from "../src/model-catalogue.js";
+import { cachePathFor } from "../src/processor/model-cache.js";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 
 const imgFile = Bun.file(`${import.meta.dir}/../assets/receipt.jpg`);
@@ -307,7 +308,7 @@ describe("model cache download path", () => {
       await PaddleOcrService.downloadModels({ verbose: true });
 
       for (const url of Object.values(DEFAULT_MODEL_URLS)) {
-        const file = join(cacheDir, url.slice(url.lastIndexOf("/") + 1));
+        const file = cachePathFor(url);
         expect(existsSync(file)).toBe(true);
         expect((await Bun.file(file).arrayBuffer()).byteLength).toBe(fakeBytes.byteLength);
       }

--- a/tests/web-ocr.test.ts
+++ b/tests/web-ocr.test.ts
@@ -2,13 +2,12 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { getPlatform, setPlatform } from "ppu-ocv";
 
 import type { PaddleOcrService } from "../src/web/paddle-ocr.service.web.js";
 import { PaddleOcrService as NodePaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { DEFAULT_MODEL } from "../src/model-catalogue.js";
+import { cachePathFor } from "../src/processor/model-cache.js";
 import { installWebCanvas, uninstallWebCanvas } from "./web-canvas-polyfill.js";
 
 // The web entry is imported dynamically inside beforeAll - NOT at module load -
@@ -24,8 +23,6 @@ let savedPlatform: ReturnType<typeof getPlatform>;
 let v6Det: ArrayBuffer;
 let v6Rec: ArrayBuffer;
 let v6Dict: ArrayBuffer;
-
-const CACHE = join(homedir(), ".cache", "ppu-paddle-ocr");
 
 const imgFile = Bun.file(`${import.meta.dir}/../assets/receipt.jpg`);
 const imageBuffer = await imgFile.arrayBuffer();
@@ -48,8 +45,7 @@ describe("web OCR service (onnxruntime-web under the polyfilled runtime)", () =>
     // significantly. Warm the cache first so a wiped cache (the model-cache
     // test clears it) or a changed default model can't ENOENT here.
     await NodePaddleOcrService.downloadModels();
-    const cached = (url: string) =>
-      Bun.file(join(CACHE, url.slice(url.lastIndexOf("/") + 1))).arrayBuffer();
+    const cached = (url: string) => Bun.file(cachePathFor(url)).arrayBuffer();
     [v6Det, v6Rec, v6Dict] = await Promise.all([
       cached(DEFAULT_MODEL.detection),
       cached(DEFAULT_MODEL.recognition),

--- a/tests/web-worker.test.ts
+++ b/tests/web-worker.test.ts
@@ -10,8 +10,6 @@
  * globals, so any web-path code that reaches for the DOM fails here.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import * as ort from "onnxruntime-web";
 import { getPlatform, setPlatform } from "ppu-ocv";
 
@@ -21,6 +19,7 @@ import type { Box } from "../src/interface.js";
 import type { PaddleOcrService } from "../src/web/paddle-ocr.service.web.js";
 import type { WebPlatformProvider } from "../src/web/platform.web.js";
 import { DEFAULT_MODEL } from "../src/model-catalogue.js";
+import { cachePathFor } from "../src/processor/model-cache.js";
 import { PaddleOcrService as NodePaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { installWebCanvas, uninstallWebCanvas } from "./web-canvas-polyfill.js";
 
@@ -40,13 +39,11 @@ let detModel: ArrayBuffer;
 let recModel: ArrayBuffer;
 let dictionary: ArrayBuffer;
 
-const CACHE = join(homedir(), ".cache", "ppu-paddle-ocr");
 const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/tilted.png`).arrayBuffer();
 
 beforeAll(async () => {
   await NodePaddleOcrService.downloadModels();
-  const cached = (url: string) =>
-    Bun.file(join(CACHE, url.slice(url.lastIndexOf("/") + 1))).arrayBuffer();
+  const cached = (url: string) => Bun.file(cachePathFor(url)).arrayBuffer();
   [detModel, recModel, dictionary] = await Promise.all([
     cached(DEFAULT_MODEL.detection),
     cached(DEFAULT_MODEL.recognition),


### PR DESCRIPTION
## What

Two changes that go together: the README now points manual model URLs at the Hugging Face mirror, and the Node/Bun model cache is keyed on the full URL instead of the file name.

```
https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main
```

`MODEL_BASE_URL` and `DICT_BASE_URL` are unchanged: the library still resolves its own defaults from GitHub. Switching those is a separate change.

## Why

**The mirror.** The models repo is over its Git LFS bandwidth budget, and `git lfs fetch` against it is already refused:

```
batch response: This repository exceeded its LFS budget.
```

Users are not broken yet, because GitHub blocks the LFS batch API while `media.githubusercontent.com` still serves the objects. Same budget, different door, and no reason to assume the second stays open. Anyone hand-rolling model URLs should be pointed somewhere without that ceiling before it matters, not after. The mirror also collapses two bases into one: on GitHub, models come from the LFS media host and dictionaries from `raw`.

**The cache key.** Found while testing the mirror, and it invalidated the first test I wrote. `fetchAndCacheResource` wrote to `CACHE_DIR/<basename>` and discarded host and directory, so:

- A custom model named `model.onnx` and a preset file of the same name shared one entry, silently serving each other's bytes.
- A run against the Hugging Face URLs read the GitHub-cached files and reported success without contacting Hugging Face at all.

The second one matters for the migration ahead: after the base URLs change, no warm-cache user fetches from the new host, and local verification of the swap silently lies unless the cache is wiped first.

## How

Cache entries now sit at `CACHE_DIR/<12 hex of sha256(url)>/<filename>`. The file name stays readable inside the digest directory. Existing caches are not migrated: the first run after upgrading re-downloads, and `clearModelCache()` removes the old flat files.

Four test files reconstructed the flat path by hand, which is how the assumption spread. They call `cachePathFor()` now.

`tests/model-cache.test.ts` covers the collision directly, serving two different bodies from one local server at `detection/model.onnx` and `recognition/model.onnx`. I verified it fails against the old key before keeping it.

The mirror was verified by running the lightweight preset against it end to end, with an isolated `HOME` so the download was real:

```
Downloading resource: PP-OCRv6_tiny_det.ort     1.9M
Downloading resource: PP-OCRv6_tiny_rec.ort     4.5M
Downloading resource: ppocrv6_tiny_dict.txt      27k
```

sha256 of all three matches the GitHub-served copies, and OCR output on `assets/receipt.jpg` is byte-identical to a GitHub-hosted run, text and boxes. `resolve/main` also returns `access-control-allow-origin` echoing the request origin, so the web build's cross-origin `fetch()` keeps working.

### Checklist

- [x] Tests pass locally (`bun test` - 294 pass, up from 290)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

No bench: the cache is a once-per-process download path, not the hot path.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

The disk cache is Node/Bun only; the web entry fetches per page load and relies on the browser's HTTP cache, so it is unaffected.

### Related

- Mirror: https://huggingface.co/snowfluke/ppu-paddle-ocr-models
- Follow-up: switching `MODEL_BASE_URL` / `DICT_BASE_URL` to the mirror, which moves the library's own downloads off the exhausted LFS budget. It needs this cache fix first, or upgrading users would keep reading their GitHub-cached copies.
