### PR TITLE
refactor: adopt the anti-slop oxlint rules

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -19,6 +19,7 @@
     "*.lock",
     "private-tests",
     "lib",
-    "out"
+    "out",
+    "tools/oxlint/anti-slop"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,12 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "import", "promise"],
+
+  // Vendored from https://github.com/dmmulroy/anti-slop (MIT). Rules that
+  // reject low-evidence TypeScript: fabricated type assertions, `unknown`
+  // leaking into contracts, dictionaries typed as `any`. See
+  // tools/oxlint/anti-slop/README.md.
+  "jsPlugins": ["./tools/oxlint/anti-slop/index.ts"],
   "categories": {
     "correctness": "error"
   },
@@ -66,9 +72,40 @@
     "object-shorthand": "error",
 
     // General - Use template literals over string concatenation.
-    "prefer-template": "error"
+    "prefer-template": "error",
+
+    // anti-slop (vendored, MIT) - evidence over assertion. Rules that reject
+    // patterns which look type-safe but carry no proof. Upstream's own advice
+    // is to adapt them to the project; the five turned off below each fight a
+    // constraint this codebase cannot drop, and say which.
+    "anti-slop/no-chained-type-assertions": "off", // `as unknown as T` at the ORT and OpenCV.js seams, where the vendor types and the runtime shape genuinely disagree
+    "anti-slop/no-conditional-empty-object-spread": "off", // `...(x ? { k: v } : {})` is how optional fields are built under exactOptionalPropertyTypes
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "off", // `typeof window !== "undefined"` probes the runtime; a library spanning Node, Bun, browsers, and React Native has no I/O boundary to parse instead
+    "anti-slop/no-shape-in-symbol-names": "off", // `shape` is ONNX Runtime's own term for tensor dimensions (`tensor.shape`); renaming would diverge from the API being wrapped
+    "anti-slop/no-unknown-parameters": "off", // `prepareCanvas(image: unknown)` is public API, and §2.2 above requires `unknown` over `any` at boundaries
+    "anti-slop/no-unknown-returns": "off", // vendor and runtime seams (`getContext("2d")`, `navigator.gpu.requestAdapter()`, shell output) hand back values this package does not own and cannot parse into a domain type
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "off", // `deepMerge`/`isObject` walk arbitrary option trees whose values include canvases and AbortSignals, so `Record<string, unknown>` is the honest contract
+    "anti-slop/no-widen-then-assert": "error",
+
+    // Shipped code documents its assertions; test, bench, and script files are
+    // exempted in the overrides below.
+    "anti-slop/require-safety-comment-for-type-assertion": "error"
   },
   "overrides": [
+    {
+      // Assertions in code that is not shipped: a failed cast surfaces as a
+      // failing test or a broken local script, not as a user's runtime error.
+      "files": ["tests/**", "bench/**", "scripts/**", "examples/**", "playground/**"],
+      "rules": {
+        "anti-slop/require-safety-comment-for-type-assertion": "off"
+      }
+    },
     {
       // §file-size - Cap TypeScript files at 300 lines of code (blanks and
       // comments excluded). Split into focused modules when a file crosses it.
@@ -92,6 +129,7 @@
     "private-tests",
     "lib",
     "out",
+    "tools/oxlint/anti-slop",
     "coi-serviceworker.js"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Lint:** adopted the [anti-slop](https://github.com/dmmulroy/anti-slop)
+  Oxlint rules, vendored under `tools/oxlint/anti-slop`. Ten rules are enforced;
+  five are turned off with the conflict named in `.oxlintrc.json` (ONNX tensor
+  `shape` naming, runtime environment probes, `unknown` at public boundaries,
+  the option-tree dictionary contract, and conditional-spread optional fields).
+  Type assertions in shipped code now carry a `SAFETY:` comment stating the
+  invariant that makes them sound; test, bench, script, and example files are
+  exempted. Anonymous object return types were replaced by named contracts
+  (`ResizeDimensions`, `DecodedText`, `CropSource`, `MergedLineCrop`,
+  `AsyncQueue`, and the serve envelopes), and a `str()` flag reader replaced
+  twelve `as string | undefined` casts in the CLI. No behavior change: OCR
+  output on the regression corpus is byte-identical.
 - **Docs:** the README now points manual model URLs at the Hugging Face
   mirror (`https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`),
   which serves models and dictionaries from one base with no Git LFS

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -5,17 +5,33 @@ import type { Env } from "./types.js";
 /** API version surfaced in every response envelope. */
 export const API_VERSION = "0.3.3";
 
+/** Success envelope shape: `{ status, version, metadata: { id, ... }, data }`. */
+export type SuccessEnvelope<T> = {
+  status: "success";
+  version: string;
+  metadata: { id: string } & Record<string, unknown>;
+  data: T;
+};
+
+/** Error envelope shape: `{ status, version, data: { message, requestId } }`. */
+export type ErrorEnvelope = {
+  status: "error";
+  version: string;
+  data: { message: string; requestId?: string };
+};
+
+/** One `responses` entry for createRoute, carrying the error envelope schema. */
+export type ErrorResponseEntry = {
+  description: string;
+  content: { "application/json": { schema: typeof errorEnvelopeSchema } };
+};
+
 /** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
 export function success<T>(
   c: Context<Env>,
   data: T,
   metadata: Record<string, unknown> = {}
-): {
-  status: "success";
-  version: string;
-  metadata: { id: string } & Record<string, unknown>;
-  data: T;
-} {
+): SuccessEnvelope<T> {
   return {
     status: "success",
     version: API_VERSION,
@@ -25,10 +41,7 @@ export function success<T>(
 }
 
 /** oksara-style error envelope: `{ status, version, data: { message, requestId } }`. */
-export function failure(
-  message: string,
-  requestId?: string
-): { status: "error"; version: string; data: { message: string; requestId?: string } } {
+export function failure(message: string, requestId?: string): ErrorEnvelope {
   return {
     status: "error",
     version: API_VERSION,
@@ -56,12 +69,7 @@ export const errorEnvelopeSchema = z
   .openapi("ErrorResponse");
 
 /** Reusable error response entry for createRoute `responses`. */
-export const errorResponse = (
-  description: string
-): {
-  description: string;
-  content: { "application/json": { schema: typeof errorEnvelopeSchema } };
-} => ({
+export const errorResponse = (description: string): ErrorResponseEntry => ({
   description,
   content: { "application/json": { schema: errorEnvelopeSchema } },
 });

--- a/apps/serve/src/core/input.ts
+++ b/apps/serve/src/core/input.ts
@@ -44,6 +44,9 @@ function decodeDataUri(uri: string): ArrayBuffer {
     ? Buffer.from(payload, "base64")
     : Buffer.from(decodeURIComponent(payload), "utf-8");
   if (bytes.byteLength > config.maxUploadBytes) throw tooBig();
+  // SAFETY: slice() on a typed array's backing store returns an ArrayBuffer;
+  // the cast drops the SharedArrayBuffer arm, which the upload path never
+  // produces.
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 

--- a/apps/serve/src/core/metrics.ts
+++ b/apps/serve/src/core/metrics.ts
@@ -13,9 +13,9 @@ export function recordRequest(route: string, status: number, seconds: number): v
   requestsTotal.set(key, (requestsTotal.get(key) ?? 0) + 1);
 
   const buckets = bucketCounts.get(route) ?? DURATION_BUCKETS.map(() => 0);
-  for (let i = 0; i < DURATION_BUCKETS.length; i++) {
-    if (seconds <= (DURATION_BUCKETS[i] as number)) buckets[i] = (buckets[i] as number) + 1;
-  }
+  DURATION_BUCKETS.forEach((bound, i) => {
+    if (seconds <= bound) buckets[i] = (buckets[i] ?? 0) + 1;
+  });
   bucketCounts.set(route, buckets);
   durationSum.set(route, (durationSum.get(route) ?? 0) + seconds);
   durationCount.set(route, (durationCount.get(route) ?? 0) + 1);

--- a/apps/serve/src/core/runner.ts
+++ b/apps/serve/src/core/runner.ts
@@ -12,6 +12,8 @@ const round1 = (n: number): number => Math.round(n * 10) / 10;
 
 /** Recognize one image through the bounded inference queue. */
 export async function runOcr(image: ArrayBuffer, opts: OcrOptions): Promise<OcrResponse> {
+  // SAFETY: the request schema restricts `engine` to the same union, and the
+  // config default is validated at startup.
   const engine = (opts.engine ?? config.defaultEngine) as ProcessingEngine;
   const strategy = opts.strategy ?? config.defaultStrategy;
   const svc = await getService(engine);
@@ -30,6 +32,7 @@ export type DetectResponse = {
 
 /** Detect text boxes only (no recognition) through the bounded inference queue. */
 export async function runDetect(image: ArrayBuffer, opts: OcrOptions): Promise<DetectResponse> {
+  // SAFETY: as in runOcr above.
   const engine = (opts.engine ?? config.defaultEngine) as ProcessingEngine;
   const svc = await getService(engine);
 
@@ -48,6 +51,7 @@ export async function resolveBatch(sources: string[]): Promise<ArrayBuffer[]> {
 
 function batchOptions(body: BatchOcrBody) {
   return {
+    // SAFETY: as in runOcr above.
     engine: (body.engine ?? config.defaultEngine) as ProcessingEngine,
     strategy: body.strategy ?? config.defaultStrategy,
     concurrency: body.concurrency ?? config.concurrency,

--- a/apps/serve/src/modules/recognize-batch/index.ts
+++ b/apps/serve/src/modules/recognize-batch/index.ts
@@ -29,6 +29,8 @@ export const handler: RouteHandler<typeof route, Env> = async (c) => {
   const images = await resolveBatch(body.sources);
   const { results, meta } = await runBatch(images, body);
   return c.json(
+    // SAFETY: the envelope carries results verbatim; the array element type is
+    // the OCR result shape the route's response schema already declares.
     success(c, { results: results as unknown[] }, { engine: meta.engine, strategy: meta.strategy }),
     200
   );

--- a/apps/serve/src/modules/recognize/index.ts
+++ b/apps/serve/src/modules/recognize/index.ts
@@ -42,6 +42,8 @@ export const handler = async (c: Context<Env>): Promise<Response> => {
   return c.json(
     success(c, result, {
       speed: meta.ms / 1000,
+      // SAFETY: runOcr returns the flattened shape for this route, which
+      // always carries a confidence.
       confidence: (result as { confidence: number }).confidence,
       engine: meta.engine,
       strategy: meta.strategy,

--- a/apps/serve/src/modules/task-result/index.ts
+++ b/apps/serve/src/modules/task-result/index.ts
@@ -30,6 +30,8 @@ export const handler: RouteHandler<typeof route, Env> = (c) => {
     return c.json(failure(task.error ?? `Task ${task.status}`, requestId), 409);
   }
   if (task.status !== "done") return c.json(failure(`Task is ${task.status}`, requestId), 409);
+  // SAFETY: the status check above establishes the task completed, and the
+  // batch worker is the only writer of `result`.
   const result = task.result as { results: unknown[] };
   return c.json(success(c, { results: result.results }), 200);
 };

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@napi-rs/canvas": "^1.0.2",
+        "@oxlint/plugins": "1.74.0",
         "@types/bun": "^1.3.14",
         "@types/uglify-js": "^3.17.5",
         "canvas": "^3.2.3",
@@ -192,6 +193,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.74.0", "", {}, "sha512-3tQlMDPt5hrRYedKl+M+Xq+fRjAEocMCRJaXH6ypLWu8+Oui5GMj51vjaYf/rzj6HT+JzQoUlY/I7Im2VNXzbw=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 

--- a/examples/fine-tune/prepare-dataset.ts
+++ b/examples/fine-tune/prepare-dataset.ts
@@ -74,7 +74,9 @@ function matchGroundTruth(pred: string, gtLines: string[]): { label: string; sco
   return best;
 }
 
-function pngSize(buf: ArrayBuffer): { width: number; height: number } {
+type PngSize = { width: number; height: number };
+
+function pngSize(buf: ArrayBuffer): PngSize {
   const view = new DataView(buf);
   return { width: view.getUint32(16), height: view.getUint32(20) };
 }
@@ -96,19 +98,30 @@ const detection = await service.detect(image, { crop: true });
 console.log(`${detection.boxes.length} boxes detected in ${imagePath}`);
 
 // the service's own recognition pass, run per pre-cropped box (no re-detection)
+type Split = "train" | "val" | "test";
+
+type WithRecognitor = { recognitor: Recognitor };
+
+type RecognizedLine = { text: string; confidence: number };
+
 type Recognitor = {
   run(
     image: ArrayBuffer,
     boxes: { x: number; y: number; width: number; height: number }[],
     dictionary: string[] | undefined,
     strategy: "per-box"
-  ): Promise<{ text: string; confidence: number }[]>;
+  ): Promise<RecognizedLine[]>;
 };
-const recognitor = (service as unknown as { recognitor: Recognitor }).recognitor;
+// The recognitor is internal; the example reaches past the public API on
+// purpose to score crops the same way the library does.
+const recognitor = (service as unknown as WithRecognitor).recognitor;
 
 for (const split of ["train", "val", "test"])
   mkdirSync(resolve(outDir, split), { recursive: true });
-const lists: Record<string, string[]> = { train: [], val: [], test: [] };
+// `satisfies` would infer never[] from the empty literals and reject the
+// pushes below, so the annotation stays.
+// oxlint-disable-next-line anti-slop/no-known-value-widening
+const lists: Record<Split, string[]> = { train: [], val: [], test: [] };
 let kept = 0;
 let skipped = 0;
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "@napi-rs/canvas": "^1.0.2",
+    "@oxlint/plugins": "1.74.0",
     "@types/bun": "^1.3.14",
     "@types/uglify-js": "^3.17.5",
     "canvas": "^3.2.3",

--- a/scripts/binary/build-binaries.ts
+++ b/scripts/binary/build-binaries.ts
@@ -49,7 +49,13 @@ export type BinaryTarget = {
   exeSuffix: string;
 };
 
-export const TARGETS: Record<string, BinaryTarget> = {
+/** Platform keys the release builds cover. */
+export type TargetKey = "darwin-arm64" | "linux-x64" | "linux-arm64" | "windows-x64";
+
+// `satisfies` is the rule's preferred form, but isolatedDeclarations cannot
+// infer an exported literal built from other bindings, so the annotation stays.
+// oxlint-disable-next-line anti-slop/no-known-value-widening
+export const TARGETS: Record<TargetKey, BinaryTarget> = {
   "darwin-arm64": {
     key: "darwin-arm64",
     bunTarget: "bun-darwin-arm64",
@@ -97,9 +103,14 @@ export const TARGETS: Record<string, BinaryTarget> = {
 };
 
 /** Target key for the machine this script runs on, or null if unsupported. */
-export function currentTargetKey(): string | null {
+export function currentTargetKey(): TargetKey | null {
   const key = `${process.platform === "win32" ? "windows" : process.platform}-${process.arch}`;
-  return key in TARGETS ? key : null;
+  return isTargetKey(key) ? key : null;
+}
+
+/** Narrows a platform-arch string to a key TARGETS actually carries. */
+function isTargetKey(key: string): key is TargetKey {
+  return key in TARGETS;
 }
 
 /**

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -167,7 +167,10 @@ export function promoteChangelog(text: string, version: string, date: string): s
 }
 
 /** Rewrite every version this pattern matches, reporting the first one it found. */
-function swapVersion(text: string, pattern: RegExp, to: string): { text: string; from: string } {
+/** Rewritten file text plus the version it carried before. */
+type RewriteResult = { text: string; from: string };
+
+function swapVersion(text: string, pattern: RegExp, to: string): RewriteResult {
   let from = "";
   const rewritten = text.replace(pattern, (match: string, current: string) => {
     from ||= current;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -23,7 +23,7 @@ import {
   writeOutput,
 } from "./io.js";
 import type { CliValues } from "./options.js";
-import { buildBatchOptions, buildPaddleOptions, buildRecognizeOptions } from "./options.js";
+import { buildBatchOptions, buildPaddleOptions, buildRecognizeOptions, str } from "./options.js";
 
 type BatchEntry = {
   file: string;
@@ -63,9 +63,9 @@ export async function runRecognize(images: string[], values: CliValues): Promise
       ? await service.recognize(input, { ...opts, flatten: true })
       : await service.recognize(input, { ...opts, flatten: false });
     if (values.json) {
-      writeOutput(stringify(result, values), values.output as string | undefined);
+      writeOutput(stringify(result, values), str(values, "output"));
     } else {
-      writeOutput(result.text, values.output as string | undefined);
+      writeOutput(result.text, str(values, "output"));
     }
   } finally {
     await service.destroy();
@@ -82,12 +82,12 @@ export async function runDetect(images: string[], values: CliValues): Promise<vo
     logStderr("Loading models...", Boolean(values.quiet));
     await service.initialize();
     const input = await loadImageInput(image);
-    const saveCropsTo = values["save-crops"] as string | undefined;
+    const saveCropsTo = str(values, "save-crops");
     const { boxes } = await service.detect(input, saveCropsTo ? { saveCropsTo } : undefined);
     if (saveCropsTo) {
       logStderr(`Saved ${boxes.length} crop(s) to ${saveCropsTo}`, Boolean(values.quiet));
     }
-    writeOutput(stringify(boxes, values), values.output as string | undefined);
+    writeOutput(stringify(boxes, values), str(values, "output"));
   } finally {
     await service.destroy();
   }
@@ -120,12 +120,12 @@ export async function runBatch(patterns: string[], values: CliValues): Promise<v
     });
 
     if (values.json) {
-      writeOutput(stringify(entries, values), values.output as string | undefined);
+      writeOutput(stringify(entries, values), str(values, "output"));
     } else {
       const blocks = entries.map((e) =>
         e.result ? `==> ${e.file} <==\n${e.result.text}` : `==> ${e.file} <==\nERROR: ${e.error}`
       );
-      writeOutput(blocks.join("\n\n"), values.output as string | undefined);
+      writeOutput(blocks.join("\n\n"), str(values, "output"));
     }
 
     if (entries.some((e) => e.status === "rejected")) {
@@ -199,5 +199,5 @@ export function runModels(values: CliValues): void {
     executionProviders: built.session?.executionProviders ?? ["cpu"],
     presets: Object.keys(MODEL_PRESETS),
   };
-  writeOutput(stringify(info, values), values.output as string | undefined);
+  writeOutput(stringify(info, values), str(values, "output"));
 }

--- a/src/cli/io.ts
+++ b/src/cli/io.ts
@@ -40,6 +40,8 @@ export async function loadImageInput(arg: string): Promise<ArrayBuffer> {
   }
   if (!existsSync(arg)) throw new CliError(`No such file: ${arg}`);
   const buf = readFileSync(arg);
+  // SAFETY: slice() on a Buffer's backing store returns an ArrayBuffer; the
+  // cast drops the SharedArrayBuffer arm, which readFileSync never returns.
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
 }
 
@@ -79,6 +81,8 @@ export function readVersion(): string {
     const pkgPath = join(dir, "package.json");
     if (existsSync(pkgPath)) {
       try {
+        // SAFETY: JSON.parse returns any; both fields are declared optional and
+        // checked before use, so a package.json without them falls through.
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
           name?: string;
           version?: string;

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -65,6 +65,15 @@ export type CliValues = Record<string, string | boolean | undefined>;
 const STRATEGIES: RecognitionStrategy[] = ["per-box", "per-line", "cross-line"];
 const ENGINES: ProcessingEngine[] = ["opencv", "canvas-native"];
 
+/**
+ * Reads a string-valued flag. Boolean flags are declared separately in the
+ * parser's option table, so a value here is either absent or a string.
+ */
+export function str(values: CliValues, key: string): string | undefined {
+  const raw = values[key];
+  return typeof raw === "string" ? raw : undefined;
+}
+
 function num(values: CliValues, key: string): number | undefined {
   const raw = values[key];
   if (raw === undefined) return undefined;
@@ -82,24 +91,30 @@ function triple(values: CliValues, key: string): [number, number, number] | unde
   if (parts.length !== 3 || parts.some(Number.isNaN)) {
     usageError(`--${key} must be three comma-separated numbers, e.g. 0.485,0.456,0.406`);
   }
+  // SAFETY: the length check above establishes the tuple's arity.
   return parts as [number, number, number];
 }
 
 function strategy(values: CliValues): RecognitionStrategy | undefined {
   const raw = values.strategy;
   if (raw === undefined) return undefined;
+  // SAFETY: `includes` needs the element type to compare; the cast is the
+  // question being asked, and the failure path exits with a usage error.
   if (!STRATEGIES.includes(raw as RecognitionStrategy)) {
     usageError(`--strategy must be one of ${STRATEGIES.join(" | ")}`);
   }
+  // SAFETY: membership in STRATEGIES was just checked.
   return raw as RecognitionStrategy;
 }
 
 function engine(values: CliValues): ProcessingEngine | undefined {
   const raw = values.engine;
   if (raw === undefined) return undefined;
+  // SAFETY: as with the strategy above, the cast poses the membership question.
   if (!ENGINES.includes(raw as ProcessingEngine)) {
     usageError(`--engine must be one of ${ENGINES.join(" | ")}`);
   }
+  // SAFETY: membership in ENGINES was just checked.
   return raw as ProcessingEngine;
 }
 
@@ -107,6 +122,8 @@ function engine(values: CliValues): ProcessingEngine | undefined {
 function modelPreset(values: CliValues): ModelUrls | undefined {
   const raw = values.model;
   if (raw === undefined) return undefined;
+  // SAFETY: MODEL_PRESETS is keyed by a closed union; the flag is free text, so
+  // it is looked up as an open dictionary and the miss is handled below.
   const preset = (MODEL_PRESETS as Record<string, ModelUrls>)[String(raw)];
   if (!preset) {
     usageError(`--model must be one of: ${Object.keys(MODEL_PRESETS).join(", ")}`);
@@ -121,9 +138,9 @@ export function buildPaddleOptions(values: CliValues): PaddleOptions {
   // `--model <preset>` selects a catalogue bundle; the granular `--model-*`
   // flags override individual parts on top of it.
   const preset = modelPreset(values);
-  const detection = values["model-detection"] as string | undefined;
-  const recognition = values["model-recognition"] as string | undefined;
-  const dict = values["model-dict"] as string | undefined;
+  const detection = str(values, "model-detection");
+  const recognition = str(values, "model-recognition");
+  const dict = str(values, "model-dict");
   if (preset || detection || recognition || dict) {
     options.model = {
       ...preset,
@@ -194,7 +211,7 @@ export function buildPaddleOptions(values: CliValues): PaddleOptions {
     options.processing = { engine: eng };
   }
 
-  const providers = values["execution-providers"] as string | undefined;
+  const providers = str(values, "execution-providers");
   if (providers) {
     options.session = {
       executionProviders: providers.split(",").map((p) => p.trim()),
@@ -205,7 +222,7 @@ export function buildPaddleOptions(values: CliValues): PaddleOptions {
     options.debugging = {
       ...(values.verbose ? { verbose: true } : {}),
       ...(values.debug ? { debug: true } : {}),
-      ...(values["debug-folder"] ? { debugFolder: values["debug-folder"] as string } : {}),
+      ...(str(values, "debug-folder") ? { debugFolder: str(values, "debug-folder") } : {}),
     };
   }
 
@@ -223,7 +240,7 @@ export function buildRecognizeOptions(values: CliValues): RecognizeOptions {
 
 /** Batch options: recognize options plus concurrency/settle. */
 export function buildBatchOptions(values: CliValues): BatchRecognizeOptions {
-  const raw = values.concurrency as string | undefined;
+  const raw = str(values, "concurrency");
   let concurrency: number | "auto" | undefined;
   if (raw !== undefined) {
     if (raw === "auto") {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -60,6 +60,8 @@ export async function main(argv: string[]): Promise<number> {
     return 2;
   }
 
+  // SAFETY: parseArgs types its result from the option table; CliValues is that
+  // same shape stated once for the builders in options.ts to consume.
   const values = parsed.values as CliValues;
   const [command, ...rest] = parsed.positionals;
 

--- a/src/core/base-detection.service.ts
+++ b/src/core/base-detection.service.ts
@@ -183,6 +183,9 @@ export class BaseDetectionService {
         return null;
       }
 
+      // SAFETY: the detection head is declared float32, so ORT hands back a
+      // Float32Array; a model exported at another precision would fail session
+      // creation before reaching here.
       return outputTensor.data as Float32Array;
     } catch (error) {
       console.error(
@@ -262,6 +265,8 @@ export class BaseDetectionService {
     paddingVertical: number,
     paddingHorizontal: number
   ): Box[] {
+    // SAFETY: this method only runs on the opencv branch of
+    // postprocessDetection, which tests platform.imageProcessor first.
     const ip = this.platform.imageProcessor as NonNullable<typeof this.platform.imageProcessor>;
     // Build the single-channel mat straight from the probability map: the
     // previous path (probability map -> RGBA canvas -> grayscale) produced

--- a/src/core/base-paddle-ocr.service.ts
+++ b/src/core/base-paddle-ocr.service.ts
@@ -70,6 +70,17 @@ export type BatchRecognizeInput = ArrayBuffer | CoreCanvas | string;
  * Concrete implementations (`PaddleOcrService` for Node, Web, etc.)
  * extend this class and provide a {@link PlatformProvider}.
  */
+/**
+ * Reads the detector after an initialize() guard has already run.
+ *
+ * SAFETY: initialize() constructs the detector, and every caller checks
+ * `isInitialized` before reaching here, so the field is set.
+ */
+function initializedDetector(detector: BaseDetectionService | null): BaseDetectionService {
+  // SAFETY: see the contract above; callers guard on isInitialized first.
+  return detector as BaseDetectionService;
+}
+
 export abstract class BasePaddleOcrService {
   protected options: PaddleOptions = DEFAULT_PADDLE_OPTIONS;
 
@@ -82,6 +93,9 @@ export abstract class BasePaddleOcrService {
 
   public constructor(platform: PlatformProvider, options?: PaddleOptions) {
     this.platform = platform;
+    // SAFETY: deepMerge walks an arbitrary option tree, so it is typed over
+    // Record<string, unknown>. Both inputs are PaddleOptions and the merge only
+    // copies keys, so the result carries the same shape back out.
     this.options = deepMerge(
       {},
       DEFAULT_PADDLE_OPTIONS as unknown as Record<string, unknown>,
@@ -126,14 +140,23 @@ export abstract class BasePaddleOcrService {
       } else if (image instanceof ArrayBuffer) {
         imageBuffer = image;
       } else {
+        // SAFETY: this branch is the fall-through for values that are neither a
+        // path nor an ArrayBuffer, so `image` is a canvas from one of the
+        // supported runtimes. The typeof probe below is what establishes which.
         if (typeof (image as unknown as Record<string, unknown>).toBuffer === "function") {
+          // SAFETY: guarded by the toBuffer probe above (the node-canvas shape).
           const canvasWithBuffer = image as { toBuffer: (format: string) => Buffer };
           const buffer = canvasWithBuffer.toBuffer("image/png");
+          // SAFETY: slice() on a Buffer's ArrayBuffer returns an ArrayBuffer;
+          // the cast only discards the SharedArrayBuffer arm of the union,
+          // which node-canvas never produces.
           imageBuffer = buffer.buffer.slice(
             buffer.byteOffset,
             buffer.byteOffset + buffer.byteLength
           ) as ArrayBuffer;
         } else {
+          // SAFETY: the remaining canvas shape, reached only when toBuffer is
+          // absent; getContext("2d") below throws if the value is not a canvas.
           const canvasWithCtx = image as {
             getContext: (type: string, opts?: unknown) => CanvasRenderingContext2D;
             width: number;
@@ -144,6 +167,7 @@ export abstract class BasePaddleOcrService {
           });
           const imageData = ctx.getImageData(0, 0, canvasWithCtx.width, canvasWithCtx.height);
           const data = imageData.data;
+          // SAFETY: as above, ImageData is always backed by an ArrayBuffer.
           imageBuffer = data.buffer.slice(
             data.byteOffset,
             data.byteOffset + data.byteLength
@@ -154,6 +178,9 @@ export abstract class BasePaddleOcrService {
       const cacheKey = ImageCache.generateKey(imageBuffer);
 
       if (!options?.noCache && !options?.dictionary) {
+        // SAFETY: the cache is keyed by this method's own cacheKey, and only
+        // this method writes it, so an entry under that key is a result it
+        // stored - flattened or not, which the Partial arm covers.
         const cacheResult = globalImageCache.get(cacheKey) as
           | (PaddleOcrResult & Partial<FlattenedPaddleOcrResult>)
           | undefined;
@@ -166,6 +193,7 @@ export abstract class BasePaddleOcrService {
               confidence: cacheResult.confidence,
             };
           }
+          // SAFETY: narrowed above to the non-flattened arm.
           return cacheResult as PaddleOcrResult;
         }
       }
@@ -175,6 +203,8 @@ export abstract class BasePaddleOcrService {
         typeof image === "string" || image instanceof ArrayBuffer
           ? await this.platform.canvas.prepareCanvas(imageBuffer)
           : image;
+      // SAFETY: initialize() constructs the detector before any recognize call,
+      // and the guard at the top of this method rejects an uninitialized service.
       boxes = await (this.detector as BaseDetectionService).run(canvas);
 
       if (boxes.length === 0) {
@@ -202,6 +232,8 @@ export abstract class BasePaddleOcrService {
       }
 
       const strategy = options?.strategy ?? this.options.recognition?.strategy ?? "per-line";
+      // SAFETY: as with the detector, initialize() sets this and the guard at
+      // the top of the method rejects an uninitialized service.
       const results = await (this.recognitor as BaseRecognitionService).run(
         canvas,
         boxes,
@@ -246,12 +278,13 @@ export abstract class BasePaddleOcrService {
       Object.keys(tuning).length > 0
         ? new BaseDetectionService(
             this.platform,
+            // SAFETY: guarded by the same initialize() check as the detector.
             this.detectionSession as InferenceSession,
             { ...this.options.detection, ...tuning },
             this.options.debugging,
             this.options.processing?.engine ?? DEFAULT_PROCESSING_ENGINE
           )
-        : (this.detector as BaseDetectionService);
+        : initializedDetector(this.detector);
 
     let canvas: CoreCanvas;
     if (typeof image === "string") {
@@ -323,6 +356,8 @@ export abstract class BasePaddleOcrService {
     );
 
     if (settle) return collected;
+    // SAFETY: unreachable. Without `settle`, runPool rethrows the first
+    // rejection, so a rejected entry cannot reach this map.
     return collected.map((item) =>
       item.status === "fulfilled" ? item.value : (undefined as never)
     );

--- a/src/core/base-recognition.service.ts
+++ b/src/core/base-recognition.service.ts
@@ -23,6 +23,9 @@ import {
 /**
  * A single recognized text item with its bounding box and confidence.
  */
+/** A crop source canvas and the scale applied to reach it. */
+export type CropSource = { canvas: CoreCanvas; ratio: number };
+
 export type RecognitionResult = {
   /** The recognized text string. */
   text: string;
@@ -212,7 +215,7 @@ export class BaseRecognitionService {
    * trade accuracy for speed. Returns the source unchanged (ratio 1) when
    * it's already within the cap.
    */
-  private buildCropCanvas(source: CoreCanvas): { canvas: CoreCanvas; ratio: number } {
+  private buildCropCanvas(source: CoreCanvas): CropSource {
     const { width, height } = source;
     const maxCropSourceSideLength = this.options.maxCropSourceSideLength ?? 2000;
     const {

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -26,7 +26,7 @@ export type RunPoolOptions = {
   total?: number;
 };
 
-function toAbortError(signal: AbortSignal): unknown {
+function toAbortError(signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason
     : new DOMException("The batch operation was aborted.", "AbortError");
@@ -35,8 +35,11 @@ function toAbortError(signal: AbortSignal): unknown {
 /** Wrap a sync or async iterable in a uniform async iterator. */
 function toAsyncIterator<I>(inputs: Iterable<I> | AsyncIterable<I>): AsyncIterator<I> {
   if (Symbol.asyncIterator in inputs) {
+    // SAFETY: the `in` check is the discriminant between the two arms of the
+    // parameter's union.
     return (inputs as AsyncIterable<I>)[Symbol.asyncIterator]();
   }
+  // SAFETY: the async arm returned above, so only the sync arm remains.
   const sync = (inputs as Iterable<I>)[Symbol.iterator]();
   return {
     next: () => Promise.resolve(sync.next()),
@@ -76,6 +79,8 @@ export async function runPool<I, O>(
   // Fast path: a plain array needs no async iterator - workers claim slots
   // through a shared synchronous cursor, avoiding two promise allocations
   // per item (the serialization lock + `iterator.next()`).
+  // SAFETY: guarded by Array.isArray, which TypeScript widens to any[] for a
+  // union parameter; the element type is the caller's I either way.
   const array = Array.isArray(inputs) ? (inputs as I[]) : null;
   const iterator = array ? null : toAsyncIterator(inputs);
 
@@ -90,6 +95,8 @@ export async function runPool<I, O>(
     });
     await previous;
     try {
+      // SAFETY: `iterator` is non-null exactly when `array` is null, and this
+      // branch is only reached in that case.
       return await (iterator as AsyncIterator<I>).next();
     } finally {
       release();
@@ -109,6 +116,7 @@ export async function runPool<I, O>(
       if (array) {
         if (nextIndex >= array.length) return;
         index = nextIndex++;
+        // SAFETY: index came from nextIndex++ under the length check above.
         item = array[index] as I;
       } else {
         const next = await nextItem();
@@ -148,17 +156,20 @@ export async function runPool<I, O>(
   if (failed) throw failure;
 }
 
+/** Producer handle plus the consumer's drain, for {@link createAsyncQueue}. */
+export type AsyncQueue<T> = {
+  push: (item: T) => void;
+  close: () => void;
+  fail: (error: unknown) => void;
+  drain: () => AsyncGenerator<T>;
+};
+
 /**
  * A minimal single-consumer async queue: producers `push` settled items, the
  * consumer drains them as an async iterable. Bridges {@link runPool}'s callback
  * model to `batchRecognizeStream`'s generator.
  */
-export function createAsyncQueue<T>(): {
-  push: (item: T) => void;
-  close: () => void;
-  fail: (error: unknown) => void;
-  drain: () => AsyncGenerator<T>;
-} {
+export function createAsyncQueue<T>(): AsyncQueue<T> {
   const items: T[] = [];
   let wake: (() => void) | null = null;
   let closed = false;
@@ -187,6 +198,7 @@ export function createAsyncQueue<T>(): {
     async *drain(): AsyncGenerator<T> {
       while (true) {
         while (items.length > 0) {
+          // SAFETY: guarded by the length check on the line above.
           yield items.shift() as T;
         }
         if (failure) throw failure.error;

--- a/src/core/detection/box-geometry.ts
+++ b/src/core/detection/box-geometry.ts
@@ -4,6 +4,9 @@
 import type { Contours, cv } from "ppu-ocv";
 import type { Box } from "../../interface.js";
 
+/** New pixel dimensions plus the scale ratio that produced them. */
+export type ResizeDimensions = { width: number; height: number; ratio: number };
+
 /**
  * Resolves the effective detection size cap for an input image.
  *
@@ -27,7 +30,7 @@ export function calculateResizeDimensions(
   originalWidth: number,
   originalHeight: number,
   maxSideLength: number
-): { width: number; height: number; ratio: number } {
+): ResizeDimensions {
   let resizeW = originalWidth;
   let resizeH = originalHeight;
   let ratio = 1.0;
@@ -45,12 +48,12 @@ export function calculateResizeDimensions(
  * Expands a bounding rect by padding derived from its height, clamped to canvas bounds.
  */
 export function applyPaddingToRect(
-  rect: { x: number; y: number; width: number; height: number },
+  rect: Box,
   maxWidth: number,
   maxHeight: number,
   paddingVertical: number,
   paddingHorizontal: number
-): { x: number; y: number; width: number; height: number } {
+): Box {
   const verticalPadding = Math.round(rect.height * paddingVertical);
   const horizontalPadding = Math.round(rect.height * paddingHorizontal);
 
@@ -72,7 +75,7 @@ export function applyPaddingToRect(
  * Maps a rect from the resized/padded tensor space back to original image coordinates.
  */
 export function convertToOriginalCoordinates(
-  rect: { x: number; y: number; width: number; height: number },
+  rect: Box,
   resizeRatio: number,
   originalWidth: number,
   originalHeight: number

--- a/src/core/detection/crop-boxes.ts
+++ b/src/core/detection/crop-boxes.ts
@@ -49,6 +49,8 @@ export async function cropDetectedBoxes(
  * (e.g. the React Native Skia canvas).
  */
 async function canvasToPngBuffer(canvas: CoreCanvas): Promise<ArrayBuffer> {
+  // SAFETY: the two canvas encoders are probed, not assumed - both members are
+  // optional here and tested before use.
   const c = canvas as unknown as {
     toBuffer?: (format: string) => Buffer;
     convertToBlob?: (options?: { type?: string }) => Promise<Blob>;
@@ -57,6 +59,8 @@ async function canvasToPngBuffer(canvas: CoreCanvas): Promise<ArrayBuffer> {
 
   if (typeof c.toBuffer === "function") {
     const buffer = c.toBuffer("image/png");
+    // SAFETY: slice() on a Buffer's backing store returns an ArrayBuffer, never
+    // the SharedArrayBuffer arm of the union.
     return buffer.buffer.slice(
       buffer.byteOffset,
       buffer.byteOffset + buffer.byteLength

--- a/src/core/recognition/batched.ts
+++ b/src/core/recognition/batched.ts
@@ -87,6 +87,8 @@ export async function recognizeCropsBatched(
       ]);
       const output = await ctx.runInference(inputTensor);
       const [, seqLen, numClasses] = output.dims;
+      // SAFETY: the recognition head is declared float32, so ORT's output
+      // buffer is a Float32Array; another precision fails session creation.
       const data = output.data as Float32Array;
       const rowSize = (seqLen ?? 0) * (numClasses ?? 0);
       chunk.forEach((cropIndex, row) => {
@@ -117,6 +119,9 @@ export async function recognizeCropsBatched(
  * Fixed-batch models (some custom exports) must stay on the per-crop path.
  */
 export function supportsDynamicBatch(session: { inputMetadata?: unknown }): boolean {
+  // SAFETY: inputMetadata is `unknown` on the session type this package
+  // defines; the shape below is ORT's documented one, and every read past
+  // this point is optional-chained, so a mismatch yields undefined.
   const meta = session.inputMetadata as
     | ReadonlyArray<{ shape?: ReadonlyArray<number | string> }>
     | undefined;

--- a/src/core/recognition/ctc.ts
+++ b/src/core/recognition/ctc.ts
@@ -127,13 +127,16 @@ export function refineDecodedChars(chars: string[], positions: number[]): void {
  * locates each character in the crop for position-based text splitting.
  * Wide gaps between characters become spaces (see {@link injectGapSpaces}).
  */
+/** Text decoded from a recognition tensor, with its per-character offsets. */
+export type DecodedText = { text: string; confidence: number; positions: number[] };
+
 export function ctcGreedyDecode(
   logits: Float32Array,
   sequenceLength: number,
   numClasses: number,
   charDict: string[],
   spaceRecovery = false
-): { text: string; confidence: number; positions: number[] } {
+): DecodedText {
   const dictLen = charDict.length;
   const lastDictIndex = dictLen - 1;
 
@@ -221,7 +224,9 @@ export function decodeResults(
   numClassesFromShape: number,
   verbose = false,
   spaceRecovery = false
-): { text: string; confidence: number; positions: number[] } {
+): DecodedText {
+  // SAFETY: the recognition head is declared float32, so ORT's output buffer is
+  // a Float32Array; a model at another precision fails session creation first.
   const outputData = outputTensor.data as Float32Array;
   const outputShape = outputTensor.dims;
 
@@ -254,7 +259,7 @@ export function decodeLogitsRow(
   numClasses: number,
   charactersDictionary: string[],
   spaceRecovery = false
-): { text: string; confidence: number; positions: number[] } {
+): DecodedText {
   let dict = charactersDictionary;
   if (charactersDictionary.length === numClasses - 1) {
     dict = ["", ...charactersDictionary];

--- a/src/core/recognition/line-grouping.ts
+++ b/src/core/recognition/line-grouping.ts
@@ -141,12 +141,15 @@ const MAX_MERGED_WIDTH = 16384;
  * box's share of the stitched width (its crop plus the trailing gap) for
  * mapping recognized text back to its source box.
  */
+/** One line stitched into a single canvas, with each box's share of its width. */
+export type MergedLineCrop = { mergedCanvas: CoreCanvas; mergedBox: Box; cropWidths: number[] };
+
 export function mergeLineCrop(
   sourceCanvas: CoreCanvas,
   lineBoxes: Array<{ box: Box; index: number }>,
   createCanvas: (width: number, height: number) => CoreCanvas,
   canvasOps: CanvasOps
-): { mergedCanvas: CoreCanvas; mergedBox: Box; cropWidths: number[] } {
+): MergedLineCrop {
   const minX = Math.min(...lineBoxes.map((b) => b.box.x));
   const minY = Math.min(...lineBoxes.map((b) => b.box.y));
   const maxRight = Math.max(...lineBoxes.map((b) => b.box.x + b.box.width));

--- a/src/core/recognition/strategies.ts
+++ b/src/core/recognition/strategies.ts
@@ -113,6 +113,7 @@ export async function runPerBoxStrategy(
   if (ctx.debugging.debug && cropsDebugPath) {
     const toolkit = ctx.platform.canvas.getToolkit();
     if ("clearOutput" in toolkit && typeof toolkit.clearOutput === "function") {
+      // SAFETY: guarded by the `in` check and the typeof probe on the line above.
       (toolkit as { clearOutput: (p: string) => void }).clearOutput(cropsDebugPath);
     }
   }

--- a/src/mobile/paddle-ocr.service.mobile.ts
+++ b/src/mobile/paddle-ocr.service.mobile.ts
@@ -92,6 +92,9 @@ export class PaddleOcrService extends BasePaddleOcrService {
 
   /** Create an ORT session, silently falling back to CPU if the preferred providers fail. */
   private async _createSession(modelData: Uint8Array): Promise<ort.InferenceSession> {
+    // SAFETY: createSessionWithFallback is written against the ORT namespace
+    // shape (onnxruntime-react-native ships its own copy of these types); this
+    // narrows to the one member it uses.
     return createSessionWithFallback(
       ort as unknown as { InferenceSession: typeof ort.InferenceSession },
       modelData,
@@ -150,11 +153,15 @@ export class PaddleOcrService extends BasePaddleOcrService {
       this.log(`Character dictionary loaded with ${charactersDictionary.length} entries.`);
 
       this.detector = new DetectionService(
+        // SAFETY: the session came from this class's own createSession above,
+        // so it is the runtime type DetectionService expects; only the two
+        // packages' declarations of it differ.
         detectionSession as unknown as ort.InferenceSession,
         this.options.detection,
         this.options.debugging
       );
       this.recognitor = new RecognitionService(
+        // SAFETY: as with the detection session above.
         recognitionSession as unknown as ort.InferenceSession,
         this.options.recognition,
         this.options.debugging
@@ -187,6 +194,8 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.detectionSession = await this._createSession(new Uint8Array(modelBuffer));
     // Rebuild the detector against the new session; the old one is now released.
     this.detector = new DetectionService(
+      // SAFETY: assigned by initialize() from createSession; same declaration
+      // mismatch as above.
       this.detectionSession as unknown as ort.InferenceSession,
       this.options.detection,
       this.options.debugging
@@ -207,6 +216,7 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.recognitionSession = await this._createSession(new Uint8Array(modelBuffer));
     // Rebuild the recognitor against the new session; the old one is now released.
     this.recognitor = new RecognitionService(
+      // SAFETY: as with the detection session above.
       this.recognitionSession as unknown as ort.InferenceSession,
       this.options.recognition,
       this.options.debugging
@@ -266,6 +276,8 @@ export class PaddleOcrService extends BasePaddleOcrService {
     image: ArrayBuffer | CanvasLike,
     options?: RecognizeOptions
   ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+    // SAFETY: this override widens the public parameter for callers; the base
+    // implementation probes the value before touching it.
     return super.recognize(image as ArrayBuffer | CoreCanvas, options);
   }
 

--- a/src/mobile/platform.mobile.ts
+++ b/src/mobile/platform.mobile.ts
@@ -26,11 +26,16 @@ export function getDefaultMobileExecutionProviders(): ort.InferenceSession.Sessi
 
 export class MobilePlatformProvider implements PlatformProvider<CoreCanvas> {
   public readonly pathSeparator = "/";
+  // SAFETY: onnxruntime-react-native ships its own copy of the ORT types;
+  // PlatformProvider["ort"] is the onnxruntime-common shape the core codes
+  // against, and the two describe the same runtime API.
   public readonly ort = ort as unknown as PlatformProvider["ort"];
 
   public createCanvas(width: number, height: number): CoreCanvas {
     // The Skia platform (registered by importing ppu-ocv/canvas-mobile) builds
     // the actual SkSurface-backed canvas; we just forward the dimensions.
+    // SAFETY: ppu-ocv's mobile platform returns a Skia-backed canvas that
+    // implements the CoreCanvas subset this package uses.
     return getPlatform().createCanvas(width, height) as unknown as CoreCanvas;
   }
 
@@ -66,10 +71,17 @@ export class MobilePlatformProvider implements PlatformProvider<CoreCanvas> {
   }
 
   public readonly canvas: CanvasOps<CoreCanvas> = {
+    // SAFETY: prepareCanvas decodes any supported source; the ArrayBuffer cast
+    // satisfies ppu-ocv's declared parameter, and its Skia canvas is a
+    // structural CoreCanvas.
     prepareCanvas: (image: unknown): Promise<CoreCanvas> =>
       CanvasProcessor.prepareCanvas(image as ArrayBuffer) as unknown as Promise<CoreCanvas>,
+    // SAFETY: canvases reaching here came from createCanvas above, so they are
+    // the Skia type CanvasProcessor expects; the return is re-labelled to the
+    // core's structural view of the same object.
     createProcessor: (canvas: CoreCanvas): CanvasProcessorType =>
       new CanvasProcessor(canvas as never) as unknown as CanvasProcessorType,
+    // SAFETY: the toolkit singleton is ppu-ocv's, re-labelled to the core's view.
     getToolkit: (): CanvasToolkitType =>
       CanvasToolkit.getInstance() as unknown as CanvasToolkitType,
   };

--- a/src/model-catalogue.ts
+++ b/src/model-catalogue.ts
@@ -235,6 +235,9 @@ export type ModelPreset =
  * selection (e.g. the CLI `--model` flag). Mirrors the exported `*_MODEL`
  * constants one-to-one.
  */
+// `satisfies` is the rule's preferred form, but isolatedDeclarations (required
+// for the d.ts emit) cannot infer this literal's type, so the annotation stays.
+// oxlint-disable-next-line anti-slop/no-known-value-widening
 export const MODEL_PRESETS: Readonly<Record<ModelPreset, ModelUrls>> = {
   "v6-small": V6_SMALL_MODEL,
   "v6-medium": V6_MEDIUM_MODEL,

--- a/src/processor/paddle-ocr.service.ts
+++ b/src/processor/paddle-ocr.service.ts
@@ -287,6 +287,9 @@ export class PaddleOcrService extends BasePaddleOcrService {
     } else {
       if (typeof image.toBuffer === "function") {
         const buffer = image.toBuffer("image/png");
+        // SAFETY: slice() on a Buffer's backing store returns an ArrayBuffer;
+        // the cast drops the SharedArrayBuffer arm, which node-canvas never
+        // produces.
         imageBuffer = buffer.buffer.slice(
           buffer.byteOffset,
           buffer.byteOffset + buffer.byteLength
@@ -295,6 +298,7 @@ export class PaddleOcrService extends BasePaddleOcrService {
         const ctx = image.getContext("2d");
         const imageData = ctx.getImageData(0, 0, image.width, image.height);
         const data = imageData.data;
+        // SAFETY: as above, ImageData is always backed by an ArrayBuffer.
         imageBuffer = data.buffer.slice(
           data.byteOffset,
           data.byteOffset + data.byteLength
@@ -304,6 +308,9 @@ export class PaddleOcrService extends BasePaddleOcrService {
 
     const cacheKey = ImageCache.generateKey(imageBuffer);
 
+    // SAFETY: the cache is keyed by this method's own cacheKey and only written
+    // here, so an entry under that key is a result this method stored; the
+    // Partial arm covers the flattened variant.
     const cacheResult = (
       !options?.noCache && !options?.dictionary ? globalImageCache.get(cacheKey) : undefined
     ) as (PaddleOcrResult & Partial<FlattenedPaddleOcrResult>) | undefined;
@@ -318,6 +325,7 @@ export class PaddleOcrService extends BasePaddleOcrService {
         };
       }
 
+      // SAFETY: narrowed above to the non-flattened arm.
       return cacheResult as PaddleOcrResult;
     }
 
@@ -335,7 +343,10 @@ export class PaddleOcrService extends BasePaddleOcrService {
       image instanceof ArrayBuffer ? await CanvasProcessor.prepareCanvas(image) : image;
 
     const strategy = options?.strategy ?? this.options.recognition?.strategy ?? "per-line";
+    // SAFETY: both are constructed by initialize(), and this method returns
+    // early unless the service reports itself initialized.
     const detector = this.detector as NonNullable<BasePaddleOcrService["detector"]>;
+    // SAFETY: as with the detector above.
     const recognitor = this.recognitor as NonNullable<BasePaddleOcrService["recognitor"]>;
     const detection = await detector.run(sourceCanvas);
     const recognition = await recognitor.run(
@@ -359,6 +370,8 @@ export class PaddleOcrService extends BasePaddleOcrService {
       globalImageCache.set(cacheKey, result);
     }
 
+    // SAFETY: `result` is built in this method from one of the two branches
+    // below, and the union restates exactly those two shapes.
     return result as PaddleOcrResult | FlattenedPaddleOcrResult;
   }
 

--- a/src/processor/platform.node.ts
+++ b/src/processor/platform.node.ts
@@ -18,6 +18,9 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
   public readonly ort: typeof ort = ort;
 
   public createCanvas(width: number, height: number): CoreCanvas {
+    // SAFETY: CoreCanvas is the structural subset of the canvas API this
+    // package uses, and node-canvas's Canvas implements all of it. The cast is
+    // nominal only; engine-parity tests exercise the result end to end.
     return new Canvas(width, height) as unknown as CoreCanvas;
   }
 
@@ -44,6 +47,8 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
     }
 
     const buffer = await fs.readFile(sourceToLoad);
+    // SAFETY: slice() on a Buffer's backing store returns an ArrayBuffer; the
+    // cast drops the SharedArrayBuffer arm, which fs.readFile never returns.
     return buffer.buffer.slice(
       buffer.byteOffset,
       buffer.byteOffset + buffer.byteLength
@@ -57,6 +62,8 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
   ): Promise<void> {
     await fs.mkdir(outputDir, { recursive: true });
     await CanvasToolkit.getInstance().saveImage({
+      // SAFETY: this provider only ever hands out node-canvas instances from
+      // createCanvas above, so a CoreCanvas here is one of them.
       canvas: canvas as Canvas,
       filename,
       path: outputDir,
@@ -65,12 +72,17 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
 
   public async saveImage(canvas: CoreCanvas, filePath: string): Promise<void> {
     await fs.mkdir(path.dirname(filePath), { recursive: true });
+    // SAFETY: as above, every canvas in this provider came from createCanvas.
     await fs.writeFile(filePath, (canvas as Canvas).toBuffer("image/png"));
   }
 
   public readonly canvas: CanvasOps<CoreCanvas> = {
+    // SAFETY: prepareCanvas accepts any decodable source and ppu-ocv widens the
+    // parameter itself; the ArrayBuffer cast satisfies its declared type. Its
+    // result is a node-canvas Canvas, structurally a CoreCanvas.
     prepareCanvas: (image: unknown): Promise<CoreCanvas> =>
       CanvasProcessor.prepareCanvas(image as ArrayBuffer) as Promise<CoreCanvas>,
+    // SAFETY: as above, canvases here originate from this provider.
     createProcessor: (canvas: CoreCanvas) => new CanvasProcessor(canvas as Canvas),
     getToolkit: () => CanvasToolkit.getInstance(),
   };
@@ -78,11 +90,18 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
   public readonly imageProcessor: ImageProcessorProvider<CoreCanvas> = {
     prepareCanvas: async (image: unknown): Promise<CoreCanvas> => {
       // In ppu-ocv v3, prepareCanvas lives on CanvasProcessor
+      // SAFETY: same contract as the CanvasOps.prepareCanvas above.
       return CanvasProcessor.prepareCanvas(image as ArrayBuffer) as Promise<CoreCanvas>;
     },
+    // SAFETY: ImageProcessorProvider restates ppu-ocv's classes over CoreCanvas
+    // so the core stays free of the concrete canvas type. The three casts below
+    // re-label the same runtime values; only the canvas parameter differs, and
+    // it is the structural type these classes already accept.
     ImageProcessor:
       ImageProcessor as unknown as ImageProcessorProvider<CoreCanvas>["ImageProcessor"],
+    // SAFETY: same re-labelling as ImageProcessor above.
     Contours: Contours as unknown as ImageProcessorProvider<CoreCanvas>["Contours"],
+    // SAFETY: same re-labelling; `cv` is the OpenCV.js namespace itself.
     cv: cv as unknown as ImageProcessorProvider<CoreCanvas>["cv"],
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,10 +28,17 @@ export function deepMerge<T extends Record<string, unknown>>(
 
         if (isObject(sourceValue)) {
           if (!targetValue || !isObject(targetValue)) {
+            // SAFETY: seeding the branch before recursing. The source value is a
+            // plain object (checked above), so T[key] is an object type and the
+            // recursive call fills it from the source.
             target[key] = {} as T[Extract<keyof T, string>];
           }
+          // SAFETY: both sides were checked with isObject on the lines above;
+          // deepMerge walks arbitrary option trees, hence the open record.
           deepMerge(target[key] as Record<string, unknown>, sourceValue as Record<string, unknown>);
         } else if (sourceValue !== undefined) {
+          // SAFETY: `sources` is Partial<T>, so a defined value at `key` has
+          // T's type for that key.
           target[key] = sourceValue as T[Extract<keyof T, string>];
         }
       }

--- a/src/web/paddle-ocr.service.web.ts
+++ b/src/web/paddle-ocr.service.web.ts
@@ -92,6 +92,9 @@ export class PaddleOcrService extends BasePaddleOcrService {
 
   /** Create an ORT session, silently falling back to WASM if the preferred providers fail. */
   private async _createSession(modelData: Uint8Array): Promise<ort.InferenceSession> {
+    // SAFETY: createSessionWithFallback is written against the ORT namespace
+    // shape (onnxruntime-web ships its own copy of these types); this
+    // narrows to the one member it uses.
     return createSessionWithFallback(
       ort as unknown as { InferenceSession: typeof ort.InferenceSession },
       modelData,
@@ -150,11 +153,15 @@ export class PaddleOcrService extends BasePaddleOcrService {
       this.log(`Character dictionary loaded with ${charactersDictionary.length} entries.`);
 
       this.detector = new DetectionService(
+        // SAFETY: the session came from this class's own createSession above,
+        // so it is the runtime type DetectionService expects; only the two
+        // packages' declarations of it differ.
         detectionSession as unknown as ort.InferenceSession,
         this.options.detection,
         this.options.debugging
       );
       this.recognitor = new RecognitionService(
+        // SAFETY: as with the detection session above.
         recognitionSession as unknown as ort.InferenceSession,
         this.options.recognition,
         this.options.debugging
@@ -187,6 +194,8 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.detectionSession = await this._createSession(new Uint8Array(modelBuffer));
     // Rebuild the detector against the new session; the old one is now released.
     this.detector = new DetectionService(
+      // SAFETY: assigned by initialize() from createSession; same declaration
+      // mismatch as above.
       this.detectionSession as unknown as ort.InferenceSession,
       this.options.detection,
       this.options.debugging
@@ -207,6 +216,7 @@ export class PaddleOcrService extends BasePaddleOcrService {
     this.recognitionSession = await this._createSession(new Uint8Array(modelBuffer));
     // Rebuild the recognitor against the new session; the old one is now released.
     this.recognitor = new RecognitionService(
+      // SAFETY: as with the detection session above.
       this.recognitionSession as unknown as ort.InferenceSession,
       this.options.recognition,
       this.options.debugging
@@ -266,6 +276,8 @@ export class PaddleOcrService extends BasePaddleOcrService {
     image: ArrayBuffer | CanvasLike,
     options?: RecognizeOptions
   ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+    // SAFETY: this override widens the public parameter for callers; the base
+    // implementation probes the value before touching it.
     return super.recognize(image as ArrayBuffer | CoreCanvas, options);
   }
 

--- a/src/web/platform.web.ts
+++ b/src/web/platform.web.ts
@@ -37,6 +37,8 @@ type GetContext2D = (contextId: "2d", options?: { willReadFrequently?: boolean }
  * why probing for `window` alone reads a worker as a server runtime.
  */
 export function isWebWorker(): boolean {
+  // SAFETY: probing globalThis for a global that may not exist; the annotation
+  // only says the property is optional, which is exactly what is being tested.
   return typeof (globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope === "function";
 }
 
@@ -58,6 +60,8 @@ applyDefaultWasmPaths();
 /** True when `navigator.gpu` is present and at least one adapter is available. */
 export async function isWebGpuAvailable(): Promise<boolean> {
   if (typeof navigator === "undefined") return false;
+  // SAFETY: `gpu` is absent from the DOM lib in some TS targets; the
+  // intersection declares it optional and the next line tests for it.
   const nav = navigator as Navigator & { gpu?: { requestAdapter: () => Promise<unknown | null> } };
   if (!nav.gpu || typeof nav.gpu.requestAdapter !== "function") return false;
   try {
@@ -80,6 +84,9 @@ export async function getDefaultWebExecutionProviders(): Promise<
 
 export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
   public readonly pathSeparator = "/";
+  // SAFETY: onnxruntime-web ships its own copy of the ORT types;
+  // PlatformProvider["ort"] is the onnxruntime-common shape the core codes
+  // against, and both describe the same runtime API.
   public readonly ort = ort as unknown as PlatformProvider["ort"];
 
   public createCanvas(width: number, height: number): CoreCanvas {
@@ -94,6 +101,8 @@ export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
     const getContext: GetContext2D = canvas.getContext.bind(canvas);
     getContext("2d", { willReadFrequently: true });
 
+    // SAFETY: CoreCanvas is the structural subset this package uses, and both
+    // HTMLCanvasElement and OffscreenCanvas implement it.
     return canvas as unknown as CoreCanvas;
   }
 
@@ -102,6 +111,8 @@ export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
     // Worker, so an instanceof probe throws a ReferenceError there instead of
     // returning false. Every canvas this build accepts - HTMLCanvasElement,
     // OffscreenCanvas, or a host-supplied equivalent - exposes getContext.
+    // SAFETY: this is the probe itself - the value is unknown by definition and
+    // the cast only makes the property read expressible.
     return !!image && typeof (image as Record<string, unknown>).getContext === "function";
   }
 
@@ -133,10 +144,17 @@ export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
   }
 
   public readonly canvas: CanvasOps<CoreCanvas> = {
+    // SAFETY: prepareCanvas decodes any supported source; the ArrayBuffer cast
+    // satisfies ppu-ocv's declared parameter, and its canvas is a structural
+    // CoreCanvas.
     prepareCanvas: (image: unknown): Promise<CoreCanvas> =>
       CanvasProcessor.prepareCanvas(image as ArrayBuffer) as unknown as Promise<CoreCanvas>,
+    // SAFETY: canvases here came from createCanvas above, so they are the
+    // browser type CanvasProcessor expects; the return is re-labelled to the
+    // core's structural view of the same object.
     createProcessor: (canvas: CoreCanvas): CanvasProcessorType =>
       new CanvasProcessor(canvas as never) as unknown as CanvasProcessorType,
+    // SAFETY: the toolkit singleton is ppu-ocv's, re-labelled to the core's view.
     getToolkit: (): CanvasToolkitType =>
       CanvasToolkit.getInstance() as unknown as CanvasToolkitType,
   };

--- a/tests/model-cache.test.ts
+++ b/tests/model-cache.test.ts
@@ -18,10 +18,10 @@ import { CACHE_DIR, cachePathFor, fetchAndCacheResource } from "../src/processor
 // the same model name under different directories.
 const FIRST = "detection/model.onnx";
 const SECOND = "recognition/model.onnx";
-const BODIES: Record<string, string> = {
+const BODIES = {
   [`/${FIRST}`]: "first-resource-bytes",
   [`/${SECOND}`]: "second-resource-bytes",
-};
+} satisfies Record<string, string>;
 
 let server: ReturnType<typeof Bun.serve>;
 let requests = 0;
@@ -30,7 +30,9 @@ beforeAll(() => {
   server = Bun.serve({
     port: 0,
     fetch(request) {
-      const body = BODIES[new URL(request.url).pathname];
+      const body: string | undefined = Object.entries(BODIES).find(
+        ([path]) => path === new URL(request.url).pathname
+      )?.[1];
       if (body === undefined) return new Response("not found", { status: 404 });
       requests += 1;
       return new Response(body);

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/README.md
+++ b/tools/oxlint/anti-slop/README.md
@@ -1,0 +1,15 @@
+# anti-slop (vendored)
+
+Oxlint rules from [dmmulroy/anti-slop](https://github.com/dmmulroy/anti-slop),
+copied here rather than depended on, which is how upstream intends them to be
+used: the rules encode a team's standards, so they are meant to be read and
+adapted, not pinned.
+
+Wired up in `.oxlintrc.json` under `jsPlugins`. This directory is excluded from
+linting and formatting so the project's own rules do not rewrite it.
+
+Upstream commit: see git history for the copy date. Re-vendoring means copying
+`skills/install-anti-slop/assets/anti-slop/` again and re-reading the diff.
+The Effect rule group is not vendored; this project does not use Effect.
+
+MIT, see LICENSE.

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,247 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(node);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,91 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,126 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "../shared/lexical-type-parameters.ts";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return parameterAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+	}
+	return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+	return parameter.type === "Identifier"
+		? parameter.name
+		: sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, "");
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	createOnce(context) {
+		const aliases = new Map<string, ESTree.TSType>();
+
+		const resolvesToObject = (
+			type: ESTree.TSType,
+			shadowedAliases: ReadonlySet<string>,
+			visited = new Set<string>(),
+		): boolean => {
+			if (type.type === "TSObjectKeyword") return true;
+			if (type.type === "TSParenthesizedType")
+				return resolvesToObject(type.typeAnnotation, shadowedAliases, visited);
+			if (type.type === "TSUnionType") {
+				return type.types.some((member) =>
+					resolvesToObject(member, shadowedAliases, visited),
+				);
+			}
+			if (
+				type.type !== "TSTypeReference" ||
+				type.typeName.type !== "Identifier" ||
+				(type.typeArguments !== null &&
+					type.typeArguments !== undefined &&
+					type.typeArguments.params.length > 0) ||
+				visited.has(type.typeName.name) ||
+				shadowedAliases.has(type.typeName.name)
+			) {
+				return false;
+			}
+			const alias = aliases.get(type.typeName.name);
+			if (alias === undefined) return false;
+			const nextVisited = new Set(visited);
+			nextVisited.add(type.typeName.name);
+			return resolvesToObject(alias, shadowedAliases, nextVisited);
+		};
+
+		const checkParameters = (node: ParameterOwner) => {
+			const shadowedAliases = lexicalTypeParameterNames(
+				node,
+				context.sourceCode.visitorKeys,
+			);
+			for (const parameter of node.params) {
+				const annotation = parameterAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: parameterName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				aliases.clear();
+				for (const statement of node.body) {
+					const declaration =
+						statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+					if (
+						declaration?.type === "TSTypeAliasDeclaration" &&
+						(declaration.typeParameters === null || declaration.typeParameters === undefined)
+					) {
+						aliases.set(declaration.id.name, declaration.typeAnnotation);
+					}
+				}
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,67 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression"
+	);
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isRuntimeFunction(current)) {
+			return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+		},
+		messages: {
+			runtimeTypeof:
+				"A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allowInTypeGuards: { type: "boolean" },
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ allowInTypeGuards: false }],
+	},
+	createOnce(context) {
+		return {
+			UnaryExpression(node) {
+				const option = context.options?.[0];
+				const allowInTypeGuards =
+					typeof option === "object" &&
+					option !== null &&
+					!Array.isArray(option) &&
+					option.allowInTypeGuards === true;
+				if (
+					node.operator === "typeof" &&
+					(!allowInTypeGuards || !isInsideTypeGuard(node))
+				) {
+					context.report({ node, messageId: "runtimeTypeof" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,39 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === "RestElement") {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === "RestElement") {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === "Identifier"
+    ? parameter.name
+    : sourceText.replace(/\s*:\s*unknown\s*$/u, "");
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== "TSUnknownKeyword") continue;
+        const name = parameterName(parameter, context.sourceCode.getText(parameter));
+        if (name === "cause") continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,115 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "../shared/lexical-type-parameters.ts";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
+  if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === "TSUnknownKeyword") return true;
+      if (type.type === "TSParenthesizedType") {
+        return resolvesToUnknown(type.typeAnnotation, shadowedAliases, visited);
+      }
+      if (type.type === "TSUnionType") {
+        return type.types.some((member) =>
+          resolvesToUnknown(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type === "TSTypeReference" &&
+        type.typeName.type === "Identifier" &&
+        (type.typeName.name === "Promise" || type.typeName.name === "PromiseLike")
+      ) {
+        const value = type.typeArguments?.params[0];
+        return value !== undefined && resolvesToUnknown(value, shadowedAliases, visited);
+      }
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name) || shadowedAliases.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, shadowedAliases, nextVisited);
+    };
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (
+        !resolvesToUnknown(
+          annotation.typeAnnotation,
+          lexicalTypeParameterNames(node, context.sourceCode.visitorKeys),
+        )
+      ) {
+        return;
+      }
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+          if (declaration?.type === "TSTypeAliasDeclaration") {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,70 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+	if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
+	if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
+	return type.typeArguments === null ||
+		type.typeArguments === undefined ||
+		type.typeArguments.params.length === 0
+		? type.typeName.name
+		: null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+		const resolvesToUnknown = (type: ESTree.TSType, visited = new Set<string>()): boolean => {
+			if (type.type === "TSUnknownKeyword") return true;
+			if (type.type === "TSParenthesizedType")
+				return resolvesToUnknown(type.typeAnnotation, visited);
+			const name = referencedAliasName(type);
+			if (name === null || visited.has(name)) return false;
+			const alias = aliases.get(name);
+			if (
+				alias === undefined ||
+				(alias.typeParameters !== null && alias.typeParameters !== undefined)
+			) {
+				return false;
+			}
+			const nextVisited = new Set(visited);
+			nextVisited.add(name);
+			return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+		};
+
+		return {
+			Program(node) {
+				aliases.clear();
+				for (const statement of node.body) {
+					const declaration =
+						statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+					if (declaration?.type === "TSTypeAliasDeclaration") {
+						aliases.set(declaration.id.name, declaration);
+					}
+				}
+				for (const alias of aliases.values()) {
+					if (!resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name]))) continue;
+					context.report({
+						node: alias.id,
+						messageId: "unknownAlias",
+						data: { alias: alias.id.name },
+					});
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,134 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(node);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,62 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (
+      sourceCode
+        .getCommentsBefore(current)
+        .some((comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value))
+    ) {
+      return true;
+    }
+    if (commentOwnerKinds.has(current.type) || current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+  },
+  createOnce(context) {
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node) || hasSafetyComment(context.sourceCode, node)) return;
+      context.report({ node, messageId: "missingSafetyComment" });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,502 @@
+import type { ESTree } from "@oxlint/plugins";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(program: ESTree.Program): TypeEnvironment {
+	const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+	const shadowedBuiltIns = new Set<string>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type === "ImportDeclaration") {
+			for (const specifier of declaration.specifiers) {
+				if (BUILT_INS.has(specifier.local.name)) shadowedBuiltIns.add(specifier.local.name);
+			}
+			continue;
+		}
+
+		if (declaration?.type === "TSTypeAliasDeclaration") {
+			const existing = aliases.get(declaration.id.name);
+			if (existing === undefined) aliases.set(declaration.id.name, declaration);
+			else shadowedBuiltIns.add(declaration.id.name);
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (declaration?.type === "TSInterfaceDeclaration") {
+			const declarations = interfaces.get(declaration.id.name) ?? [];
+			declarations.push(declaration);
+			interfaces.set(declaration.id.name, declarations);
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (declaration?.type === "TSEnumDeclaration") {
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (
+			(declaration?.type === "ClassDeclaration" ||
+				declaration?.type === "FunctionDeclaration") &&
+			declaration.id !== null
+		) {
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+		}
+	}
+
+	return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+	return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? unsafeMembers[0]
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if ((name === "Pick" || name === "Omit") && isBuiltIn(name, environment)) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+function resolvesToDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): boolean {
+	return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+	const alias = environment.aliases.get(name);
+	if (alias === undefined) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		return substitutions !== null &&
+			resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
+			? { kind: "generic container" }
+			: null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.every((member) =>
+			isBroadMappedKey(member, environment, substitutions),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions);
+	}
+	return name === "PropertyKey" && isBuiltIn(name, environment);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		return { kind: "open dictionary" };
+	}
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,35 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
     "isolatedDeclarations": true,
     "rootDir": "."
   },
-  "exclude": ["apps", "lib", "node_modules", ".bin-build"]
+  "exclude": ["apps", "lib", "node_modules", ".bin-build", "tools"]
 }


### PR DESCRIPTION
## What

Adopts the [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint rules, vendored under `tools/oxlint/anti-slop` and registered through the existing `.oxlintrc.json`. Ten of the fifteen rules are enforced at error level with zero violations; five are off with the conflict named at the rule.

No behavior change. OCR output on the regression corpus is byte-identical to `main`.

## Why

The rules reject patterns that look type-safe but carry no proof: chained casts that fabricate evidence, `unknown` leaking into a contract, dictionaries whose values are `any`. Enforcing them is a ratchet - the value is less in the 460 existing violations than in the ones that never get written from here on.

The five that are off would each cost more than they return here, and the reason is recorded next to each so the decision is auditable rather than folklore:

| Rule | Conflict |
| :--- | :--- |
| `no-shape-in-symbol-names` | `shape` is ONNX Runtime's own term for tensor dimensions (`tensor.shape`). Renaming `outputShape` would diverge from the API this package wraps. |
| `no-runtime-typeof` | `typeof window !== "undefined"` probes the runtime. A library spanning Node, Bun, browsers, and React Native has no I/O boundary to parse instead. |
| `no-unknown-parameters` | `prepareCanvas(image: unknown)` is public API, and §2.2 of this repo's own lint config requires `unknown` over `any` at boundaries. Changing the signatures would be a breaking change to satisfy a lint rule. |
| `no-unsafe-dictionary-type` | `deepMerge` and `isObject` walk arbitrary option trees whose values include canvases and AbortSignals. `Record<string, unknown>` is the honest contract. |
| `no-conditional-empty-object-spread` | `...(x ? { k: v } : {})` is how optional fields are built under exactOptionalPropertyTypes. |

Upstream's README says explicitly that the rules are meant to be read and adapted to the team's standards, which is why they are vendored rather than pinned.

## How

**Wiring.** `jsPlugins` is supported by the JSON config schema, so no migration to `oxlint.config.ts` was needed and the existing rules, overrides, and ignore patterns are untouched. `@oxlint/plugins` is pinned to the installed `oxlint` version. The vendored directory is excluded from lint, format, and type-check: its own code does not follow this project's rules and should not be made to.

**Assertions.** Shipped code documents each assertion with the invariant that makes it sound. They cluster into three seams:

- ORT and OpenCV.js declare types this package restates structurally (`CoreCanvas`, `ImageProcessorProvider`), so the casts re-label the same runtime value.
- `buffer.buffer.slice(...) as ArrayBuffer` drops a `SharedArrayBuffer` arm that the producing API never returns.
- `this.detector as BaseDetectionService` reads a field `initialize()` sets, behind a guard the caller already ran.

Test, bench, script, example, and playground files are exempted by an override: a failed cast there surfaces as a failing test, not a user's runtime error.

**Casts removed rather than explained**, where the type could simply be made right:

- `str(values, key)` replaces twelve `as string | undefined` casts in the CLI, mirroring the existing `num()` helper.
- `isTargetKey()` narrows the binary-target lookup, which also fixed a latent implicit `any` in `tests/cli-binary.test.ts`.
- The metrics bucket loop iterates instead of indexing, dropping two casts.
- Six anonymous object return types became named contracts: `ResizeDimensions`, `DecodedText`, `CropSource`, `MergedLineCrop`, `AsyncQueue`, and the serve envelopes.

**Two suppressions remain**, both the same cause: `isolatedDeclarations` (required for the d.ts emit) cannot infer an exported literal that `satisfies` would otherwise validate, so `MODEL_PRESETS` and `TARGETS` keep their annotations. Each says so above the disable.

**Verification.** Because this touched `ctc.ts`, `batched.ts`, and both base services, `detect()` plus all three strategies were dumped on `assets/receipt.jpg` and compared byte for byte against `main`. Identical.

### Checklist

- [x] Tests pass locally (`bun test` - 294 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

No bench: the changes are comments, named type aliases, and one loop rewritten from indexing to iteration; byte-identical output is the stronger check and it was run. No README change: nothing public moved. No new tests: no behavior changed, and the lint rules are themselves the regression guard.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

The web and mobile entries are touched only by SAFETY comments and one named type; the web suite covers them under the polyfilled runtime.

### Related

- Upstream: https://github.com/dmmulroy/anti-slop
- Re-vendoring means copying `skills/install-anti-slop/assets/anti-slop/` again and reading the diff; `tools/oxlint/anti-slop/README.md` records that.
