### PR TITLE
fix: serve models from the hugging face mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Models now download from Hugging Face.** `MODEL_BASE_URL` and
+  `DICT_BASE_URL` point at
+  `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`, a
+  mirror of the models repo that serves from a CDN. The GitHub copies are
+  behind a Git LFS bandwidth budget which, once exhausted, cuts off downloads
+  for every published version at once; the LFS batch API on that repo is
+  already refused. Paths are identical on both hosts, so a custom URL built
+  from either base keeps working, and the GitHub copies stay in place for
+  versions that reference them. Output is unchanged: the tiny preset fetched
+  from each host produces byte-identical OCR results and the model files match
+  by sha256.
+
+### Changed
+
 - **Lint:** adopted the [anti-slop](https://github.com/dmmulroy/anti-slop)
   Oxlint rules, vendored under `tools/oxlint/anti-slop`. Ten rules are enforced;
   five are turned off with the conflict named in `.oxlintrc.json` (ONNX tensor

--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ const service = new PaddleOcrService({ model: V5_THAI_MOBILE_MODEL });
 const service = new PaddleOcrService({ model: V5_ARABIC_MOBILE_MODEL });
 ```
 
-**Manual URLs** (advanced). Prefer the Hugging Face mirror: it serves models and dictionaries from one CDN-backed base, with no Git LFS bandwidth budget behind it.
+**Manual URLs** (advanced). The library's own defaults resolve from the Hugging Face mirror, which serves models and dictionaries from one CDN-backed base with no Git LFS bandwidth budget behind it. Build custom URLs from the same base.
 
 ```ts
 const BASE = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
@@ -845,11 +845,11 @@ const service = new PaddleOcrService({
 
 Paths are identical on both hosts, so the base is the only part that changes:
 
-| Host                  | Base URL                                                                                      | Notes                                            |
-| :-------------------- | :-------------------------------------------------------------------------------------------- | :----------------------------------------------- |
-| Hugging Face          | `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`                         | Preferred. One base for models and dictionaries. |
-| GitHub (models)       | `https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main` | Git LFS, subject to a bandwidth budget.          |
-| GitHub (dictionaries) | `https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main`         | Plain files, not LFS.                            |
+| Host                  | Base URL                                                                                      | Notes                                                                                   |
+| :-------------------- | :-------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| Hugging Face          | `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`                         | Preferred. One base for models and dictionaries.                                        |
+| GitHub (models)       | `https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main` | Source of truth for the files. Git LFS, subject to a bandwidth budget that can run out. |
+| GitHub (dictionaries) | `https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main`         | Plain files, not LFS.                                                                   |
 
 ### Server Models (Higher Accuracy)
 

--- a/examples/fine-tune/README.md
+++ b/examples/fine-tune/README.md
@@ -114,7 +114,7 @@ const service = new PaddleOcrService({
     recognition: "./models/my_finetuned_rec.onnx",
     // same dict your tier trained with — tiny shown:
     charactersDictionary:
-      "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main/recognition/ppocrv6_tiny_dict.txt",
+      "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main/recognition/ppocrv6_tiny_dict.txt",
   },
 });
 ```

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -154,7 +154,7 @@ The `/web` entry point always uses `canvas-native` regardless of this flag - Ope
 
 ## Default models, the cache, and how to warm it
 
-By default, `initialize()` fetches three files from `media.githubusercontent.com` and caches them under `~/.cache/ppu-paddle-ocr` (Node/Bun only):
+By default, `initialize()` fetches three files from `huggingface.co/snowfluke/ppu-paddle-ocr-models` and caches them under `~/.cache/ppu-paddle-ocr` (Node/Bun only):
 
 | Component   | File                     | Purpose                         |
 | :---------- | :----------------------- | :------------------------------ |
@@ -202,10 +202,8 @@ const english = new PaddleOcrService({ model: V5_EN_MOBILE_MODEL }); // English-
 The catalogue covers PP-OCRv6 (`V6_SMALL_MODEL` default, `V6_MEDIUM_MODEL`, `V6_TINY_MODEL`), PP-OCRv5 (English/server/INT8 + per-script: `V5_THAI_MOBILE_MODEL`, `V5_ARABIC_MOBILE_MODEL`, `V5_CYRILLIC_MOBILE_MODEL`, ...), PP-OCRv4, and PP-OCRv3. `DEFAULT_MODEL` aliases the current default. The pre-converted ONNX/`.ort` files behind every preset live in [ppu-paddle-ocr-models](https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models). To use a script-specific v5 model (or any custom export), point all three model paths at the files:
 
 ```ts
-const MODEL_BASE =
-  "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
-const DICT_BASE =
-  "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
+const MODEL_BASE = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
+const DICT_BASE = MODEL_BASE;
 
 // Thai
 const service = new PaddleOcrService({

--- a/skill-ppu-paddle-ocr/references/recipes.md
+++ b/skill-ppu-paddle-ocr/references/recipes.md
@@ -76,10 +76,8 @@ export default app;
 Keep the detection session warm, swap just the recognition model and dictionary.
 
 ```ts
-const MODEL =
-  "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
-const DICT =
-  "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/refs/heads/main";
+const MODEL = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
+const DICT = MODEL;
 
 const service = new PaddleOcrService();
 await service.initialize();

--- a/src/model-catalogue.ts
+++ b/src/model-catalogue.ts
@@ -8,12 +8,24 @@ export type ModelUrls = Readonly<{
   charactersDictionary: string;
 }>;
 
-/** Base URL for model files on GitHub. */
-export const MODEL_BASE_URL =
-  "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
-/** Base URL for dictionary files on GitHub. */
-export const DICT_BASE_URL =
-  "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
+/**
+ * Base URL for model files.
+ *
+ * The Hugging Face mirror of
+ * https://github.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models. It serves
+ * from a CDN with no Git LFS bandwidth budget behind it, which the GitHub
+ * copies have and can exhaust, cutting off downloads for every version at
+ * once. Paths are identical on both hosts, so only the base differs.
+ */
+export const MODEL_BASE_URL = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
+/**
+ * Base URL for dictionary files.
+ *
+ * Same host as {@link MODEL_BASE_URL}; kept separate because it is a public
+ * export and callers build URLs from it. On GitHub the two differed, since
+ * models came from the LFS media host and dictionaries from raw.
+ */
+export const DICT_BASE_URL = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
 
 // ─── PP-OCRv6 Models ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Points `MODEL_BASE_URL` and `DICT_BASE_URL` at the Hugging Face mirror, so `initialize()` downloads models and dictionaries from a CDN instead of Git LFS.

```
https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main
```

Both constants are public exports and both keep their names. Paths are identical on the two hosts, so a URL built from either base still resolves. Also updates the shipped skill docs, the recipes, and the fine-tune example, which named the GitHub hosts.

## Why

The models repo is over its Git LFS bandwidth budget. This is not a forecast; the batch API already refuses:

```
batch response: This repository exceeded its LFS budget.
The account responsible for the budget should increase it to restore access.
```

Installs are not failing today only because GitHub blocks the LFS batch API while `media.githubusercontent.com` keeps serving the same objects. Same budget, different door. When that one closes, every published version fails at `initialize()` on a cold cache simultaneously - there is no per-version blast radius here, because all 61 published versions resolve their models from that host at runtime.

The mirror has no such ceiling, and the GitHub copies stay in place for the versions that reference them.

## How

One-line change per constant, plus doc updates. The verification is the substance:

| Check | Result |
| :--- | :--- |
| Every catalogue path resolves on the mirror | 50/50 present |
| Cold-cache download from Hugging Face (isolated `HOME`) | 3 files actually fetched |
| sha256 of each file vs the GitHub-served copy | identical |
| `detect()` + all three strategies, HF-cold vs GitHub-cold | byte-identical |

The cold-cache isolation is load-bearing. Before #107 keyed the cache on the full URL, both runs would have read the same GitHub-cached files off disk and the comparison would have passed while proving nothing. Warm-cache users will not re-download from the new host either; their existing entries stay valid until cleared, which is intended.

### One behavioral note

Hugging Face is dual-stack; GitHub's media host resolved over IPv6 throughout my testing without trouble. During verification my own IPv6 route to Hugging Face flapped and produced a TLS reset at connect, which failed 28 of 28 test files; forced IPv4 fetched cleanly at the same moment, and the suite passed once the route recovered. That was my network, not the mirror. It does mean users behind broken IPv6 have a failure path they did not have before, and `fetchArrayBufferWithRetry`'s three attempts will not rescue them if the resolver keeps choosing the same address. Not worth pre-emptive code, but worth knowing when the first report arrives.

### Checklist

- [x] Tests pass locally (`bun test` - 294 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

No bench: this changes where bytes come from, not what happens to them, and byte-identical output is the stronger check. No new tests: the suite already downloads the default models on a cold cache, so it exercises the new host on every CI run that starts cold; asserting a specific hostname would only pin the thing most likely to change again.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

The web entry fetches these same URLs from the page. `resolve/main` returns `access-control-allow-origin` echoing the request origin, verified by direct request, so the cross-origin fetch keeps working; I have not driven it from a real browser.

### Related

- Mirror: https://huggingface.co/snowfluke/ppu-paddle-ocr-models, refreshed by the `Publish to Hugging Face` workflow in the models repo.
- Follows #107, which keyed the cache on the full URL. Without it, upgrading users would keep reading their GitHub-cached copies and this change would be untestable locally.
