### PR TITLE
fix: debug dump isolation, debug output paths, and image cache keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ private
 coverage/
 # stray test debug output
 out-test-debug/
-/Users/
 
 # Cloudflare deploy output
 playground/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Debug mode changed OCR output.** The detected-box overlay was stroked onto
+  the same canvas the recognition stage then read, so enabling
+  `debugging.debug` altered the recognized text: box outlines fall in the gaps
+  between words and swallowed the spaces. On the receipt sample the text went
+  from 382 to 377 characters. The overlay is now drawn on a copy. Reported by
+  @xirf in #101.
+- **Debug dumps ignored an absolute `debugFolder`.** `CanvasToolkit.saveImage`
+  joins its path onto `process.cwd()` unconditionally, so an absolute folder
+  was created empty while the images were written to a path rebuilt under the
+  working directory. Node now resolves the folder and writes the PNG itself,
+  which also drops the toolkit's incrementing `0. ` filename prefix and the
+  doubled `.png` on crop dumps. Reported by @xirf in #101.
+- **A failed debug dump aborted detection.** Writing debug images is wrapped so
+  a read-only filesystem returns boxes instead of an empty result. Reported by
+  @xirf in #101.
+- **Image cache keys collided on same-sized images.** `ImageCache.generateKey`
+  hashed only the first 1024 bytes plus the length, so two images sharing a
+  length and an opening run of uniform pixels got one key and the second call
+  returned the first one's text. Canvas input reaches the cache as raw RGBA,
+  where both conditions are ordinary. The key now samples across the whole
+  buffer, endpoints included. Reported by @xirf in #102.
+- **`buildBatchOptions` omitted `settle`.** The batch and stream commands set
+  it themselves, so behavior is unchanged, but the exported builder now returns
+  what the commands actually run with. Reported by @xirf in #103.
+
 ### Changed
 
 - **Models now download from Hugging Face.** `MODEL_BASE_URL` and

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -108,7 +108,6 @@ export async function runBatch(patterns: string[], values: CliValues): Promise<v
     };
     const settled = await service.batchRecognize(inputs(), {
       ...buildBatchOptions(values),
-      settle: true,
       onProgress: (done) => logStderr(`  ${done}/${files.length}`, Boolean(values.quiet)),
     });
 
@@ -152,10 +151,7 @@ export async function runStream(patterns: string[], values: CliValues): Promise<
     const inputs = async function* (): AsyncGenerator<ArrayBuffer> {
       for (const file of files) yield loadImageInput(file);
     };
-    for await (const item of service.batchRecognizeStream(inputs(), {
-      ...buildBatchOptions(values),
-      settle: true,
-    })) {
+    for await (const item of service.batchRecognizeStream(inputs(), buildBatchOptions(values))) {
       const file = files[item.index] ?? "?";
       if (item.status === "fulfilled") {
         const entry: BatchEntry = { file, status: "fulfilled", result: item.value };

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -60,7 +60,7 @@ Session:
 
 Batch / stream:
   --concurrency <n|auto>         images in flight at once (default auto)
-  --settle                       keep going past a failed image (default on for batch/stream)
+  --settle                       keep going past a failed image (always on for batch/stream)
 
 Output:
   -o, --output <file>            write to a file instead of stdout

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -238,8 +238,11 @@ export function buildRecognizeOptions(values: CliValues): RecognizeOptions {
   };
 }
 
-/** Batch options: recognize options plus concurrency/settle. */
-export function buildBatchOptions(values: CliValues): BatchRecognizeOptions {
+/**
+ * Batch options: recognize options plus concurrency. `settle` is part of the
+ * return type, not a choice, so the batch commands select the settled overload.
+ */
+export function buildBatchOptions(values: CliValues): BatchRecognizeOptions & { settle: true } {
   const raw = str(values, "concurrency");
   let concurrency: number | "auto" | undefined;
   if (raw !== undefined) {
@@ -254,5 +257,10 @@ export function buildBatchOptions(values: CliValues): BatchRecognizeOptions {
   return {
     ...buildRecognizeOptions(values),
     ...(concurrency !== undefined ? { concurrency } : {}),
+    // Batch and stream always settle: one unreadable file must not throw away
+    // the results of every other image, and the command still exits non-zero
+    // by counting the rejected entries afterwards. `--settle` is accepted for
+    // compatibility and names this default rather than switching it.
+    settle: true,
   };
 }

--- a/src/core/base-detection.service.ts
+++ b/src/core/base-detection.service.ts
@@ -103,8 +103,14 @@ export class BaseDetectionService {
       const detectedBoxes = this.postprocessDetection(detection, input);
 
       if (this.debugging.debug && this.debugging.debugFolder && this.lastDetectionCanvas) {
-        await this.debugDetectionCanvas(this.lastDetectionCanvas, input.width, input.height);
-        await this.debugDetectedBoxes(canvasToProcess, detectedBoxes);
+        // A debug dump is an observation, not a step: a read-only filesystem or
+        // a full disk must not turn a successful detection into zero boxes.
+        try {
+          await this.debugDetectionCanvas(this.lastDetectionCanvas, input.width, input.height);
+          await this.debugDetectedBoxes(canvasToProcess, detectedBoxes);
+        } catch (error) {
+          this.log(`Debug dump failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
       }
 
       this.log(`Detected ${detectedBoxes.length} text boxes in image`);
@@ -368,11 +374,16 @@ export class BaseDetectionService {
    * Debug the bounding boxes by drawing a rectangle onto the original image
    */
   private async debugDetectedBoxes(image: ArrayBuffer | CoreCanvas, boxes: Box[]): Promise<void> {
-    const canvas = this.platform.isCanvas(image)
+    const source = this.platform.isCanvas(image)
       ? image
       : await this.platform.canvas.prepareCanvas(image);
 
+    // Draw on a copy. The caller's canvas goes on to the recognition stage, and
+    // box outlines land in the gaps between words: stroking the source turns
+    // debug mode into a different image than the one production reads.
+    const canvas = this.platform.createCanvas(source.width, source.height);
     const ctx = canvas.getContext("2d");
+    ctx.drawImage(source, 0, 0);
 
     for (const box of boxes) {
       const { x, y, width, height } = box;

--- a/src/core/image-cache.ts
+++ b/src/core/image-cache.ts
@@ -2,6 +2,17 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 /**
+ * How many bytes {@link ImageCache.generateKey} reads. Bounded so the cost stays
+ * flat on large scans: a full-resolution photo reaches here as tens of megabytes
+ * of raw RGBA, and hashing all of it would cost more than the OCR it saves.
+ *
+ * ponytail: sampled hash, not a digest of every byte - two images differing only
+ * at unsampled indices still collide. Raise this, or switch to a real hash over
+ * the whole buffer, if a collision is ever observed in practice.
+ */
+const MAX_KEY_SAMPLES = 4096;
+
+/**
  * Simple LRU cache for processed images to avoid redundant processing
  */
 export class ImageCache {
@@ -53,12 +64,22 @@ export class ImageCache {
    * Generate cache key from image data
    */
   static generateKey(imageBuffer: ArrayBuffer): string {
-    // Simple hash based on first few bytes and length
+    // Sample across the whole buffer rather than its first bytes. Canvas input
+    // reaches here as raw RGBA, so two same-sized images share a length and a
+    // header of uniform margin pixels; hashing only the head hands one image's
+    // cached result to the other.
     const view = new Uint8Array(imageBuffer);
-    const len = Math.min(view.length, 1024);
+    if (view.length === 0) return "0_0";
+
+    // Sample positions span the buffer end to end, so a difference in the last
+    // byte counts as much as one in the first. A fixed stride would stop short
+    // of the tail on any buffer that is not an exact multiple of it.
+    const samples = Math.min(view.length, MAX_KEY_SAMPLES);
+    const last = view.length - 1;
     let hash = 0;
-    for (let i = 0; i < len; i++) {
-      hash = (hash << 5) - hash + view[i];
+    for (let k = 0; k < samples; k++) {
+      const index = samples === 1 ? 0 : Math.round((k * last) / (samples - 1));
+      hash = (hash << 5) - hash + (view[index] ?? 0);
       hash = hash & hash; // Convert to 32-bit integer
     }
     return `${hash}_${view.length}`;

--- a/src/processor/platform.node.ts
+++ b/src/processor/platform.node.ts
@@ -60,14 +60,16 @@ export class NodePlatformProvider implements PlatformProvider<CoreCanvas> {
     filename: string,
     outputDir: string
   ): Promise<void> {
-    await fs.mkdir(outputDir, { recursive: true });
-    await CanvasToolkit.getInstance().saveImage({
-      // SAFETY: this provider only ever hands out node-canvas instances from
-      // createCanvas above, so a CoreCanvas here is one of them.
-      canvas: canvas as Canvas,
-      filename,
-      path: outputDir,
-    });
+    // CanvasToolkit.saveImage joins the output path onto process.cwd()
+    // unconditionally, so an absolute debugFolder lands under the working
+    // directory instead. Resolve it here and write the buffer directly, which
+    // also drops the toolkit's incrementing "0. " filename prefix.
+    const dir = path.resolve(outputDir);
+    const file = filename.endsWith(".png") ? filename : `${filename}.png`;
+    await fs.mkdir(dir, { recursive: true });
+    // SAFETY: this provider only ever hands out node-canvas instances from
+    // createCanvas above, so a CoreCanvas here is one of them.
+    await fs.writeFile(path.join(dir, file), (canvas as Canvas).toBuffer("image/png"));
   }
 
   public async saveImage(canvas: CoreCanvas, filePath: string): Promise<void> {

--- a/tests/image-cache.test.ts
+++ b/tests/image-cache.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { ImageCache } from "../src/core/image-cache.js";
+
+/**
+ * The cache key stands in for the whole image. Two different images that map to
+ * one key make `recognize()` return the first one's text for the second, so the
+ * key has to depend on bytes throughout the buffer, not just its head.
+ */
+
+describe("ImageCache.generateKey", () => {
+  test("separates buffers that share a header and a length", () => {
+    // The shape canvas input takes: raw RGBA of the same dimensions, so the
+    // lengths match, opening with identical uniform-margin pixels. The bodies
+    // differ the way two documents do, over a region rather than one byte.
+    const a = new Uint8Array(8192).fill(255, 0, 2048);
+    const b = new Uint8Array(8192).fill(255, 0, 2048);
+    a.fill(42, 5000, 5200);
+    b.fill(99, 5000, 5200);
+
+    expect(ImageCache.generateKey(a.buffer)).not.toBe(ImageCache.generateKey(b.buffer));
+  });
+
+  test("separates buffers that differ only in their last bytes", () => {
+    const a = new Uint8Array(1 << 20);
+    const b = new Uint8Array(1 << 20);
+    a[a.length - 1] = 1;
+
+    expect(ImageCache.generateKey(a.buffer)).not.toBe(ImageCache.generateKey(b.buffer));
+  });
+
+  test("is stable for equal buffers", () => {
+    const a = new Uint8Array([1, 2, 3, 4, 5]);
+    const b = new Uint8Array([1, 2, 3, 4, 5]);
+
+    expect(ImageCache.generateKey(a.buffer)).toBe(ImageCache.generateKey(b.buffer));
+  });
+
+  test("separates buffers of different lengths with the same content", () => {
+    const a = new Uint8Array(64).fill(7);
+    const b = new Uint8Array(65).fill(7);
+
+    expect(ImageCache.generateKey(a.buffer)).not.toBe(ImageCache.generateKey(b.buffer));
+  });
+});

--- a/tests/strategies-options.test.ts
+++ b/tests/strategies-options.test.ts
@@ -96,6 +96,45 @@ describe("debugging options", () => {
     if (existsSync(debugFolder)) rmSync(debugFolder, { recursive: true, force: true });
   });
 
+  test("debug dumps do not change recognition output", async () => {
+    // The box overlay used to be stroked onto the canvas the recognition stage
+    // then read, so turning on debug silently changed the text: outlines land
+    // in the gaps between words and swallow the spaces.
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const plain = new PaddleOcrService();
+      await plain.initialize();
+      const withoutDebug = await plain.recognize(imageBuffer, { noCache: true, flatten: true });
+      await plain.destroy();
+
+      const debugged = new PaddleOcrService({ debugging: { debug: true, debugFolder } });
+      await debugged.initialize();
+      const withDebug = await debugged.recognize(imageBuffer, { noCache: true, flatten: true });
+      await debugged.destroy();
+
+      expect(withDebug.text).toBe(withoutDebug.text);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }, 60000);
+
+  test("debug dumps land in an absolute debugFolder", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const service = new PaddleOcrService({ debugging: { debug: true, debugFolder } });
+      await service.initialize();
+      await service.recognize(imageBuffer, { noCache: true });
+      await service.destroy();
+
+      // Not under a path rebuilt from the working directory, which is where an
+      // absolute folder used to end up.
+      expect(existsSync(join(debugFolder, "boxes-debug.png"))).toBe(true);
+      expect(existsSync(join(process.cwd(), debugFolder))).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }, 30000);
+
   test("verbose + debug exercise the logging and dump paths", async () => {
     // Run the verbose/debug code paths for coverage, but silence the console so
     // the suite output stays clean (the calls still execute, just to a no-op).


### PR DESCRIPTION
## What

Four fixes reported by @xirf across #101, #102, and #103, reworked onto current `main` with regression tests. Supersedes all three; those PRs are closed with credit.

| Fix | Reported in |
| :--- | :--- |
| Debug overlay no longer mutates the canvas recognition reads | #101 |
| An absolute `debugFolder` receives the dumps | #101 |
| A failed debug dump no longer aborts detection | #101 |
| Cache key samples the whole buffer instead of its first 1024 bytes | #102 |
| `buildBatchOptions` returns the `settle` the commands run with | #103 |

## Why

**Debug mode changed OCR output.** `debugDetectedBoxes` stroked box outlines onto the canvas the caller passes in, which is the same object the recognition stage reads next. The outlines fall in the gaps between words:

```
debug off: 382 chars   "ALFAMART ARTHA GADING N / 081294665105"
debug on:  377 chars   "ALFAMART ARTHA GADING N /081294665105"
```

So anyone who enabled `debug` to investigate an accuracy problem was measuring a different image than their production runs produce, and the tool for diagnosing accuracy was itself changing accuracy.

**Debug dumps went to the wrong directory.** `CanvasToolkit.saveImage` joins its path onto `process.cwd()` with no check for an absolute one. `debugFolder: "/tmp/dbg"` created `/tmp/dbg` empty and wrote the images to `<cwd>/tmp/dbg`. This repository has been leaking its own dumps that way: the suite uses an absolute `debugFolder`, and a `/Users/` entry in `.gitignore` was hiding the 1.4 MB tree it produced under the working directory on every run. That entry is deleted along with the bug.

**Cache keys collided on same-sized images.** `generateKey` hashed the first 1024 bytes plus the length, so two images sharing a length and an opening run of identical pixels shared a key, and `recognize()` returned the first one's text for the second. Neither condition is adversarial: canvas input reaches the cache as raw RGBA, so any two images of the same dimensions have the same length, and the first 1024 bytes are the first 256 pixels of the top row, which is uniform margin in most documents. Two 600x200 canvases with white margins and different text both hash to `750239744_480000` on `main`.

## How

Each fix carries a test that fails without it.

**Overlay.** Drawn on a copy. `tests/strategies-options.test.ts` recognizes the same image with debug on and off and compares the text; pointing the overlay back at the source canvas fails it, which I verified by doing exactly that.

**Debug path.** Node resolves the folder and writes the PNG itself. That drops the toolkit's incrementing `0. ` filename prefix, which numbered by call order rather than content, and stops crop dumps landing as `crop_019.png.png`. A second test asserts the file appears under the absolute folder and that no path rebuilt from the working directory exists.

**Cache key.** Samples up to 4096 positions spread end to end, `round(k * (len - 1) / (samples - 1))`. The inclusive span is deliberate and is where this differs from #102: a fixed stride stops short of the tail, so a difference in the final byte would not be seen. My own test caught that, which is why the formula is not a plain stride.

It remains a sampled hash rather than a digest, and the code says so with a `ponytail:` marker naming the upgrade path. Two images differing only at unsampled indices still collide; hashing every byte of a full-resolution scan would cost more than the OCR it saves.

**settle.** Inverted relative to #103. Rather than forwarding a value both call sites immediately overwrite, `buildBatchOptions` now carries `settle: true` in its return type and the call sites stop restating it. Behavior is unchanged. `--settle` keeps working and now reads as naming the default rather than switching it: there is no way to turn it off and no reason to offer one, because the command already exits non-zero by counting rejected entries.

### Checklist

- [x] Tests pass locally (`bun test` - 300 pass, up from 294)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

The cache key is on the `recognize()` path, so it is worth being explicit about cost rather than benching it: the old key read at most 1024 bytes, the new one at most 4096, both bounded and both dwarfed by the decode that follows. No README change: no public option or default moved.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

`saveDebugImage` is a no-op on web and mobile, so the path fix is Node-only. The overlay and cache-key fixes are in shared code and apply everywhere.

### Related

- Supersedes #101, #102, #103. Every bug here was found by @xirf; the diffs differ, the diagnoses do not.
- #104 and #105 stay open. #105's per-call overrides are inert on Node because `PaddleOcrService` overrides `recognize` and calls the recognitor directly, which is exactly what #104 unifies, so that pair wants finishing in order.
