### PR TITLE
chore: release 6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.2] - 2026-08-25
+
 ### Changed
 
 - **Models now download from Hugging Face.** `MODEL_BASE_URL` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Models now download from Hugging Face.** `MODEL_BASE_URL` and
+  `DICT_BASE_URL` point at
+  `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`, a
+  mirror of the models repo that serves from a CDN. The GitHub copies are
+  behind a Git LFS bandwidth budget which, once exhausted, cuts off downloads
+  for every published version at once; the LFS batch API on that repo is
+  already refused. Paths are identical on both hosts, so a custom URL built
+  from either base keeps working, and the GitHub copies stay in place for
+  versions that reference them. Output is unchanged: the tiny preset fetched
+  from each host produces byte-identical OCR results and the model files match
+  by sha256.
+- **Lint:** adopted the [anti-slop](https://github.com/dmmulroy/anti-slop)
+  Oxlint rules, vendored under `tools/oxlint/anti-slop`. Ten rules are enforced;
+  five are turned off with the conflict named in `.oxlintrc.json` (ONNX tensor
+  `shape` naming, runtime environment probes, `unknown` at public boundaries,
+  the option-tree dictionary contract, and conditional-spread optional fields).
+  Type assertions in shipped code now carry a `SAFETY:` comment stating the
+  invariant that makes them sound; test, bench, script, and example files are
+  exempted. Anonymous object return types were replaced by named contracts
+  (`ResizeDimensions`, `DecodedText`, `CropSource`, `MergedLineCrop`,
+  `AsyncQueue`, and the serve envelopes), and a `str()` flag reader replaced
+  twelve `as string | undefined` casts in the CLI. No behavior change: OCR
+  output on the regression corpus is byte-identical.
+- **Docs:** the README now points manual model URLs at the Hugging Face
+  mirror (`https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`),
+  which serves models and dictionaries from one base with no Git LFS
+  bandwidth budget behind it. Paths are identical on both hosts. The
+  library's own defaults still resolve from GitHub.
+
 ### Fixed
 
 - **Debug mode changed OCR output.** The detected-box overlay was stroked onto
@@ -33,43 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`buildBatchOptions` omitted `settle`.** The batch and stream commands set
   it themselves, so behavior is unchanged, but the exported builder now returns
   what the commands actually run with. Reported by @xirf in #103.
-
-### Changed
-
-- **Models now download from Hugging Face.** `MODEL_BASE_URL` and
-  `DICT_BASE_URL` point at
-  `https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`, a
-  mirror of the models repo that serves from a CDN. The GitHub copies are
-  behind a Git LFS bandwidth budget which, once exhausted, cuts off downloads
-  for every published version at once; the LFS batch API on that repo is
-  already refused. Paths are identical on both hosts, so a custom URL built
-  from either base keeps working, and the GitHub copies stay in place for
-  versions that reference them. Output is unchanged: the tiny preset fetched
-  from each host produces byte-identical OCR results and the model files match
-  by sha256.
-
-### Changed
-
-- **Lint:** adopted the [anti-slop](https://github.com/dmmulroy/anti-slop)
-  Oxlint rules, vendored under `tools/oxlint/anti-slop`. Ten rules are enforced;
-  five are turned off with the conflict named in `.oxlintrc.json` (ONNX tensor
-  `shape` naming, runtime environment probes, `unknown` at public boundaries,
-  the option-tree dictionary contract, and conditional-spread optional fields).
-  Type assertions in shipped code now carry a `SAFETY:` comment stating the
-  invariant that makes them sound; test, bench, script, and example files are
-  exempted. Anonymous object return types were replaced by named contracts
-  (`ResizeDimensions`, `DecodedText`, `CropSource`, `MergedLineCrop`,
-  `AsyncQueue`, and the serve envelopes), and a `str()` flag reader replaced
-  twelve `as string | undefined` casts in the CLI. No behavior change: OCR
-  output on the regression corpus is byte-identical.
-- **Docs:** the README now points manual model URLs at the Hugging Face
-  mirror (`https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main`),
-  which serves models and dictionaries from one base with no Git LFS
-  bandwidth budget behind it. Paths are identical on both hosts. The
-  library's own defaults still resolve from GitHub.
-
-### Fixed
-
 - **Model cache collisions.** The Node/Bun cache keyed entries on the file name
   alone, so two resources sharing a name (a custom model and a preset, or the
   same path on two hosts) served each other's bytes. Entries now sit under a

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -80,12 +80,12 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 // success
 {
   "status": "success",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "metadata": { "id": "<request-id>", "speed": 0.27, "confidence": 0.95, "engine": "opencv", "strategy": "per-line" },
   "data": { "text": "...", "lines": [ ... ], "confidence": 0.95 }
 }
 // error
-{ "status": "error", "version": "0.3.3", "data": { "message": "...", "requestId": "<request-id>" } }
+{ "status": "error", "version": "0.3.4", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
 `/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr-serve",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "description": "Production-grade REST API serving ppu-paddle-ocr (Hono + Bun).",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -91,7 +91,7 @@ if (config.docsEnabled) {
     openapi: "3.1.0",
     info: {
       title: "ppu-paddle-ocr-serve",
-      version: "0.3.3",
+      version: "0.3.4",
       description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
     },
   });

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
-export const API_VERSION = "0.3.3";
+export const API_VERSION = "0.3.4";
 
 /** Success envelope shape: `{ status, version, metadata: { id, ... }, data }`. */
 export type SuccessEnvelope<T> = {

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-paddle-ocr",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-paddle-ocr",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "Lightweight, probably the fastest PaddleOCR SDK in TypeScript. Runs anywhere JavaScript runs: Node.js, Bun, Deno, mobile react-native, web worker, web browsers, and browser extensions. Docker & CLI supported. The official SDK is browser-only. Accurate text detection and recognition for documents, data extraction, and computer vision.",
   "keywords": [
     "accurate-ocr",

--- a/playground/index.html
+++ b/playground/index.html
@@ -2338,7 +2338,7 @@
             // Fallback to npm CDN
             console.warn("Local build failed to load:", e);
             console.log("Falling back to CDN...");
-            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.4.1/web/index.js");
+            mod = await import("https://cdn.jsdelivr.net/npm/ppu-paddle-ocr@6.4.2/web/index.js");
           }
         }
         PaddleOcrService = mod.PaddleOcrService;


### PR DESCRIPTION
## What

Cuts release 6.4.2. `bun bump 6.4.2` rewrote every version touchpoint and promoted `[Unreleased]` into `[6.4.2] - 2026-08-25`. A preceding commit consolidates the changelog section; no source changes in this PR.

| Touchpoint | Change |
| :--- | :--- |
| `package.json`, `jsr.json` | 6.4.1 -> 6.4.2 |
| `playground/index.html` | CDN fallback pin -> `ppu-paddle-ocr@6.4.2` |
| `CHANGELOG.md` | `[Unreleased]` -> `[6.4.2] - 2026-08-25` |
| `apps/serve` (4 files) | REST envelope 0.3.3 -> 0.3.4 |

## Why

Nine changes have landed since 6.4.1, and two of them are worth shipping promptly rather than waiting for more:

- **Debug mode changed OCR output.** Box overlays were drawn onto the canvas the recognition stage reads, so enabling `debugging.debug` altered the recognized text. The tool for investigating accuracy was changing accuracy.
- **Model downloads moved to the Hugging Face mirror**, off a Git LFS bandwidth budget that is already exhausted on the models repo. The GitHub media host still serves today, which is the only reason installs are not failing, but it draws on the same budget.

Patch rather than minor: nine entries and not one adds, removes, or changes public API. `MODEL_BASE_URL` changed value while keeping its name and type. The cache re-key and the host move each cost one extra download on first run after upgrading, which is compatible behavior, not a break.

The serve app takes its default patch bump this cycle, and it is warranted: `api-response.ts` and `metrics.ts` both changed under the anti-slop refactor.

## How

Ran `bun bump 6.4.2` on a release branch, per the [Cutting a release](../blob/main/CONTRIBUTING.md#cutting-a-release) runbook.

The first commit is separate on purpose. `[Unreleased]` had accumulated two `### Changed` groups and two `### Fixed` groups from being prepended across five PRs; `bun bump` sorts sections into Keep a Changelog order but does not merge duplicate headings, so the release section would have shipped with repeated headings. Consolidating it first keeps the bump commit mechanical and reviewable on its own.

### Checklist

- [x] Tests pass locally (`bun test` - 300 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [ ] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

No bench: this PR carries no source change. No README change: nothing public moved, and the model host was already documented when it changed. Tests came with the PRs being released.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

`bun run build` also verified locally.

### Related

- Releases #107 (cache keyed on the full URL, Hugging Face docs), #108 (anti-slop lint rules), #109 (models served from the mirror), and #110 (debug isolation, debug output paths, image cache keys).
- The debug and cache-key bugs in #110 were reported by @xirf in #101, #102, and #103.
- After merge: signed tag, `gh release create v6.4.2`, then `gh workflow run deploy-serve.yml`. The release also triggers `cli-binaries.yml`, so the standalone executables land a few minutes later.
