### PR TITLE
fix: stop the demo sending a referer hugging face rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Web demo could not load models.** Hugging Face returns `404` for requests
+  carrying a `*.workers.dev` referer, and a 404 response has no CORS headers,
+  so the browser reported it as "No 'Access-Control-Allow-Origin' header is
+  present" rather than as the 404 it was. The demo is hosted on workers.dev, so
+  every model fetch failed after the 6.4.2 move to the mirror. The page now
+  sends `Referrer-Policy: no-referrer`, which nothing there needs. Only pages
+  whose origin Hugging Face blocklists are affected; `pages.dev`, `vercel.app`,
+  `netlify.app`, and localhost all serve normally, as do Node and Bun, which
+  send no referer at all.
+
 ## [6.4.2] - 2026-08-25
 
 ### Changed

--- a/playground/_headers
+++ b/playground/_headers
@@ -1,3 +1,4 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
+  Referrer-Policy: no-referrer

--- a/playground/index.html
+++ b/playground/index.html
@@ -2,6 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Hugging Face returns 404 for model requests carrying a *.workers.dev
+         referer, and a 404 has no CORS headers, so the browser reports it as a
+         CORS failure. Nothing needs the referer here. The _headers file sets
+         this too; the meta tag covers local dev, which is served without it. -->
+    <meta name="referrer" content="no-referrer" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta
       name="description"


### PR DESCRIPTION
## What

Sends `Referrer-Policy: no-referrer` from the playground, via `playground/_headers` and a `<meta name="referrer">` for local dev. Two lines of configuration; no source change.

## Why

The demo could not load models after 6.4.2 moved them to the Hugging Face mirror. The browser reported:

```
Access to fetch at 'https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main/detection/ort/PP-OCRv6_tiny_det.ort'
from origin 'https://ppu-paddle-ocr.snowfluke.workers.dev' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

That message is a symptom, not the cause. Hugging Face returns `404` for requests carrying a `*.workers.dev` referer, and a 404 response has no CORS headers, so the browser blames CORS. The demo happens to be hosted on workers.dev.

Same URL, same everything, varying only the referer:

| `Referer` | Result |
| :--- | :--- |
| `ppu-paddle-ocr.snowfluke.workers.dev` | **404** |
| `unrelated-name.workers.dev` | **404** |
| `other.pages.dev` | 302 -> 200 |
| `foo.vercel.app` | 302 -> 200 |
| `foo.netlify.app` | 302 -> 200 |
| `example.com`, `localhost:3000` | 302 -> 200 |
| none | 302 -> 200 |
| the same request to the old GitHub media host, workers.dev referer | 200 |

So this is a blocklist on the host the demo sits on, not a problem with the mirror, the model URLs, or the web build. Node, Bun, and CI send no referer and were never affected; the 6.4.2 release CI downloaded these exact files from the mirror on a cold cache.

Worth stating plainly because the error message sends you the wrong way: this is not a CORS misconfiguration and not COEP. `require-corp` does not block it either, since cors-mode requests are exempt per the [COEP definition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy), and the library fetches with a plain `fetch(url, { signal })`.

## How

The page has no use for a referer, so it sends none. `Referrer-Policy: no-referrer` in `_headers` covers the deployed site; the meta tag covers `bun run demo`, which serves without that file.

The default policy is not enough: `strict-origin-when-cross-origin` still sends the bare origin, and `Referer: https://ppu-paddle-ocr.snowfluke.workers.dev` (no path) is refused the same way, which I measured.

Verified by replaying the exact request with and without the header. After merge, Cloudflare redeploys on push, so the fix reaches production without a release.

### Checklist

- [x] Tests pass locally (`bun test` - 300 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

No bench: configuration only. No README change: nothing about the library's public surface moved. No new test: the behaviour under test belongs to a third-party host and a browser header, neither of which the suite can exercise; `tests/playground.test.ts` still passes.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

Node and Bun are listed because the suite runs there, not because they were affected. The browser rows stay unticked until the deployed page is reloaded and confirmed.

### Related

- Follows #109, which moved `MODEL_BASE_URL` to the mirror.
- Anyone embedding the library in a page whose origin Hugging Face blocklists hits the same wall. A library-side `referrerPolicy: "no-referrer"` on the model fetches would cover them without each site knowing to set a header; that is a source change and a release, so it is not in this PR.
