### PR TITLE
feat: cache models, fix sample switching, and report real load failures in the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The web demo caches models in the browser.** They are stored by URL in
+  IndexedDB after the first download and reused on later loads, so a reload no
+  longer re-fetches tens of megabytes. A "Clear cached models" button in the
+  configuration panel drops them. IndexedDB rather than the Cache API because
+  Hugging Face redirects model requests to its CDN, and `Cache.put()` refuses a
+  redirected response.
+
 ### Fixed
 
+- **Web demo: switching sample images needed a page reload.** The sample chips
+  were inside the placeholder element that gets hidden once an image loads, so
+  choosing one sample hid the row offering the others.
+- **Web demo: model load failures reported nothing useful.** A cross-origin
+  failure surfaces as a bare `TypeError`, so the demo now re-asks in `no-cors`
+  mode to tell "the server answered and the browser withheld it" from "the host
+  was never reached", and keeps the prefetch's diagnosis instead of discarding
+  it. It also drops the per-file `HEAD` probe, which was a second request and a
+  second way to fail for a size each `GET` already reports, and retries a
+  refused file against the GitHub original.
 - **Web demo could not load models.** Hugging Face returns `404` for requests
   carrying a `*.workers.dev` referer, and a 404 response has no CORS headers,
   so the browser reported it as "No 'Access-Control-Allow-Origin' header is

--- a/playground/index.html
+++ b/playground/index.html
@@ -676,12 +676,23 @@
         }
       }
       /* Sample image chips in the empty state */
+      /* Pinned to the panel rather than sitting in the placeholder, so the
+         samples stay reachable once an image is on the canvas. */
       .sample-row {
+        position: absolute;
+        z-index: 11;
+        left: 50%;
+        bottom: 0.6rem;
+        transform: translateX(-50%);
         display: flex;
         flex-wrap: wrap;
         gap: 0.4rem;
         justify-content: center;
-        margin-top: 0.75rem;
+        max-width: calc(100% - 1.2rem);
+        padding: 0.4rem 0.55rem;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--bg-card);
       }
       .sample-chip {
         padding: 0.25rem 0.6rem;
@@ -1787,6 +1798,15 @@
                     inputmode="url"
                   />
                 </div>
+                <div class="input-group">
+                  <button type="button" class="btn-reset" id="btn-clear-model-cache">
+                    Clear cached models
+                  </button>
+                  <p class="field-help" id="model-cache-hint">
+                    Models stay in this browser after the first download, so a reload does not fetch
+                    them again.
+                  </p>
+                </div>
               </div>
             </details>
 
@@ -2063,56 +2083,59 @@
                 <polyline points="21 15 16 10 5 21" />
               </svg>
               <p>Upload an image to begin</p>
-              <div class="sample-row" id="sample-row">
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="receipt.jpg"
-                  data-label="receipt"
-                >
-                  Receipt photo
-                </button>
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="tilted.png"
-                  data-label="tilted"
-                >
-                  Tilted text
-                </button>
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="config-matrix/dark-dense-portrait.png"
-                  data-label="dark app UI"
-                >
-                  Dark app UI
-                </button>
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="config-matrix/light-sparse-portrait.png"
-                  data-label="form"
-                >
-                  Form
-                </button>
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="config-matrix/light-dense-landscape.png"
-                  data-label="document"
-                >
-                  Document page
-                </button>
-                <button
-                  type="button"
-                  class="sample-chip"
-                  data-sample="config-matrix/low-contrast-photo-landscape.png"
-                  data-label="low contrast"
-                >
-                  Low contrast
-                </button>
-              </div>
+            </div>
+            <!-- Outside #result-placeholder on purpose: the placeholder is
+                 hidden once an image loads, and these chips used to go with it,
+                 so switching samples needed a page reload. -->
+            <div class="sample-row" id="sample-row">
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="receipt.jpg"
+                data-label="receipt"
+              >
+                Receipt photo
+              </button>
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="tilted.png"
+                data-label="tilted"
+              >
+                Tilted text
+              </button>
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="config-matrix/dark-dense-portrait.png"
+                data-label="dark app UI"
+              >
+                Dark app UI
+              </button>
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="config-matrix/light-sparse-portrait.png"
+                data-label="form"
+              >
+                Form
+              </button>
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="config-matrix/light-dense-landscape.png"
+                data-label="document"
+              >
+                Document page
+              </button>
+              <button
+                type="button"
+                class="sample-chip"
+                data-sample="config-matrix/low-contrast-photo-landscape.png"
+                data-label="low contrast"
+              >
+                Low contrast
+              </button>
             </div>
             <div class="model-error" id="model-error" role="alert" hidden>
               <strong>OCR models unavailable</strong>
@@ -2697,7 +2720,10 @@
           serviceReady = true;
           btnProcess.disabled = !loadedImage;
           setSamplesEnabled(true);
-          setStatus("ready", "Ready");
+          setStatus("ready", servedFromCache > 0 ? "Ready (cached models)" : "Ready");
+          if (usedFallbackHost && modelCacheHint) {
+            modelCacheHint.textContent = "The mirror refused a file, so GitHub served it instead.";
+          }
           console.log("✅ Service initialized successfully");
           return true;
         } catch (err) {
@@ -2705,7 +2731,11 @@
           btnProcess.disabled = true;
           resultPlaceholder.style.display = "none";
           const message = err instanceof Error ? err.message : String(err);
-          modelErrorMessage.textContent = `${message} Check your connection or model URLs, then retry.`;
+          const detail =
+            lastPrefetchError && !message.includes(lastPrefetchError)
+              ? ` ${lastPrefetchError}.`
+              : "";
+          modelErrorMessage.textContent = `${message}.${detail} Check your connection or model URLs, then retry.`;
           modelError.hidden = false;
           setStatus("error", "Models failed to load");
           console.error("❌ Service failed to initialize:", message);
@@ -2725,6 +2755,21 @@
           return false;
         }
       }
+
+      const btnClearModelCache = document.getElementById("btn-clear-model-cache");
+      const modelCacheHint = document.getElementById("model-cache-hint");
+      btnClearModelCache?.addEventListener("click", async () => {
+        btnClearModelCache.disabled = true;
+        const previous = btnClearModelCache.textContent;
+        btnClearModelCache.textContent = "Clearing...";
+        await clearModelCache();
+        btnClearModelCache.textContent = "Cleared";
+        modelCacheHint.textContent = "Cache cleared. The next load downloads the models again.";
+        setTimeout(() => {
+          btnClearModelCache.textContent = previous;
+          btnClearModelCache.disabled = false;
+        }, 1500);
+      });
 
       btnRetryModels.addEventListener("click", async () => {
         btnRetryModels.disabled = true;
@@ -2787,10 +2832,55 @@
         bootStage.textContent = stageText;
       }
 
+      // The mirror the library defaults to, and the GitHub originals behind it.
+      // Models and dictionaries live under one base on Hugging Face but two on
+      // GitHub: weights come from the LFS media host, text files from raw.
+      const HF_BASE = "https://huggingface.co/snowfluke/ppu-paddle-ocr-models/resolve/main";
+      /** Set when a model came from GitHub instead, so the UI can say so. */
+      let usedFallbackHost = false;
+      /** Diagnosis from the prefetch, shown if the plain init then fails too. */
+      let lastPrefetchError = "";
+      /** How many of this run's model files came from IndexedDB. */
+      let servedFromCache = 0;
+      const GH_MODEL_BASE =
+        "https://media.githubusercontent.com/media/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
+      const GH_DICT_BASE =
+        "https://raw.githubusercontent.com/PT-Perkasa-Pilar-Utama/ppu-paddle-ocr-models/main";
+
+      /** GitHub URL for a Hugging Face one, or null if it is not a mirror URL. */
+      function githubMirrorOf(url) {
+        if (!url.startsWith(`${HF_BASE}/`)) return null;
+        const path = url.slice(HF_BASE.length + 1);
+        return `${path.endsWith(".txt") ? GH_DICT_BASE : GH_MODEL_BASE}/${path}`;
+      }
+
+      /**
+       * Why a fetch() rejected. A cross-origin failure gives the page a bare
+       * TypeError whatever the cause, so ask again in no-cors mode: an opaque
+       * response means the server answered and the browser withheld it (a
+       * status with no CORS headers, e.g. hotlink protection), while another
+       * rejection means the request never got an answer at all.
+       */
+      async function describeFetchFailure(url, error) {
+        if (error instanceof Error && /^HTTP \d/.test(error.message)) return error.message;
+        try {
+          await fetch(url, { method: "GET", mode: "no-cors", cache: "no-store" });
+          return `${new URL(url).host} answered but the response was withheld from this page (no CORS headers, typically a blocked or errored status)`;
+        } catch {
+          return `${new URL(url).host} could not be reached (offline, DNS, or TLS)`;
+        }
+      }
+
       async function fetchModelWithProgress(url, onBytes) {
-        const res = await fetch(url);
-        if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+        let res;
+        try {
+          res = await fetch(url);
+        } catch (error) {
+          throw new Error(await describeFetchFailure(url, error));
+        }
+        if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
         const total = Number(res.headers.get("content-length")) || 0;
+        onBytes(0, total);
         if (!res.body || !total) {
           const buf = await res.arrayBuffer();
           onBytes(buf.byteLength, total || buf.byteLength);
@@ -2813,6 +2903,95 @@
           offset += c.byteLength;
         }
         return buf.buffer;
+      }
+
+      // -- Model byte cache (IndexedDB) --
+      //
+      // Models are tens of megabytes and never change for a given URL, so they
+      // are stored by URL and reused across reloads. IndexedDB rather than the
+      // Cache API on purpose: Hugging Face redirects model requests to its CDN,
+      // and Cache.put() refuses a redirected response, so the obvious tool does
+      // not work here. Storing the ArrayBuffer we already hold sidesteps it.
+      const MODEL_DB = "ppu-paddle-ocr-demo";
+      const MODEL_STORE = "models";
+
+      function openModelDb() {
+        return new Promise((resolve, reject) => {
+          const request = indexedDB.open(MODEL_DB, 1);
+          request.onupgradeneeded = () => {
+            if (!request.result.objectStoreNames.contains(MODEL_STORE)) {
+              request.result.createObjectStore(MODEL_STORE);
+            }
+          };
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        });
+      }
+
+      /** Run one transaction, resolving with its request. Never throws. */
+      async function modelStore(mode, run) {
+        let db;
+        try {
+          db = await openModelDb();
+        } catch {
+          return null; // private mode, disabled storage: fall back to network
+        }
+        try {
+          return await new Promise((resolve, reject) => {
+            const tx = db.transaction(MODEL_STORE, mode);
+            const request = run(tx.objectStore(MODEL_STORE));
+            request.onsuccess = () => resolve(request.result ?? null);
+            request.onerror = () => reject(request.error);
+          });
+        } catch (error) {
+          console.warn("Model cache unavailable:", error);
+          return null;
+        } finally {
+          db.close();
+        }
+      }
+
+      const cachedModel = (url) => modelStore("readonly", (store) => store.get(url));
+
+      async function putCachedModel(url, bytes) {
+        // A quota rejection is not a failure worth surfacing: the models are in
+        // memory already and the page works, it just re-downloads next time.
+        await modelStore("readwrite", (store) => store.put(bytes, url));
+      }
+
+      async function clearModelCache() {
+        await modelStore("readwrite", (store) => store.clear());
+      }
+
+      /** Bytes for one model URL, from the cache when it is there. */
+      async function loadModel(url, onBytes) {
+        const hit = await cachedModel(url);
+        if (hit instanceof ArrayBuffer && hit.byteLength > 0) {
+          onBytes(hit.byteLength, hit.byteLength);
+          servedFromCache += 1;
+          return hit;
+        }
+        const bytes = await fetchModelWithFallback(url, onBytes);
+        await putCachedModel(url, bytes);
+        return bytes;
+      }
+
+      /**
+       * Fetch a model file, falling back to the GitHub original if the mirror
+       * refuses. Best effort only: the GitHub copies sit behind a Git LFS
+       * bandwidth budget that can be exhausted, so this is a second chance,
+       * not a guarantee.
+       */
+      async function fetchModelWithFallback(url, onBytes) {
+        try {
+          return await fetchModelWithProgress(url, onBytes);
+        } catch (error) {
+          const fallback = githubMirrorOf(url);
+          if (!fallback) throw error;
+          console.warn(`Mirror failed for ${url} (${error.message}); trying ${fallback}`);
+          usedFallbackHost = true;
+          return await fetchModelWithProgress(fallback, onBytes);
+        }
       }
 
       // Full-screen progress for ANY (re)initialization: first boot, Apply
@@ -2845,15 +3024,19 @@
           try {
             bootStage.textContent = "Downloading models...";
             const files = [urlSet.detection, urlSet.recognition, urlSet.charactersDictionary];
+            // Each GET reports its own Content-Length as it starts, so the bar
+            // fills from the downloads themselves. A HEAD probe first would
+            // only add a second request and a second way to fail.
             let received = 0;
             let totalKnown = 0;
-            const heads = await Promise.all(
-              files.map((u) => fetch(u, { method: "HEAD" }).catch(() => null))
-            );
-            for (const h of heads) {
-              totalKnown += (h && Number(h.headers.get("content-length"))) || 0;
-            }
-            const onBytes = (n) => {
+            servedFromCache = 0;
+            bootIndeterminate("Preparing models...");
+            const onBytes = (n, total) => {
+              if (total) {
+                totalKnown += total;
+                bootStage.textContent =
+                  servedFromCache > 0 ? "Loading cached models..." : "Downloading models...";
+              }
               received += n;
               if (totalKnown > 0) {
                 const pct = Math.min(100, Math.round((received / totalKnown) * 100));
@@ -2861,15 +3044,15 @@
                 bootBarFill.style.width = `${pct}%`;
               }
             };
-            if (!totalKnown) bootIndeterminate("Downloading models...");
-            const [det, rec, dict] = await Promise.all(
-              files.map((u) => fetchModelWithProgress(u, onBytes))
-            );
+            const [det, rec, dict] = await Promise.all(files.map((u) => loadModel(u, onBytes)));
             opts.model = { detection: det, recognition: rec, charactersDictionary: dict };
             bootPercent.textContent = "100%";
             bootBarFill.style.width = "100%";
           } catch (err) {
             // Progress prefetch is UX only; the service can fetch by itself.
+            // Keep the reason: the library's own failure message is generic,
+            // and this one says which host answered how.
+            lastPrefetchError = err instanceof Error ? err.message : String(err);
             console.warn("Model prefetch failed, falling back to plain init:", err);
             bootIndeterminate("Downloading models...");
           }


### PR DESCRIPTION
## What

Four changes to the playground, all in its single HTML file. No library change.

| Change | Effect |
| :--- | :--- |
| Sample chips moved out of the placeholder | switching sample images no longer needs a page reload |
| Models cached in IndexedDB by URL | a reload reuses them instead of re-downloading tens of megabytes |
| Per-file `HEAD` probe removed | one request per model instead of two, and one less way to fail |
| Failures diagnosed and reported | the error card names what actually happened |
| A refused file retried against GitHub | best-effort second chance when the mirror says no |

## Why

**Switching samples needed a reload.** The chips were markup inside `#result-placeholder`:

```
#result-panel
  #result-placeholder      <- img.onload sets display:none
      "Upload an image to begin"
      #sample-row          <- the chips lived here, so they vanished with it
```

Loading any image hid the row offering the other samples. Nothing was wrong with the click handler, which is why it looked like a state bug.

**Reloading re-downloaded everything.** The default tier is about 6 MB and the larger presets run much bigger. Model bytes never change for a given URL, so paying for them once per page view was pure waste.

**Failures said nothing.** This is the reason the mirror incident took three wrong theories: the browser reports every cross-origin failure as a bare `TypeError: Failed to fetch`, the prefetch discarded that error on its way to the plain-init fallback, and the card printed the library's generic retry message. The actual cause was a `404` nobody could see.

## How

**Samples.** The row is a sibling of the placeholder now, pinned to the bottom of the canvas panel so it survives an image being drawn. A comment records why it must not go back inside.

**Cache.** Model bytes are stored by URL in IndexedDB and reused. Keying on the full URL means switching preset or pointing at a custom model is a different entry rather than a collision. A "Clear cached models" button in the configuration panel drops them, and the status line reads "Ready (cached models)" when a run needed no network.

IndexedDB rather than the Cache API on purpose, and the code says so: Hugging Face redirects model requests to its CDN, and `Cache.put()` refuses a redirected response. The obvious tool does not work here. Storage failures (private mode, quota) are swallowed: the page has the bytes in memory and simply re-downloads next time.

**Progress.** Each `GET` reports its own `Content-Length` as it starts, which is what the removed `HEAD` probe was asking for separately.

**Diagnosis.** On a rejected fetch the URL is re-asked in `no-cors` mode. An opaque response means the server answered and the browser withheld it, which is a status with no CORS headers; another rejection means the host was never reached. Those are different problems and now read differently. The prefetch keeps its diagnosis so the card can show it when the library's own error is generic.

**Fallback.** A model URL the mirror refuses is retried against the GitHub original, mapping to the LFS media host for weights and raw for dictionaries. Best effort only, and commented as such: those copies sit behind a Git LFS budget that is already exhausted.

### Verification

The cache helpers were lifted verbatim out of the built `playground/dist/index.html` and driven against `fake-indexeddb`:

```
cold miss     -> null
after put     -> 1,2,3,4 (4 bytes)
different url -> null
after clear   -> null
```

That dev dependency was removed afterwards, so it is not in this diff. The page has no bundler, so the inline module is parsed with `bun build` after every edit; a syntax error would otherwise ship silently and only show up in production.

### Checklist

- [x] Tests pass locally (`bun test` - 300 pass)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed
- [ ] New tests added for bugs fixed or features added

No bench: the demo is not the hot path. No README change: the library's surface is untouched. No new automated test: the behaviour here is a browser page's DOM and IndexedDB, which the bun suite cannot drive; `tests/playground.test.ts` still passes, and the manual verification above is recorded rather than implied.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

Node and Bun are listed because the suite runs there; this PR does not touch code they execute. The browser rows want a pass on the deployed preview: load, pick a sample, pick a second sample, reload and confirm the second load is offline-fast, then Clear cached models and confirm it downloads again.

### Related

- Follows #113, which stopped the page sending a referer Hugging Face rejects. This branch was stacked on it and rebased once it merged.
- The library-side counterpart, a `referrerPolicy: "no-referrer"` on model fetches so embedders on a blocklisted origin are covered without setting a header themselves, is still open and needs a release.
