### PR TITLE
fix: ask for no referer on model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Web demo: the sample images are a collapsible dock.** They sit in the
+  bottom-left of the canvas panel and fold to a single chip once an image is
+  loaded, so they stay reachable without covering the image.
+
 ### Fixed
 
 - **Model downloads no longer send a referer.** Some hosts blocklist the origin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Model downloads no longer send a referer.** Some hosts blocklist the origin
+  of the page doing the embedding and answer with a status that carries no CORS
+  headers, which the browser then reports as "No 'Access-Control-Allow-Origin'
+  header is present" rather than as the block it is. A model download has no use
+  for a referer, so the web fetches ask for `no-referrer`. This is what the demo
+  needed a page header for; embedders now get it without knowing to set one.
+  Node and Bun have no referer to send and are unaffected.
+
 ### Added
 
 - **The web demo caches models in the browser.** They are stored by URL in

--- a/playground/index.html
+++ b/playground/index.html
@@ -677,21 +677,48 @@
       }
       /* Sample image chips in the empty state */
       /* Pinned to the panel rather than sitting in the placeholder, so the
-         samples stay reachable once an image is on the canvas. */
-      .sample-row {
+         samples stay reachable once an image is on the canvas. Collapsed to a
+         single chip while an image is loaded, so it does not cover the thing
+         the user came to look at. */
+      .sample-dock {
         position: absolute;
         z-index: 11;
-        left: 50%;
+        left: 0.6rem;
         bottom: 0.6rem;
-        transform: translateX(-50%);
+        max-width: calc(100% - 1.2rem);
+      }
+      .sample-dock > summary {
+        display: inline-block;
+        padding: 0.25rem 0.6rem;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--bg-card);
+        color: var(--text-secondary);
+        font-size: 0.62rem;
+        font-family: "JetBrains Mono", monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+      }
+      .sample-dock > summary::-webkit-details-marker {
+        display: none;
+      }
+      .sample-dock > summary:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .sample-dock[open] > summary {
+        margin-bottom: 0.4rem;
+      }
+      .sample-row {
         display: flex;
         flex-wrap: wrap;
         gap: 0.4rem;
-        justify-content: center;
-        max-width: calc(100% - 1.2rem);
-        padding: 0.4rem 0.55rem;
+        padding: 0.45rem 0.5rem;
         border: 1px solid var(--border);
-        border-radius: 999px;
+        border-radius: var(--radius-xs);
         background: var(--bg-card);
       }
       .sample-chip {
@@ -2086,57 +2113,62 @@
             </div>
             <!-- Outside #result-placeholder on purpose: the placeholder is
                  hidden once an image loads, and these chips used to go with it,
-                 so switching samples needed a page reload. -->
-            <div class="sample-row" id="sample-row">
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="receipt.jpg"
-                data-label="receipt"
-              >
-                Receipt photo
-              </button>
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="tilted.png"
-                data-label="tilted"
-              >
-                Tilted text
-              </button>
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="config-matrix/dark-dense-portrait.png"
-                data-label="dark app UI"
-              >
-                Dark app UI
-              </button>
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="config-matrix/light-sparse-portrait.png"
-                data-label="form"
-              >
-                Form
-              </button>
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="config-matrix/light-dense-landscape.png"
-                data-label="document"
-              >
-                Document page
-              </button>
-              <button
-                type="button"
-                class="sample-chip"
-                data-sample="config-matrix/low-contrast-photo-landscape.png"
-                data-label="low contrast"
-              >
-                Low contrast
-              </button>
-            </div>
+                 so switching samples needed a page reload. A disclosure rather
+                 than a bare row so the samples do not sit over the image once
+                 there is one to look at. -->
+            <details class="sample-dock" id="sample-dock" open>
+              <summary>Sample images</summary>
+              <div class="sample-row" id="sample-row">
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="receipt.jpg"
+                  data-label="receipt"
+                >
+                  Receipt photo
+                </button>
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="tilted.png"
+                  data-label="tilted"
+                >
+                  Tilted text
+                </button>
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="config-matrix/dark-dense-portrait.png"
+                  data-label="dark app UI"
+                >
+                  Dark app UI
+                </button>
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="config-matrix/light-sparse-portrait.png"
+                  data-label="form"
+                >
+                  Form
+                </button>
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="config-matrix/light-dense-landscape.png"
+                  data-label="document"
+                >
+                  Document page
+                </button>
+                <button
+                  type="button"
+                  class="sample-chip"
+                  data-sample="config-matrix/low-contrast-photo-landscape.png"
+                  data-label="low contrast"
+                >
+                  Low contrast
+                </button>
+              </div>
+            </details>
             <div class="model-error" id="model-error" role="alert" hidden>
               <strong>OCR models unavailable</strong>
               <p id="model-error-message">
@@ -2405,6 +2437,7 @@
       const bootBarFill = document.getElementById("boot-bar-fill");
       const bootStage = document.getElementById("boot-stage");
       const sampleChips = [...document.querySelectorAll(".sample-chip")];
+      const sampleDock = document.getElementById("sample-dock");
       const cfgLibVersion = document.getElementById("cfg-lib-version");
       const jsonResult = document.getElementById("json-result");
       const modelError = document.getElementById("model-error");
@@ -3228,6 +3261,8 @@
 
           canvasContainer.style.display = "flex";
           resultPlaceholder.style.display = "none";
+          // An image is worth more screen than the sample list is.
+          if (sampleDock) sampleDock.open = false;
           URL.revokeObjectURL(url);
           btnProcess.disabled = !serviceReady;
           if (serviceReady) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,7 +94,15 @@ export async function fetchArrayBufferWithRetry(
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(timeoutMs),
+        // A model download has no use for a referer, and sending one can cost
+        // the download outright: hosts that blocklist an embedding page's
+        // origin answer with a status carrying no CORS headers, which the
+        // browser then reports as a CORS error rather than as the block it is.
+        // Ignored outside browsers, where there is no referer to send.
+        referrerPolicy: "no-referrer",
+      });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`);
       }

--- a/src/web/platform.web.ts
+++ b/src/web/platform.web.ts
@@ -127,7 +127,8 @@ export class WebPlatformProvider implements PlatformProvider<CoreCanvas> {
     const sourceToLoad = typeof source === "string" ? source : defaultUrl;
 
     // In browser, all string sources are treated as URLs
-    const response = await fetch(sourceToLoad);
+    // No referer, for the same reason as the model fetches in utils.ts.
+    const response = await fetch(sourceToLoad, { referrerPolicy: "no-referrer" });
     if (!response.ok) {
       throw new Error(`Failed to fetch resource from ${sourceToLoad}`);
     }

--- a/tests/fetch-referrer.test.ts
+++ b/tests/fetch-referrer.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { fetchArrayBufferWithRetry } from "../src/utils.js";
+
+/**
+ * Model downloads must not send a referer.
+ *
+ * Some hosts blocklist the origin of the page doing the embedding and answer
+ * with a status that carries no CORS headers, which a browser then reports as
+ * "No 'Access-Control-Allow-Origin' header is present" rather than as the block
+ * it is. A referer buys a model download nothing, so none is sent.
+ *
+ * Bun has no referer to send, so the behaviour itself is not observable here.
+ * These pin the request the browser is handed.
+ */
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Capture the init of every fetch, answering each with `body`. */
+function captureFetch(body: ArrayBuffer, status = 200): RequestInit[] {
+  const calls: RequestInit[] = [];
+  globalThis.fetch = ((_url: string, init: RequestInit) => {
+    calls.push(init);
+    return Promise.resolve(new Response(status === 200 ? body : null, { status }));
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe("model downloads", () => {
+  test("ask the browser for no referer", async () => {
+    const calls = captureFetch(new Uint8Array([1, 2, 3]).buffer);
+
+    await fetchArrayBufferWithRetry("https://example.com/model.onnx");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.referrerPolicy).toBe("no-referrer");
+  });
+
+  test("keep the policy on every retry", async () => {
+    const calls = captureFetch(new ArrayBuffer(0), 500);
+
+    await expect(
+      fetchArrayBufferWithRetry("https://example.com/model.onnx", { retries: 2 })
+    ).rejects.toThrow();
+
+    expect(calls).toHaveLength(3);
+    for (const init of calls) {
+      expect(init.referrerPolicy).toBe("no-referrer");
+    }
+  });
+
+  test("still carry the abort signal", async () => {
+    const calls = captureFetch(new Uint8Array([1]).buffer);
+
+    await fetchArrayBufferWithRetry("https://example.com/model.onnx");
+
+    expect(calls[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});


### PR DESCRIPTION
## What

Model downloads ask the browser for `no-referrer`, and the demo's sample images become a collapsible dock instead of a bar across the canvas.

| Change | Files |
| :--- | :--- |
| `referrerPolicy: "no-referrer"` on model fetches | `src/utils.ts`, `src/web/platform.web.ts` |
| Contract tests for the request the browser is handed | `tests/fetch-referrer.test.ts` |
| Sample images fold into a dock once an image loads | `playground/index.html` |

## Why

**The referer costs downloads and buys nothing.** Hugging Face answers `404` to model requests carrying a referer from an origin it blocklists, and a 404 response has no CORS headers, so the browser reports:

```
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

That message points at CORS, which is not the problem, and hides the 404, which is. #113 fixed the demo with a page-level `Referrer-Policy` header, but nobody embedding this library can be expected to know that is the cure, or to read a CORS error as a hotlink block. A model download has no use for a referer in the first place.

Measured on the same URL, varying only the referer: `*.workers.dev` gets 404, while `pages.dev`, `vercel.app`, `netlify.app`, `example.com`, `localhost` and no-referer all get 302 -> 200. Which origins are blocklisted is the host's business and can change; not sending a referer sidesteps the question.

**The sample dock is a correction of my own change.** #114 moved the sample chips out of `#result-placeholder` so switching samples stopped needing a page reload. That fixed the bug but left a wide pill parked across the bottom of the canvas, covering the image the user is there to look at.

## How

`fetchArrayBufferWithRetry` is the single choke point for model downloads on web, so the option goes there, plus the web platform's `loadResource` for image URLs. Node and Bun ignore it: there is no referer to send outside a browser. Verified rather than assumed, with a real fetch on both runtimes:

```
bun:  200 27157 bytes
node: 200 27157 bytes
```

Browser referer behaviour is not observable from bun, so the tests pin the request instead: `globalThis.fetch` is stubbed and the init asserted, including that the policy survives all three retry attempts and that the abort signal is still attached. That is a weaker guarantee than testing the behaviour, and it is the strongest one available here.

The sample chips are a native `<details>` docked bottom-left of the canvas panel: open while the canvas is empty, folded to a single "Sample images" chip as soon as an image loads. Native disclosure keeps it keyboard reachable without scripting a toggle.

### Checklist

- [x] Tests pass locally (`bun test` - 303 pass, up from 300)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [ ] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

No bench: one fetch option on a once-per-session download. No README change: no public option or default moved, and the README's cross-origin isolation section is about COEP, which is not involved here.

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows

The browser rows are the ones that matter here and want a pass on the preview: models load on a page whose origin is blocklisted, and the sample dock sits clear of the image, expanded and collapsed, on a narrow window.

### Related

- Follows #113 (page-level header for the demo) and #114 (sample chips moved out of the placeholder, model caching). This supersedes the need for embedders to replicate #113.
- The demo keeps its `Referrer-Policy` header: it costs nothing and covers requests this library does not make.
