### PR TITLE
feat: add one-shot ocr and detect functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `recognize()` accepts per-call overrides for `minimumConfidence`,
   `spaceRecovery`, `rotateVerticalCrops`, and `recBatchSize` on Node, Bun,
   web, and React Native.
+- One-shot `ocr()` and `detect()` functions on the Node/Bun, web, and React
+  Native entry points. Each call initializes and destroys its own service;
+  repeated work should continue to use `PaddleOcrService`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Node, web, and React Native now share the same recognition and lifecycle
   implementation.
+- `recognize()` skips the result cache when `strategy` or any per-call
+  recognition override is set, since the cache is keyed on the image alone.
 
 ## [6.4.3] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -974,6 +974,8 @@ Per-call options for `recognize()`.
 | `rotateVerticalCrops` |                 `boolean`                 | service default | Override vertical crop rotation for this call.          |
 | `recBatchSize`        |                 `number`                  | service default | Override the recognition inference batch size per call. |
 
+A call that sets `strategy`, `dictionary`, or any of the four recognition overrides skips the result cache, which is keyed on the image alone.
+
 ### `DetectOptions`
 
 Per-call options for `detect()`. Extends [`DetectionOptions`](#detectionoptions),

--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ console.log(result.text);
 await service.destroy();
 ```
 
+For a single image, `ocr()` and `detect()` manage a short-lived service for
+you. Create a `PaddleOcrService` when processing more than one image so the
+models remain initialized between calls.
+
+```ts
+import { detect, ocr } from "ppu-paddle-ocr";
+
+const result = await ocr(imageBuffer);
+const { boxes } = await detect(imageBuffer);
+```
+
 ### Custom Models
 
 **Using preset models**, import constants for quick switching:

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -65,8 +65,11 @@ The library is a building block; this wraps it as a service you'd be comfortable
   "strategy": "per-line",
   "flatten": false,
   "engine": "opencv",
+  "minimumConfidence": 0.5,
 }
 ```
+
+`minimumConfidence` (0 to 1) overrides `MIN_CONFIDENCE` for that request only; `0` disables the filter. The batch, stream, and async endpoints take the same field.
 
 `source` must be a `data:` URI or an `https` URL whose host is in `SOURCE_URL_ALLOWLIST` (empty = https disabled). **Local filesystem paths are rejected**, and URL fetches refuse redirects - so the API never reads arbitrary host files or gets steered off-allowlist. Uploads are sniffed by magic bytes; non-images get a `400`, not a `500`.
 

--- a/apps/serve/src/core/runner.ts
+++ b/apps/serve/src/core/runner.ts
@@ -65,6 +65,7 @@ function batchOptions(body: BatchOcrBody) {
     strategy: body.strategy ?? config.defaultStrategy,
     concurrency: body.concurrency ?? config.concurrency,
     flatten: body.flatten ?? false,
+    minimumConfidence: body.minimumConfidence,
   };
 }
 
@@ -79,9 +80,9 @@ export async function runBatch(
   body: BatchOcrBody,
   signal?: AbortSignal
 ): Promise<BatchResponse> {
-  const { engine, strategy, concurrency, flatten } = batchOptions(body);
+  const { engine, strategy, concurrency, flatten, minimumConfidence } = batchOptions(body);
   const svc = await getService(engine);
-  const opts = { strategy, concurrency, noCache: true, flatten, signal };
+  const opts = { strategy, concurrency, noCache: true, flatten, minimumConfidence, signal };
   const results = body.settle
     ? await svc.batchRecognize(images, { ...opts, settle: true })
     : await svc.batchRecognize(images, opts);
@@ -93,13 +94,14 @@ export async function* streamBatch(
   images: ArrayBuffer[],
   body: BatchOcrBody
 ): AsyncGenerator<BatchItemResult<unknown>> {
-  const { engine, strategy, concurrency, flatten } = batchOptions(body);
+  const { engine, strategy, concurrency, flatten, minimumConfidence } = batchOptions(body);
   const svc = await getService(engine);
   yield* svc.batchRecognizeStream(images, {
     strategy,
     concurrency,
     noCache: true,
     flatten,
+    minimumConfidence,
     settle: body.settle ?? false,
   });
 }

--- a/apps/serve/src/core/schemas.ts
+++ b/apps/serve/src/core/schemas.ts
@@ -41,6 +41,7 @@ export const multipartOcrSchema = z
     strategy,
     flatten: booleanish,
     engine,
+    minimumConfidence,
   })
   .openapi("OcrMultipartRequest");
 

--- a/apps/serve/test/ocr.test.ts
+++ b/apps/serve/test/ocr.test.ts
@@ -53,6 +53,35 @@ describe("POST /v1/ocr (success)", () => {
     expect(body.status).toBe("success");
     expect(Array.isArray(body.data.results)).toBe(true);
   }, 30_000);
+
+  test("minimumConfidence is honored per request on JSON, multipart, and batch", async () => {
+    const strictJson = await app.request(
+      "/v1/ocr",
+      json({ source: dataUri, minimumConfidence: 1 })
+    );
+    expect(strictJson.status).toBe(200);
+    expect((await strictJson.json()).data.lines).toHaveLength(0);
+
+    const form = new FormData();
+    form.append("file", new File([receipt], "receipt.jpg", { type: "image/jpeg" }));
+    form.append("minimumConfidence", "1");
+    const strictForm = await app.request("/v1/ocr", { method: "POST", body: form });
+    expect(strictForm.status).toBe(200);
+    expect((await strictForm.json()).data.lines).toHaveLength(0);
+
+    const strictBatch = await app.request(
+      "/v1/ocr/batch",
+      json({ sources: [dataUri], minimumConfidence: 1 })
+    );
+    expect(strictBatch.status).toBe(200);
+    expect((await strictBatch.json()).data.results[0].lines).toHaveLength(0);
+
+    const outOfRange = await app.request(
+      "/v1/ocr",
+      json({ source: dataUri, minimumConfidence: 2 })
+    );
+    expect(outOfRange.status).toBe(400);
+  }, 60_000);
 });
 
 describe("POST /v1/detect", () => {

--- a/skill-ppu-paddle-ocr/SKILL.md
+++ b/skill-ppu-paddle-ocr/SKILL.md
@@ -82,6 +82,10 @@ If detection finds zero boxes, `recognize()` returns an empty result (`text: ""`
 
 ## Detection-only inference: `detect()`
 
+For a single image, the package entry points also export one-shot `ocr()` and
+`detect()` functions that initialize and destroy a service automatically. Use
+`PaddleOcrService` for repeated work so model sessions are reused.
+
 When the user only needs layout - where the text is, not what it says - point them at `detect(image, options?)` instead of `recognize()`. It runs just the detection model and returns `{ boxes: Box[] }` in original image coordinates. Same accepted inputs as `recognize()`, available on all three entry points, and also exposed as the CLI `detect` command and the serve app's `POST /v1/detect`.
 
 ```ts

--- a/src/core/one-shot.ts
+++ b/src/core/one-shot.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
+import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
+
 /** Run one operation with a newly initialized service. */
 export async function runOneShot<
   TService extends { initialize(): Promise<void>; destroy(): Promise<void> },
@@ -13,4 +15,38 @@ export async function runOneShot<
   } finally {
     await service.destroy();
   }
+}
+
+/** Constructor vs per-call split for `ocr()`. */
+export type SplitOcrResult = { paddle: PaddleOptions; perCall: RecognizeOptions };
+
+/** Constructor vs per-call split for `detect()`. */
+export type SplitDetectResult = { paddle: PaddleOptions; perCall: DetectOptions };
+
+/**
+ * Split a combined `PaddleOptions & RecognizeOptions` bag into the constructor
+ * portion and the per-call portion so the one-shot helpers do not leak
+ * constructor keys into `service.recognize()`.
+ */
+export function splitOcrOptions(options?: PaddleOptions & RecognizeOptions): SplitOcrResult {
+  if (!options) return { paddle: {}, perCall: {} };
+  const { model, detection, recognition, debugging, session, processing, ...perCall } = options;
+  return {
+    paddle: { model, detection, recognition, debugging, session, processing },
+    perCall,
+  };
+}
+
+/**
+ * Split a combined `PaddleOptions & DetectOptions` bag into the constructor
+ * portion and the per-call portion so the one-shot helpers do not leak
+ * constructor keys into `service.detect()`.
+ */
+export function splitDetectOptions(options?: PaddleOptions & DetectOptions): SplitDetectResult {
+  if (!options) return { paddle: {}, perCall: {} };
+  const { model, detection, recognition, debugging, session, processing, ...perCall } = options;
+  return {
+    paddle: { model, detection, recognition, debugging, session, processing },
+    perCall,
+  };
 }

--- a/src/core/one-shot.ts
+++ b/src/core/one-shot.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+/** Run one operation with a newly initialized service. */
+export async function runOneShot<
+  TService extends { initialize(): Promise<void>; destroy(): Promise<void> },
+  TResult,
+>(createService: () => TService, run: (service: TService) => Promise<TResult>): Promise<TResult> {
+  const service = createService();
+  try {
+    await service.initialize();
+    return await run(service);
+  } finally {
+    await service.destroy();
+  }
+}

--- a/src/core/one-shot.ts
+++ b/src/core/one-shot.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
-import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
+import type { PaddleOptions } from "../interface.js";
 
 /** Run one operation with a newly initialized service. */
 export async function runOneShot<
@@ -17,33 +17,19 @@ export async function runOneShot<
   }
 }
 
-/** Constructor vs per-call split for `ocr()`. */
-export type SplitOcrResult = { paddle: PaddleOptions; perCall: RecognizeOptions };
-
-/** Constructor vs per-call split for `detect()`. */
-export type SplitDetectResult = { paddle: PaddleOptions; perCall: DetectOptions };
+/** Constructor options on the left, whatever the call passes through on the right. */
+export type SplitOptions<T> = { paddle: PaddleOptions; perCall: Omit<T, keyof PaddleOptions> };
 
 /**
- * Split a combined `PaddleOptions & RecognizeOptions` bag into the constructor
- * portion and the per-call portion so the one-shot helpers do not leak
- * constructor keys into `service.recognize()`.
+ * Split a combined `PaddleOptions & T` bag into the constructor portion and
+ * the per-call portion so the one-shot helpers do not leak constructor keys
+ * into `service.recognize()` or `service.detect()`.
  */
-export function splitOcrOptions(options?: PaddleOptions & RecognizeOptions): SplitOcrResult {
-  if (!options) return { paddle: {}, perCall: {} };
-  const { model, detection, recognition, debugging, session, processing, ...perCall } = options;
-  return {
-    paddle: { model, detection, recognition, debugging, session, processing },
-    perCall,
-  };
-}
-
-/**
- * Split a combined `PaddleOptions & DetectOptions` bag into the constructor
- * portion and the per-call portion so the one-shot helpers do not leak
- * constructor keys into `service.detect()`.
- */
-export function splitDetectOptions(options?: PaddleOptions & DetectOptions): SplitDetectResult {
-  if (!options) return { paddle: {}, perCall: {} };
+export function splitOptions<T extends object>(options?: PaddleOptions & T): SplitOptions<T> {
+  if (!options) {
+    // SAFETY: an empty bag has no per-call keys; the cast only names the shape.
+    return { paddle: {}, perCall: {} as Omit<T, keyof PaddleOptions> };
+  }
   const { model, detection, recognition, debugging, session, processing, ...perCall } = options;
   return {
     paddle: { model, detection, recognition, debugging, session, processing },

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "./core/base-paddle-ocr.service.js";
-import { runOneShot } from "./core/one-shot.js";
+import { runOneShot, splitOcrOptions, splitDetectOptions } from "./core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "./interface.js";
 import { PaddleOcrService } from "./processor/paddle-ocr.service.js";
 
@@ -118,12 +118,13 @@ export function ocr(
   image: ArrayBuffer | Canvas,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  const { paddle, perCall } = splitOcrOptions(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
-    () => new PaddleOcrService(options),
+    () => new PaddleOcrService(paddle),
     (service) =>
-      options?.flatten
-        ? service.recognize(image, { ...options, flatten: true })
-        : service.recognize(image, { ...options, flatten: false })
+      perCall.flatten
+        ? service.recognize(image, { ...perCall, flatten: true })
+        : service.recognize(image, { ...perCall, flatten: false })
   );
 }
 
@@ -132,8 +133,9 @@ export function detect(
   image: ArrayBuffer | Canvas,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
+  const { paddle, perCall } = splitDetectOptions(options);
   return runOneShot(
-    () => new PaddleOcrService(options),
-    (service) => service.detect(image, options)
+    () => new PaddleOcrService(paddle),
+    (service) => service.detect(image, perCall)
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "./core/base-paddle-ocr.service.js";
-import { runOneShot, splitOcrOptions, splitDetectOptions } from "./core/one-shot.js";
+import { runOneShot, splitOptions } from "./core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "./interface.js";
 import { PaddleOcrService } from "./processor/paddle-ocr.service.js";
 
@@ -118,7 +118,7 @@ export function ocr(
   image: ArrayBuffer | Canvas,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
-  const { paddle, perCall } = splitOcrOptions(options);
+  const { paddle, perCall } = splitOptions<RecognizeOptions>(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
     () => new PaddleOcrService(paddle),
     (service) =>
@@ -133,7 +133,7 @@ export function detect(
   image: ArrayBuffer | Canvas,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
-  const { paddle, perCall } = splitDetectOptions(options);
+  const { paddle, perCall } = splitOptions<DetectOptions>(options);
   return runOneShot(
     () => new PaddleOcrService(paddle),
     (service) => service.detect(image, perCall)

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,3 +94,46 @@ export {
   DEFAULT_PROCESSING_OPTIONS,
   DEFAULT_RECOGNITION_OPTIONS,
 } from "./constants.js";
+
+import type { Canvas } from "ppu-ocv";
+import type {
+  DetectResult,
+  FlattenedPaddleOcrResult,
+  PaddleOcrResult,
+} from "./core/base-paddle-ocr.service.js";
+import { runOneShot } from "./core/one-shot.js";
+import type { DetectOptions, PaddleOptions, RecognizeOptions } from "./interface.js";
+import { PaddleOcrService } from "./processor/paddle-ocr.service.js";
+
+/** Recognize one image without managing a service lifecycle. */
+export function ocr(
+  image: ArrayBuffer | Canvas,
+  options: PaddleOptions & RecognizeOptions & { flatten: true }
+): Promise<FlattenedPaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | Canvas,
+  options?: PaddleOptions & RecognizeOptions & { flatten?: false }
+): Promise<PaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | Canvas,
+  options?: PaddleOptions & RecognizeOptions
+): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
+    () => new PaddleOcrService(options),
+    (service) =>
+      options?.flatten
+        ? service.recognize(image, { ...options, flatten: true })
+        : service.recognize(image, { ...options, flatten: false })
+  );
+}
+
+/** Detect text regions in one image without managing a service lifecycle. */
+export function detect(
+  image: ArrayBuffer | Canvas,
+  options?: PaddleOptions & DetectOptions
+): Promise<DetectResult> {
+  return runOneShot(
+    () => new PaddleOcrService(options),
+    (service) => service.detect(image, options)
+  );
+}

--- a/src/mobile/index.ts
+++ b/src/mobile/index.ts
@@ -105,7 +105,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "../core/base-paddle-ocr.service.js";
-import { runOneShot, splitOcrOptions, splitDetectOptions } from "../core/one-shot.js";
+import { runOneShot, splitOptions } from "../core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
 import { PaddleOcrService } from "./paddle-ocr.service.mobile.js";
 
@@ -122,7 +122,7 @@ export function ocr(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
-  const { paddle, perCall } = splitOcrOptions(options);
+  const { paddle, perCall } = splitOptions<RecognizeOptions>(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
     () => new PaddleOcrService(paddle),
     (service) =>
@@ -137,7 +137,7 @@ export function detect(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
-  const { paddle, perCall } = splitDetectOptions(options);
+  const { paddle, perCall } = splitOptions<DetectOptions>(options);
   return runOneShot(
     () => new PaddleOcrService(paddle),
     (service) => service.detect(image, perCall)

--- a/src/mobile/index.ts
+++ b/src/mobile/index.ts
@@ -105,7 +105,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "../core/base-paddle-ocr.service.js";
-import { runOneShot } from "../core/one-shot.js";
+import { runOneShot, splitOcrOptions, splitDetectOptions } from "../core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
 import { PaddleOcrService } from "./paddle-ocr.service.mobile.js";
 
@@ -122,12 +122,13 @@ export function ocr(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  const { paddle, perCall } = splitOcrOptions(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
-    () => new PaddleOcrService(options),
+    () => new PaddleOcrService(paddle),
     (service) =>
-      options?.flatten
-        ? service.recognize(image, { ...options, flatten: true })
-        : service.recognize(image, { ...options, flatten: false })
+      perCall.flatten
+        ? service.recognize(image, { ...perCall, flatten: true })
+        : service.recognize(image, { ...perCall, flatten: false })
   );
 }
 
@@ -136,8 +137,9 @@ export function detect(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
+  const { paddle, perCall } = splitDetectOptions(options);
   return runOneShot(
-    () => new PaddleOcrService(options),
-    (service) => service.detect(image, options)
+    () => new PaddleOcrService(paddle),
+    (service) => service.detect(image, perCall)
   );
 }

--- a/src/mobile/index.ts
+++ b/src/mobile/index.ts
@@ -98,3 +98,46 @@ export {
   DEFAULT_PROCESSING_OPTIONS,
   DEFAULT_RECOGNITION_OPTIONS,
 } from "../constants.js";
+
+import type { CanvasLike } from "ppu-ocv/canvas-mobile";
+import type {
+  DetectResult,
+  FlattenedPaddleOcrResult,
+  PaddleOcrResult,
+} from "../core/base-paddle-ocr.service.js";
+import { runOneShot } from "../core/one-shot.js";
+import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
+import { PaddleOcrService } from "./paddle-ocr.service.mobile.js";
+
+/** Recognize one image without managing a service lifecycle. */
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options: PaddleOptions & RecognizeOptions & { flatten: true }
+): Promise<FlattenedPaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & RecognizeOptions & { flatten?: false }
+): Promise<PaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & RecognizeOptions
+): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
+    () => new PaddleOcrService(options),
+    (service) =>
+      options?.flatten
+        ? service.recognize(image, { ...options, flatten: true })
+        : service.recognize(image, { ...options, flatten: false })
+  );
+}
+
+/** Detect text regions in one image without managing a service lifecycle. */
+export function detect(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & DetectOptions
+): Promise<DetectResult> {
+  return runOneShot(
+    () => new PaddleOcrService(options),
+    (service) => service.detect(image, options)
+  );
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -101,7 +101,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "../core/base-paddle-ocr.service.js";
-import { runOneShot, splitOcrOptions, splitDetectOptions } from "../core/one-shot.js";
+import { runOneShot, splitOptions } from "../core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
 import { PaddleOcrService } from "./paddle-ocr.service.web.js";
 
@@ -118,7 +118,7 @@ export function ocr(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
-  const { paddle, perCall } = splitOcrOptions(options);
+  const { paddle, perCall } = splitOptions<RecognizeOptions>(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
     () => new PaddleOcrService(paddle),
     (service) =>
@@ -133,7 +133,7 @@ export function detect(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
-  const { paddle, perCall } = splitDetectOptions(options);
+  const { paddle, perCall } = splitOptions<DetectOptions>(options);
   return runOneShot(
     () => new PaddleOcrService(paddle),
     (service) => service.detect(image, perCall)

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -94,3 +94,46 @@ export {
   DEFAULT_PROCESSING_OPTIONS,
   DEFAULT_RECOGNITION_OPTIONS,
 } from "../constants.js";
+
+import type { CanvasLike } from "ppu-ocv/web";
+import type {
+  DetectResult,
+  FlattenedPaddleOcrResult,
+  PaddleOcrResult,
+} from "../core/base-paddle-ocr.service.js";
+import { runOneShot } from "../core/one-shot.js";
+import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
+import { PaddleOcrService } from "./paddle-ocr.service.web.js";
+
+/** Recognize one image without managing a service lifecycle. */
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options: PaddleOptions & RecognizeOptions & { flatten: true }
+): Promise<FlattenedPaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & RecognizeOptions & { flatten?: false }
+): Promise<PaddleOcrResult>;
+export function ocr(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & RecognizeOptions
+): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
+    () => new PaddleOcrService(options),
+    (service) =>
+      options?.flatten
+        ? service.recognize(image, { ...options, flatten: true })
+        : service.recognize(image, { ...options, flatten: false })
+  );
+}
+
+/** Detect text regions in one image without managing a service lifecycle. */
+export function detect(
+  image: ArrayBuffer | CanvasLike,
+  options?: PaddleOptions & DetectOptions
+): Promise<DetectResult> {
+  return runOneShot(
+    () => new PaddleOcrService(options),
+    (service) => service.detect(image, options)
+  );
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -101,7 +101,7 @@ import type {
   FlattenedPaddleOcrResult,
   PaddleOcrResult,
 } from "../core/base-paddle-ocr.service.js";
-import { runOneShot } from "../core/one-shot.js";
+import { runOneShot, splitOcrOptions, splitDetectOptions } from "../core/one-shot.js";
 import type { DetectOptions, PaddleOptions, RecognizeOptions } from "../interface.js";
 import { PaddleOcrService } from "./paddle-ocr.service.web.js";
 
@@ -118,12 +118,13 @@ export function ocr(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & RecognizeOptions
 ): Promise<PaddleOcrResult | FlattenedPaddleOcrResult> {
+  const { paddle, perCall } = splitOcrOptions(options);
   return runOneShot<PaddleOcrService, PaddleOcrResult | FlattenedPaddleOcrResult>(
-    () => new PaddleOcrService(options),
+    () => new PaddleOcrService(paddle),
     (service) =>
-      options?.flatten
-        ? service.recognize(image, { ...options, flatten: true })
-        : service.recognize(image, { ...options, flatten: false })
+      perCall.flatten
+        ? service.recognize(image, { ...perCall, flatten: true })
+        : service.recognize(image, { ...perCall, flatten: false })
   );
 }
 
@@ -132,8 +133,9 @@ export function detect(
   image: ArrayBuffer | CanvasLike,
   options?: PaddleOptions & DetectOptions
 ): Promise<DetectResult> {
+  const { paddle, perCall } = splitDetectOptions(options);
   return runOneShot(
-    () => new PaddleOcrService(options),
-    (service) => service.detect(image, options)
+    () => new PaddleOcrService(paddle),
+    (service) => service.detect(image, perCall)
   );
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { Canvas } from "ppu-ocv";
 import { CanvasProcessor } from "ppu-ocv";
 import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
@@ -66,6 +66,35 @@ describe("PaddleOcrService Initialization", () => {
     // v5 en-only model on a receipt - keep threshold moderate.
     expect(result.confidence).toBeGreaterThan(0.5);
   });
+});
+
+describe("one-shot OCR functions", () => {
+  test("ocr initializes, recognizes, and destroys its service", async () => {
+    const { ocr } = await import("../src/index.js");
+    const destroySpy = spyOn(PaddleOcrService.prototype, "destroy");
+
+    try {
+      const result = await ocr(imageBuffer, { noCache: true });
+      expect(result.text).not.toBeEmpty();
+      expect(result.lines.length).toBeGreaterThan(0);
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      destroySpy.mockRestore();
+    }
+  }, 30000);
+
+  test("detect initializes, detects, and destroys its service", async () => {
+    const { detect } = await import("../src/index.js");
+    const destroySpy = spyOn(PaddleOcrService.prototype, "destroy");
+
+    try {
+      const result = await detect(imageBuffer);
+      expect(result.boxes.length).toBeGreaterThan(0);
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      destroySpy.mockRestore();
+    }
+  }, 30000);
 });
 
 describe("PaddleOcrService.recognize()", () => {

--- a/tests/web-ocr.test.ts
+++ b/tests/web-ocr.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test
 import { getPlatform, setPlatform } from "ppu-ocv";
 
 import type { PaddleOcrService } from "../src/web/paddle-ocr.service.web.js";
+import type { ocr as webOcrFunction } from "../src/web/index.js";
 import { PaddleOcrService as NodePaddleOcrService } from "../src/processor/paddle-ocr.service.js";
 import { DEFAULT_MODEL } from "../src/model-catalogue.js";
 import { cachePathFor } from "../src/processor/model-cache.js";
@@ -15,6 +16,7 @@ import { installWebCanvas, uninstallWebCanvas } from "./web-canvas-polyfill.js";
 // the node test suites run in the same `bun test` process. The active platform
 // is saved before and restored after this suite.
 let WebPaddleOcrService: typeof PaddleOcrService;
+let webOcr: typeof webOcrFunction;
 let savedPlatform: ReturnType<typeof getPlatform>;
 
 // Pre-loaded v6 model ArrayBuffers read from the Node disk cache.
@@ -55,8 +57,9 @@ describe("web OCR service (onnxruntime-web under the polyfilled runtime)", () =>
 
     savedPlatform = getPlatform();
     installWebCanvas();
-    ({ PaddleOcrService: WebPaddleOcrService } =
-      await import("../src/web/paddle-ocr.service.web.js"));
+    const webModule = await import("../src/web/index.js");
+    WebPaddleOcrService = webModule.PaddleOcrService;
+    webOcr = webModule.ocr;
   }, 120_000);
 
   afterAll(() => {
@@ -120,6 +123,17 @@ describe("web OCR service (onnxruntime-web under the polyfilled runtime)", () =>
 
     expect(result.lines).toHaveLength(0);
     expect(result.text).toBeEmpty();
+  }, 60000);
+
+  test("one-shot ocr runs through the web runtime", async () => {
+    const result = await webOcr(smallBuffer, {
+      model: { detection: v6Det, recognition: v6Rec, charactersDictionary: v6Dict },
+      processing: { engine: "canvas-native" },
+      noCache: true,
+    });
+
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.lines.length).toBeGreaterThan(0);
   }, 60000);
 
   test("batchRecognize and streaming work on the web path", async () => {


### PR DESCRIPTION
## What

Adds one-shot `ocr()` and `detect()` functions to the Node/Bun, web, and React Native entry points. Each call creates, initializes, uses, and destroys its own service.

Replaces #106.

## Why

A one-shot API makes the common single-image case concise, but the original #106 implementation retained a module singleton. That allowed the first call's model and runtime configuration to leak into later calls and provided no deterministic cleanup. The recreated API keeps each call isolated; callers processing multiple images can continue using `PaddleOcrService` to reuse initialized sessions.

## How

A small shared `runOneShot()` helper wraps initialization and cleanup in `try/finally`. Each platform entry point supplies its own `PaddleOcrService` and preserves the grouped/flattened result overloads. Tests run real OCR and detection, assert non-empty results, and spy on `destroy()` to prove cleanup occurs.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [x] Benchmark run if this touches the hot path (`bun run bench/index.bench.ts`) — not required; existing service inference is unchanged
- [x] CHANGELOG updated under `## [Unreleased]` (or bump version if cutting a release)
- [x] README updated if the public API, defaults, or setup changed
- [x] New tests added for bugs fixed or features added

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [ ] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [x] Windows

### Validation

- The new Node one-shot OCR and detection tests pass with real model inference and verify one `destroy()` call per operation.
- The new web one-shot test passes through `onnxruntime-web` using its WASM provider under the repository web runtime harness.
- Built package smoke tests produced the same receipt result on Bun 1.4.2, Node 26.5.0, and Deno 2.9.6: 382 characters, confidence 0.9394856972, and 28 detection boxes.
- Clean full run before splitting the independently applicable commits: 294 tests passed, 0 failed.
- A later run while another process saturated the CPU exceeded five existing 5-second test limits; all new tests remained green.

### Related

- Replaces #106
