### PR TITLE
refactor: migrate the serve app from zod to valibot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `flatten`, `settle`, and `concurrency`; string forms are still accepted in
   multipart fields, where everything arrives as a string.
 
+### Fixed
+
+- Serve: malformed JSON on `/v1/ocr/batch`, `/stream`, and `/async` returns
+  `400` in the error envelope instead of `500`.
+
 ## [6.5.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Serve: request validation and the OpenAPI spec now come from valibot via
+  `hono-openapi` instead of zod via `@hono/zod-openapi`. Routes, envelopes,
+  `/openapi.json`, and `/docs` are unchanged apart from JSON Schema
+  spelling (`const` for literals, no spurious `nullable`). One tightening:
+  JSON bodies now require real numbers and booleans for `minimumConfidence`,
+  `flatten`, `settle`, and `concurrency`; string forms are still accepted in
+  multipart fields, where everything arrives as a string.
+
 ## [6.5.0] - 2026-09-08
 
 ### Added

--- a/apps/serve/Dockerfile
+++ b/apps/serve/Dockerfile
@@ -16,7 +16,7 @@ COPY package.json bun.lock ./
 RUN bun install --production --ignore-scripts \
   && bun add onnxruntime-node --ignore-scripts \
   && bun pm trust onnxruntime-node
-# Serve app: only hono + zod at runtime (its lib deps are devDeps that resolve
+# Serve app: only hono + valibot at runtime (its lib deps are devDeps that resolve
 # from the root node_modules above).
 COPY apps/serve/package.json apps/serve/bun.lock apps/serve/
 RUN cd apps/serve && bun install --production

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -91,7 +91,7 @@ Every JSON response uses a consistent envelope and carries the request id (also 
 { "status": "error", "version": "0.4.0", "data": { "message": "...", "requestId": "<request-id>" } }
 ```
 
-`/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the zod schemas via `@hono/zod-openapi`.
+`/metrics` is the only exception (Prometheus text). The spec at `/openapi.json` (rendered at `/docs`) is generated from the valibot schemas via `hono-openapi`.
 
 ## Configuration (env)
 

--- a/apps/serve/bun.lock
+++ b/apps/serve/bun.lock
@@ -5,10 +5,12 @@
     "": {
       "name": "ppu-paddle-ocr-serve",
       "dependencies": {
-        "@hono/zod-openapi": "^1.6.3",
         "@scalar/hono-api-reference": "^0.12.1",
+        "@standard-schema/spec": "^1.0.0",
+        "@valibot/to-json-schema": "^1.7.1",
         "hono": "^4.13.7",
-        "zod": "^4.5.4",
+        "hono-openapi": "^1.3.2",
+        "valibot": "^1.4.2",
       },
       "devDependencies": {
         "onnxruntime-common": "^1.27.0",
@@ -22,11 +24,7 @@
     "adm-zip": "^0.6.0",
   },
   "packages": {
-    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@9.1.0", "", { "dependencies": { "openapi3-ts": "^4.6.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pLMeRgRYS7/vZIgAAkOe2P6+XGTifR1MT9pqDoxZ11EmcJJ+DPmdPqLN8ZZF4U8R9KHCCQCS9c2wtuE8wSrfkw=="],
-
-    "@hono/zod-openapi": ["@hono/zod-openapi@1.6.3", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^9.1.0", "@hono/zod-validator": "^0.9.1", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-VYR82Y60plu8g3pN60OUXMVKpmxh3R04Qs++3DY9vtwZ9/sA/BRY0PcRIR+Z37/3itWtM7pYwT9bKiH9JhqV6Q=="],
-
-    "@hono/zod-validator": ["@hono/zod-validator@0.9.1", "", { "peerDependencies": { "hono": ">=4.11.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-iiv6w0qrIc0arfvCtUqBWsvl4fXjzaTcQcCJTTtCnkawF9HHGE+KjEl0ox3gQJ6rKZEgE3mLExlQCF72M+mNuw=="],
+    "@hono/standard-validator": ["@hono/standard-validator@0.4.0", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=4.11.2" } }, "sha512-MxOm1asDh9j7c1D0KiWwppSbFgAQxTRO4YEhjMrJn3lF1BIcXenPdgjSGKDRfQmZdaTaMA8slQLETgVOKyJxFw=="],
 
     "@napi-rs/canvas": ["@napi-rs/canvas@1.0.0", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.0", "@napi-rs/canvas-darwin-arm64": "1.0.0", "@napi-rs/canvas-darwin-x64": "1.0.0", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0", "@napi-rs/canvas-linux-arm64-gnu": "1.0.0", "@napi-rs/canvas-linux-arm64-musl": "1.0.0", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-musl": "1.0.0", "@napi-rs/canvas-win32-arm64-msvc": "1.0.0", "@napi-rs/canvas-win32-x64-msvc": "1.0.0" } }, "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg=="],
 
@@ -64,7 +62,15 @@
 
     "@scalar/validation": ["@scalar/validation@0.6.3", "", {}, "sha512-j3s9XPv8Wo1EG5/naBi4XGF0uXYQ2A3QZNI0NKWgCMxRHVrDJGlZEYymcHDHY7fquRm73P8U3c8xqJqB5yad6w=="],
 
+    "@standard-community/standard-json": ["@standard-community/standard-json@0.3.6", "", { "dependencies": { "quansync": "^0.2.11" }, "peerDependencies": { "@standard-schema/spec": "^1.0.0", "@types/json-schema": "^7.0.15", "@valibot/to-json-schema": "^1.3.0", "arktype": "^2.1.20", "effect": "^3.20.0", "sury": "^10.0.0", "typebox": "^1.0.17", "valibot": "^1.4.2", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "typebox", "valibot", "zod", "zod-to-json-schema"] }, "sha512-tuXKz1Ps4al0W4xhfwii7v4lskKtOv3QE7mcouRVThrBdOR6JzY4Vea3nsxcEnte84bOJvMvXGmOMWE3IBbHyA=="],
+
+    "@standard-community/standard-openapi": ["@standard-community/standard-openapi@0.2.10", "", { "peerDependencies": { "@standard-community/standard-json": "^0.3.5", "@standard-schema/spec": "^1.0.0", "arktype": "^2.1.20", "effect": "^3.20.0", "openapi-types": "^12.1.3", "sury": "^10.0.0", "typebox": "^1.0.0", "valibot": "^1.4.2", "zod": "^3.25.0 || ^4.0.0", "zod-openapi": "^4" }, "optionalPeers": ["arktype", "effect", "sury", "typebox", "valibot", "zod", "zod-openapi"] }, "sha512-whaCN9eu5zv5gu6Kyeh5am/S3AyS1nqo57/wAxs/KPS7+94UhBUZmkIetmXzm22qIV0zMrHt3y+2VfjkbkYYTA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@techstark/opencv-js": ["@techstark/opencv-js@5.0.0-release.1", "", {}, "sha512-PIm+eB0MFtieXoNC2GRao0dv/02sehG+Nv2nSW5D6pQm6J/4WqvDHm0RyoqOmGYQm67jdGiaOdIeTShCY3PIUg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -106,6 +112,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.1", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A=="],
+
     "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -128,6 +136,8 @@
 
     "hono": ["hono@4.13.7", "", {}, "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="],
 
+    "hono-openapi": ["hono-openapi@1.3.2", "", { "dependencies": { "@hono/standard-validator": "^0.4.0", "@standard-community/standard-json": "^0.3.5", "@standard-community/standard-openapi": "^0.2.9", "@standard-schema/spec": "^1.0.0", "@types/json-schema": "^7.0.15", "openapi-types": "^12.1.3" }, "peerDependencies": { "hono": "^4.11.2" } }, "sha512-4feiTNQ6URizSmOuTMZsrbOczep8uXy+WrStnwZxxB3ud7+hGy6E5XbJVWSgT0hb9kZ9k2AqukYZbvJqx1aQqA=="],
+
     "matcher": ["matcher@4.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ=="],
 
     "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
@@ -138,9 +148,11 @@
 
     "onnxruntime-node": ["onnxruntime-node@1.27.0", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^4.1.3", "onnxruntime-common": "1.27.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw=="],
 
-    "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "ppu-ocv": ["ppu-ocv@4.0.0", "", { "dependencies": { "@napi-rs/canvas": "^1.0.0", "@techstark/opencv-js": "^5.0.0-release.1" }, "peerDependencies": { "@shopify/react-native-skia": ">=1.0.0" }, "optionalPeers": ["@shopify/react-native-skia"] }, "sha512-ol+S9/KLZ0aTV0xbC8+ZB0iM+FYux8ujoULeQoYY2IDBZj4LAuujJUkzHzUA2O3KzHs17KuuIzV/w4/htPdn3w=="],
+
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
@@ -152,11 +164,9 @@
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
     "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
-
-    "@asteasolutions/zod-to-openapi/openapi3-ts": ["openapi3-ts@4.6.1", "", { "dependencies": { "yaml": "^2.9.0" } }, "sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA=="],
 
     "@scalar/types/type-fest": ["type-fest@5.9.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw=="],
   }

--- a/apps/serve/package.json
+++ b/apps/serve/package.json
@@ -12,10 +12,12 @@
   },
   "comment": "Standalone app importing ppu-paddle-ocr from source via tsconfig paths. Runtime deps are just hono+zod; the lib's deps (ppu-ocv, onnxruntime) are dev-only here (needed to type-check the imported source) and resolve from the repo-root node_modules at runtime.",
   "dependencies": {
-    "@hono/zod-openapi": "^1.6.3",
     "@scalar/hono-api-reference": "^0.12.1",
+    "@standard-schema/spec": "^1.0.0",
+    "@valibot/to-json-schema": "^1.7.1",
     "hono": "^4.13.7",
-    "zod": "^4.5.4"
+    "hono-openapi": "^1.3.2",
+    "valibot": "^1.4.2"
   },
   "devDependencies": {
     "onnxruntime-common": "^1.27.0",

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors";
 import { ipRestriction } from "hono/ip-restriction";
 import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
+import { HTTPException } from "hono/http-exception";
 import { secureHeaders } from "hono/secure-headers";
 import { openAPIRouteHandler } from "hono-openapi";
 import { multipartDetectSchema, multipartOcrSchema } from "./core/schemas.js";
@@ -115,6 +116,9 @@ app.notFound((c) => sendError(c, 404, "Route not found"));
 
 app.onError((err, c) => {
   if (err instanceof HttpError) return sendError(c, err.status, err.message);
+  // Hono's own middleware (the body validator on malformed JSON, for one)
+  // throws these with the right status; keep it instead of masking as 500.
+  if (err instanceof HTTPException) return sendError(c, err.status, err.message);
   if (err instanceof QueueFullError) {
     return c.json(failure(err.message, c.get("requestId")), 429, { "Retry-After": "1" });
   }

--- a/apps/serve/src/app.ts
+++ b/apps/serve/src/app.ts
@@ -1,4 +1,4 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
+import { Hono } from "hono";
 import { Scalar } from "@scalar/hono-api-reference";
 import { bearerAuth } from "hono/bearer-auth";
 import { getConnInfo } from "hono/bun";
@@ -7,7 +7,8 @@ import { ipRestriction } from "hono/ip-restriction";
 import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
-import { ZodError } from "zod";
+import { openAPIRouteHandler } from "hono-openapi";
+import { multipartDetectSchema, multipartOcrSchema } from "./core/schemas.js";
 import { failure } from "./core/api-response.js";
 import { config } from "./core/config.js";
 import { HttpError, sendError } from "./core/errors.js";
@@ -28,18 +29,7 @@ import * as taskCancel from "./modules/task-cancel/index.js";
 import * as taskResult from "./modules/task-result/index.js";
 import * as taskStatus from "./modules/task-status/index.js";
 
-export const app = new OpenAPIHono<Env>({
-  strict: false,
-  // Consistent envelope for request-validation failures.
-  defaultHook: (result, c) => {
-    if (!result.success) {
-      const detail = result.error.issues
-        .map((i) => `${i.path.join(".") || "body"}: ${i.message}`)
-        .join("; ");
-      return sendError(c, 400, `Validation failed - ${detail}`);
-    }
-  },
-});
+export const app = new Hono<Env>({ strict: false });
 
 app.use("*", requestId());
 app.use("*", logger());
@@ -61,40 +51,60 @@ app.use("*", async (c, next) => {
 if (config.rateLimitEnabled) app.use("/v1/*", rateLimiter());
 if (config.secretKey) app.use("/v1/*", bearerAuth({ token: config.secretKey }));
 
-// One folder = one endpoint; register each slice's route + handler.
-app.openapi(health.route, health.handler);
-app.openapi(ready.route, ready.handler);
-app.openapi(metrics.route, metrics.handler);
-app.openapi(models.route, models.handler);
-// /v1/ocr accepts multipart OR JSON, so it's documented (registerPath) but
-// parses its body manually rather than via auto-validation.
-app.openAPIRegistry.registerPath(recognize.route);
-app.post(recognize.route.path, recognize.handler);
-// /v1/detect is dual-content (multipart or JSON) like /v1/ocr.
-app.openAPIRegistry.registerPath(detect.route);
-app.post(detect.route.path, detect.handler);
-app.openapi(recognizeBatch.route, recognizeBatch.handler);
-app.openapi(recognizeStream.route, recognizeStream.handler);
-app.openapi(recognizeAsync.route, recognizeAsync.handler);
-app.openapi(taskStatus.route, taskStatus.handler);
-app.openapi(taskResult.route, taskResult.handler);
-app.openapi(taskCancel.route, taskCancel.handler);
-
-app.openAPIRegistry.registerComponent("securitySchemes", "Bearer", {
-  type: "http",
-  scheme: "bearer",
-  description: "Send `Authorization: Bearer <SECRET_KEY>`. Required only when SECRET_KEY is set.",
-});
+// One folder = one endpoint; each slice mounts its own route, validator, and
+// handler so `c.req.valid()` stays typed end to end.
+for (const slice of [
+  health,
+  ready,
+  metrics,
+  models,
+  recognize,
+  detect,
+  recognizeBatch,
+  recognizeStream,
+  recognizeAsync,
+  taskStatus,
+  taskResult,
+  taskCancel,
+]) {
+  slice.mount(app);
+}
 
 if (config.docsEnabled) {
-  app.doc("/openapi.json", {
-    openapi: "3.1.0",
-    info: {
-      title: "ppu-paddle-ocr-serve",
-      version: "0.4.0",
-      description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
-    },
-  });
+  app.get(
+    "/openapi.json",
+    openAPIRouteHandler(app, {
+      documentation: {
+        openapi: "3.1.0",
+        info: {
+          title: "ppu-paddle-ocr-serve",
+          version: "0.4.0",
+          description: "REST API serving ppu-paddle-ocr. POST an image, get OCR JSON.",
+        },
+        components: {
+          // Documentation-only bodies (parsed manually); named here so the
+          // dual-content routes can $ref them like every other request body.
+          schemas: {
+            OcrMultipartRequest: multipartOcrSchema,
+            DetectMultipartRequest: multipartDetectSchema,
+          },
+          securitySchemes: {
+            Bearer: {
+              type: "http",
+              scheme: "bearer",
+              description:
+                "Send `Authorization: Bearer <SECRET_KEY>`. Required only when SECRET_KEY is set.",
+            },
+          },
+        },
+      },
+      // The spec, the docs page, and the redirect are not API operations.
+      exclude: ["/openapi.json", "/docs", "/"],
+      // Validation failures use the error envelope declared per route, not
+      // hono-openapi's own { success, error, data } shape.
+      defaultValidationErrorResponse: false,
+    })
+  );
   app.get("/docs", Scalar({ url: "/openapi.json", pageTitle: "ppu-paddle-ocr-serve - API" }));
   app.get("/", (c) => c.redirect("/docs"));
 } else {
@@ -105,10 +115,6 @@ app.notFound((c) => sendError(c, 404, "Route not found"));
 
 app.onError((err, c) => {
   if (err instanceof HttpError) return sendError(c, err.status, err.message);
-  if (err instanceof ZodError) {
-    const detail = err.issues.map((i) => `${i.path.join(".") || "body"}: ${i.message}`).join("; ");
-    return sendError(c, 400, `Validation failed - ${detail}`);
-  }
   if (err instanceof QueueFullError) {
     return c.json(failure(err.message, c.get("requestId")), 429, { "Retry-After": "1" });
   }

--- a/apps/serve/src/core/api-response.ts
+++ b/apps/serve/src/core/api-response.ts
@@ -1,5 +1,7 @@
-import { z } from "@hono/zod-openapi";
 import type { Context } from "hono";
+import { resolver } from "hono-openapi";
+import type { DescribeRouteOptions } from "hono-openapi";
+import * as v from "valibot";
 import type { Env } from "./types.js";
 
 /** API version surfaced in every response envelope. */
@@ -20,13 +22,10 @@ export type ErrorEnvelope = {
   data: { message: string; requestId?: string };
 };
 
-/** One `responses` entry for createRoute, carrying the error envelope schema. */
-export type ErrorResponseEntry = {
-  description: string;
-  content: { "application/json": { schema: typeof errorEnvelopeSchema } };
-};
+/** One entry of a route's `responses` map. */
+type ResponseEntry = NonNullable<DescribeRouteOptions["responses"]>[string];
 
-/** oksara-style success envelope: `{ status, version, metadata: { id, … }, data }`. */
+/** oksara-style success envelope: `{ status, version, metadata: { id, ... }, data }`. */
 export function success<T>(
   c: Context<Env>,
   data: T,
@@ -49,27 +48,34 @@ export function failure(message: string, requestId?: string): ErrorEnvelope {
   };
 }
 
-/** Wrap a data schema in the success envelope for OpenAPI responses. */
-export function envelope<T extends z.ZodTypeAny>(data: T): z.ZodTypeAny {
-  return z.object({
-    status: z.literal("success"),
-    version: z.string(),
-    metadata: z.object({ id: z.string() }).passthrough(),
+/** Wrap a data schema in the success envelope. */
+export function envelope<T extends v.GenericSchema>(data: T): v.GenericSchema {
+  return v.object({
+    status: v.literal("success"),
+    version: v.string(),
+    metadata: v.looseObject({ id: v.string() }),
     data,
   });
 }
 
 /** Error envelope schema for OpenAPI responses. */
-export const errorEnvelopeSchema = z
-  .object({
-    status: z.literal("error"),
-    version: z.string(),
-    data: z.object({ message: z.string(), requestId: z.string().optional() }),
-  })
-  .openapi("ErrorResponse");
+export const errorEnvelopeSchema = v.pipe(
+  v.object({
+    status: v.literal("error"),
+    version: v.string(),
+    data: v.object({ message: v.string(), requestId: v.optional(v.string()) }),
+  }),
+  v.metadata({ ref: "ErrorResponse" })
+);
 
-/** Reusable error response entry for createRoute `responses`. */
-export const errorResponse = (description: string): ErrorResponseEntry => ({
+/** A JSON success response entry carrying `data` inside the envelope. */
+export const jsonResponse = (description: string, data: v.GenericSchema): ResponseEntry => ({
   description,
-  content: { "application/json": { schema: errorEnvelopeSchema } },
+  content: { "application/json": { schema: resolver(envelope(data)) } },
+});
+
+/** Reusable error response entry for a route's `responses`. */
+export const errorResponse = (description: string): ResponseEntry => ({
+  description,
+  content: { "application/json": { schema: resolver(errorEnvelopeSchema) } },
 });

--- a/apps/serve/src/core/config.ts
+++ b/apps/serve/src/core/config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as v from "valibot";
 
 const toArray = (val: string | undefined): string[] =>
   (val ?? "")
@@ -9,64 +9,67 @@ const toArray = (val: string | undefined): string[] =>
 const toBoolean = (val: string | undefined): boolean =>
   val ? ["true", "1", "yes", "on"].includes(val.toLowerCase()) : false;
 
+/** Env values arrive as strings; parse them as numbers and reject NaN. */
+const num = v.pipe(v.union([v.string(), v.number()]), v.transform(Number), v.number());
+const positiveInt = v.pipe(num, v.integer(), v.minValue(1));
+const nonNegativeInt = v.pipe(num, v.integer(), v.minValue(0));
+const str = (fallback: string) => v.optional(v.string(), fallback);
+const int = (fallback: number) => v.optional(positiveInt, fallback);
+
 /** Raw environment schema. Every knob is documented in `.env.example`. */
-const EnvSchema = z.object({
-  API_ENV: z.enum(["development", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(8080),
-  HOST: z.string().default("0.0.0.0"),
+const EnvSchema = v.object({
+  API_ENV: v.optional(v.picklist(["development", "production"]), "development"),
+  PORT: int(8080),
+  HOST: str("0.0.0.0"),
 
   // Security
-  SECRET_KEY: z.string().optional(),
-  IP_WHITE_LIST: z.string().default("*"),
-  IP_DENY_LIST: z.string().default(""),
-  CORS_ORIGINS: z.string().default("*"),
-  DOCS_ENABLED: z.string().default("true"),
+  SECRET_KEY: v.optional(v.string()),
+  IP_WHITE_LIST: str("*"),
+  IP_DENY_LIST: str(""),
+  CORS_ORIGINS: str("*"),
+  DOCS_ENABLED: str("true"),
 
   // Rate limiting (fixed window, per client IP)
-  RATE_LIMIT_ENABLED: z.string().default("true"),
-  RATE_LIMIT_PER_WINDOW: z.coerce.number().int().positive().default(120),
-  RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),
+  RATE_LIMIT_ENABLED: str("true"),
+  RATE_LIMIT_PER_WINDOW: int(120),
+  RATE_LIMIT_WINDOW_SECONDS: int(60),
 
   // Request limits
-  REQUEST_TIMEOUT_SECONDS: z.coerce.number().int().positive().default(30),
-  MAX_UPLOAD_BYTES: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(10 * 1024 * 1024),
-  MAX_IMAGE_PIXELS: z.coerce.number().int().positive().default(40_000_000),
-  MAX_BATCH_IMAGES: z.coerce.number().int().positive().default(32),
+  REQUEST_TIMEOUT_SECONDS: int(30),
+  MAX_UPLOAD_BYTES: int(10 * 1024 * 1024),
+  MAX_IMAGE_PIXELS: int(40_000_000),
+  MAX_BATCH_IMAGES: int(32),
 
   // OCR engine / models
-  EXECUTION_PROVIDERS: z.string().default("cpu"),
-  DEFAULT_STRATEGY: z.enum(["per-box", "per-line", "cross-line"]).default("per-line"),
-  DEFAULT_ENGINE: z.enum(["opencv", "canvas-native"]).default("opencv"),
-  MIN_CONFIDENCE: z.coerce.number().min(0).max(1).optional(),
-  MAX_SIDE_LENGTH: z.union([z.literal("auto"), z.coerce.number().int().positive()]).optional(),
-  MAX_CROP_SOURCE_SIDE_LENGTH: z.coerce.number().int().positive().optional(),
-  MODEL_DETECTION: z.string().optional(),
-  MODEL_RECOGNITION: z.string().optional(),
-  MODEL_DICT: z.string().optional(),
+  EXECUTION_PROVIDERS: str("cpu"),
+  DEFAULT_STRATEGY: v.optional(v.picklist(["per-box", "per-line", "cross-line"]), "per-line"),
+  DEFAULT_ENGINE: v.optional(v.picklist(["opencv", "canvas-native"]), "opencv"),
+  MIN_CONFIDENCE: v.optional(v.pipe(num, v.minValue(0), v.maxValue(1))),
+  MAX_SIDE_LENGTH: v.optional(v.union([v.literal("auto"), positiveInt])),
+  MAX_CROP_SOURCE_SIDE_LENGTH: v.optional(positiveInt),
+  MODEL_DETECTION: v.optional(v.string()),
+  MODEL_RECOGNITION: v.optional(v.string()),
+  MODEL_DICT: v.optional(v.string()),
 
   // Inference backpressure / async tasks
-  MAX_CONCURRENCY: z.coerce.number().int().nonnegative().default(0),
-  MAX_QUEUE_DEPTH: z.coerce.number().int().positive().default(100),
-  TASK_TTL_SECONDS: z.coerce.number().int().positive().default(600),
+  MAX_CONCURRENCY: v.optional(nonNegativeInt, 0),
+  MAX_QUEUE_DEPTH: int(100),
+  TASK_TTL_SECONDS: int(600),
 
   // Source fetching (SSRF allowlist of https hosts)
-  SOURCE_URL_ALLOWLIST: z.string().default(""),
+  SOURCE_URL_ALLOWLIST: str(""),
 });
 
 function build(raw: NodeJS.ProcessEnv) {
-  const parsed = EnvSchema.safeParse(raw);
+  const parsed = v.safeParse(EnvSchema, raw);
   if (!parsed.success) {
     console.error(
-      "❌ Invalid environment variables:",
-      JSON.stringify(parsed.error.flatten().fieldErrors, null, 2)
+      "Invalid environment variables:",
+      JSON.stringify(v.flatten(parsed.issues).nested, null, 2)
     );
     process.exit(1);
   }
-  const e = parsed.data;
+  const e = parsed.output;
 
   const executionProviders = toArray(e.EXECUTION_PROVIDERS);
   const usesAccelerator = executionProviders.some((p) => p !== "cpu" && p !== "wasm");

--- a/apps/serve/src/core/input.ts
+++ b/apps/serve/src/core/input.ts
@@ -1,8 +1,10 @@
 import type { Context } from "hono";
+import * as v from "valibot";
 import { config } from "./config.js";
 import { badRequest, payloadTooLarge } from "./errors.js";
 import type { OcrOptions } from "./schemas.js";
-import { jsonOcrSchema, ocrOptionsSchema } from "./schemas.js";
+import { jsonOcrSchema, multipartOcrOptionsSchema } from "./schemas.js";
+import { describeIssues } from "./validate.js";
 
 const tooBig = () =>
   payloadTooLarge(`Image exceeds MAX_UPLOAD_BYTES (${config.maxUploadBytes} bytes)`);
@@ -92,6 +94,13 @@ export async function resolveSource(source: string): Promise<ArrayBuffer> {
   return buf;
 }
 
+/** Parse with the same 400 the route validators produce. */
+function parseOrThrow<S extends v.GenericSchema>(schema: S, input: unknown): v.InferOutput<S> {
+  const result = v.safeParse(schema, input);
+  if (!result.success) throw badRequest(`Validation failed - ${describeIssues(result.issues)}`);
+  return result.output;
+}
+
 /** Read a single image: multipart `file` field, or JSON `{ source, ...opts }`. */
 export async function readSingle(c: Context): Promise<{ image: ArrayBuffer; opts: OcrOptions }> {
   const contentType = c.req.header("content-type") ?? "";
@@ -105,7 +114,7 @@ export async function readSingle(c: Context): Promise<{ image: ArrayBuffer; opts
     const image = await file.arrayBuffer();
     if (image.byteLength > config.maxUploadBytes) throw tooBig();
     assertImage(image);
-    const opts = ocrOptionsSchema.parse({
+    const opts = parseOrThrow(multipartOcrOptionsSchema, {
       strategy: body["strategy"],
       flatten: body["flatten"],
       engine: body["engine"],
@@ -117,7 +126,7 @@ export async function readSingle(c: Context): Promise<{ image: ArrayBuffer; opts
   const json = await c.req.json().catch(() => {
     throw badRequest("Invalid JSON body");
   });
-  const { source, ...opts } = jsonOcrSchema.parse(json);
+  const { source, ...opts } = parseOrThrow(jsonOcrSchema, json);
   const image = await resolveSource(source);
   return { image, opts };
 }

--- a/apps/serve/src/core/schemas.ts
+++ b/apps/serve/src/core/schemas.ts
@@ -1,126 +1,163 @@
-import { z } from "@hono/zod-openapi";
+import * as v from "valibot";
 
-const booleanish = z.preprocess(
-  (v) => (typeof v === "string" ? v === "true" || v === "1" : v),
-  z.boolean().optional()
-);
-
-const strategy = z.enum(["per-box", "per-line", "cross-line"]).optional();
-const engine = z.enum(["opencv", "canvas-native"]).optional();
-
-const minimumConfidence = z.coerce.number().min(0).max(1).optional();
+const strategy = v.optional(v.picklist(["per-box", "per-line", "cross-line"]));
+const engine = v.optional(v.picklist(["opencv", "canvas-native"]));
+const unitInterval = v.pipe(v.number(), v.minValue(0), v.maxValue(1));
+const positiveInt = v.pipe(v.number(), v.integer(), v.minValue(1));
 
 /** Per-request recognition options shared by every input shape. */
-export const ocrOptionsSchema = z.object({
+export const ocrOptionsSchema = v.object({
   strategy,
-  flatten: booleanish,
+  flatten: v.optional(v.boolean()),
   engine,
-  minimumConfidence,
+  minimumConfidence: v.optional(unitInterval),
 });
-export type OcrOptions = z.infer<typeof ocrOptionsSchema>;
+export type OcrOptions = v.InferOutput<typeof ocrOptionsSchema>;
 
-// A 1×1 PNG as a data: URI - a valid, runnable example so Scalar's "Send"
+// Multipart fields arrive as strings; coerce them to the JSON option types.
+const formBoolean = v.optional(
+  v.pipe(
+    v.string(),
+    v.transform((s) => s === "true" || s === "1")
+  )
+);
+const formNumber = v.pipe(v.string(), v.transform(Number), v.number());
+
+/** The same options read from multipart form fields. */
+export const multipartOcrOptionsSchema = v.object({
+  strategy,
+  flatten: formBoolean,
+  engine,
+  minimumConfidence: v.optional(v.pipe(formNumber, unitInterval)),
+});
+
+// A 1x1 PNG as a data: URI - a valid, runnable example so Scalar's "Send"
 // works out of the box (it decodes, finds no text, returns an empty result).
 const EXAMPLE_IMAGE =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
-/** JSON body for single-image OCR. */
-export const jsonOcrSchema = ocrOptionsSchema
-  .extend({
-    source: z.string().min(1).openapi({
-      description: "A `data:` URI or an allowlisted https URL. Local paths are rejected.",
-      example: EXAMPLE_IMAGE,
-    }),
-  })
-  .openapi("OcrJsonRequest");
+const source = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.description("A `data:` URI or an allowlisted https URL. Local paths are rejected."),
+  v.metadata({ example: EXAMPLE_IMAGE })
+);
 
-/** Multipart body for single-image OCR (documentation only - parsed manually). */
-export const multipartOcrSchema = z
-  .object({
-    file: z.custom<File>().openapi({ type: "string", format: "binary" }),
-    strategy,
-    flatten: booleanish,
-    engine,
-    minimumConfidence,
-  })
-  .openapi("OcrMultipartRequest");
+/** JSON body for single-image OCR. */
+export const jsonOcrSchema = v.pipe(
+  v.object({ ...ocrOptionsSchema.entries, source }),
+  v.metadata({ ref: "OcrJsonRequest" })
+);
 
 /** JSON body for detection-only inference. */
-export const jsonDetectSchema = z
-  .object({
-    engine,
-    source: z.string().min(1).openapi({
-      description: "A `data:` URI or an allowlisted https URL. Local paths are rejected.",
-      example: EXAMPLE_IMAGE,
-    }),
-  })
-  .openapi("DetectJsonRequest");
-
-/** Multipart body for detection-only inference (documentation only - parsed manually). */
-export const multipartDetectSchema = z
-  .object({
-    file: z.custom<File>().openapi({ type: "string", format: "binary" }),
-    engine,
-  })
-  .openapi("DetectMultipartRequest");
+export const jsonDetectSchema = v.pipe(
+  v.object({ engine, source }),
+  v.metadata({ ref: "DetectJsonRequest" })
+);
 
 /** JSON body for batch / async / stream OCR. */
-export const batchOcrSchema = ocrOptionsSchema
-  .extend({
-    sources: z
-      .array(z.string().min(1))
-      .min(1)
-      .openapi({ description: "data: URIs or https URLs." }),
-    concurrency: z.coerce.number().int().positive().optional(),
-    settle: booleanish,
-  })
-  .openapi("BatchRequest", {
+export const batchOcrSchema = v.pipe(
+  v.object({
+    ...ocrOptionsSchema.entries,
+    sources: v.pipe(
+      v.array(v.pipe(v.string(), v.minLength(1))),
+      v.minLength(1),
+      v.description("data: URIs or https URLs.")
+    ),
+    concurrency: v.optional(positiveInt),
+    settle: v.optional(v.boolean()),
+  }),
+  v.metadata({
+    ref: "BatchRequest",
     example: { sources: [EXAMPLE_IMAGE], strategy: "per-line", settle: true },
-  });
-export type BatchOcrBody = z.infer<typeof batchOcrSchema>;
+  })
+);
+export type BatchOcrBody = v.InferOutput<typeof batchOcrSchema>;
 
-export const taskIdParamsSchema = z.object({
-  id: z.string().openapi({ param: { name: "id", in: "path" }, example: crypto.randomUUID() }),
+export const taskIdParamsSchema = v.object({
+  id: v.pipe(v.string(), v.metadata({ example: crypto.randomUUID() })),
 });
+
+// --- Multipart bodies (documentation only - parsed manually) ---
+// Plain OpenAPI objects: the file field has no schema-library shape, and these
+// bodies never pass through a validator.
+
+const stringEnum = (values: readonly string[]) => ({ type: "string" as const, enum: [...values] });
+const multipartOptions = {
+  strategy: stringEnum(["per-box", "per-line", "cross-line"]),
+  flatten: { type: "boolean" as const },
+  engine: stringEnum(["opencv", "canvas-native"]),
+  minimumConfidence: { type: "number" as const, minimum: 0, maximum: 1 },
+};
+const binaryFile = { type: "string" as const, format: "binary" };
+
+/** Multipart body for single-image OCR. */
+export const multipartOcrSchema = {
+  type: "object" as const,
+  properties: { file: binaryFile, ...multipartOptions },
+  required: ["file"],
+};
+
+/** Multipart body for detection-only inference. */
+export const multipartDetectSchema = {
+  type: "object" as const,
+  properties: { file: binaryFile, engine: multipartOptions.engine },
+  required: ["file"],
+};
 
 // --- Response schemas ---
 
-const boxSchema = z.object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() });
-const recognitionItemSchema = z.object({
-  text: z.string(),
-  confidence: z.number(),
+const boxSchema = v.object({
+  x: v.number(),
+  y: v.number(),
+  width: v.number(),
+  height: v.number(),
+});
+const recognitionItemSchema = v.object({
+  text: v.string(),
+  confidence: v.number(),
   box: boxSchema,
 });
-export const ocrResultSchema = z
-  .object({
-    text: z.string(),
-    confidence: z.number(),
-    lines: z.array(z.array(recognitionItemSchema)).optional(),
-    results: z.array(recognitionItemSchema).optional(),
-  })
-  .openapi("OcrResult");
+export const ocrResultSchema = v.pipe(
+  v.object({
+    text: v.string(),
+    confidence: v.number(),
+    lines: v.optional(v.array(v.array(recognitionItemSchema))),
+    results: v.optional(v.array(recognitionItemSchema)),
+  }),
+  v.metadata({ ref: "OcrResult" })
+);
 
-export const detectResultSchema = z.object({ boxes: z.array(boxSchema) }).openapi("DetectResult");
+export const detectResultSchema = v.pipe(
+  v.object({ boxes: v.array(boxSchema) }),
+  v.metadata({ ref: "DetectResult" })
+);
 
-export const batchResultSchema = z.object({ results: z.array(z.unknown()) }).openapi("BatchResult");
+export const batchResultSchema = v.pipe(
+  v.object({ results: v.array(v.unknown()) }),
+  v.metadata({ ref: "BatchResult" })
+);
 
-export const taskAcceptedSchema = z
-  .object({ taskId: z.string(), status: z.string() })
-  .openapi("TaskAccepted");
+export const taskAcceptedSchema = v.pipe(
+  v.object({ taskId: v.string(), status: v.string() }),
+  v.metadata({ ref: "TaskAccepted" })
+);
 
-export const taskStatusSchema = z
-  .object({
-    id: z.string(),
-    status: z.enum(["queued", "running", "done", "failed", "cancelled"]),
-    updatedAt: z.number(),
-  })
-  .openapi("TaskStatus");
+export const taskStatusSchema = v.pipe(
+  v.object({
+    id: v.string(),
+    status: v.picklist(["queued", "running", "done", "failed", "cancelled"]),
+    updatedAt: v.number(),
+  }),
+  v.metadata({ ref: "TaskStatus" })
+);
 
-export const modelsSchema = z
-  .object({
-    engines: z.array(z.string()),
-    strategies: z.array(z.string()),
-    default: z.object({ engine: z.string(), strategy: z.string() }),
-    executionProviders: z.array(z.string()),
-  })
-  .openapi("Models");
+export const modelsSchema = v.pipe(
+  v.object({
+    engines: v.array(v.string()),
+    strategies: v.array(v.string()),
+    default: v.object({ engine: v.string(), strategy: v.string() }),
+    executionProviders: v.array(v.string()),
+  }),
+  v.metadata({ ref: "Models" })
+);

--- a/apps/serve/src/core/validate.ts
+++ b/apps/serve/src/core/validate.ts
@@ -1,0 +1,35 @@
+import type { Env as HonoEnv, ValidationTargets } from "hono";
+import { validator } from "hono-openapi";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { badRequest } from "./errors.js";
+
+/** The subset of a Standard Schema issue this formatter reads; valibot's own issues fit too. */
+type IssueLike = { message: string; path?: readonly unknown[] };
+
+/** Turn validation issues into one line: `path: message; path: message`. */
+export function describeIssues(issues: readonly IssueLike[]): string {
+  return issues
+    .map((i) => {
+      const path = (i.path ?? [])
+        .map((p) => (typeof p === "object" && p !== null && "key" in p ? String(p.key) : String(p)))
+        .join(".");
+      return `${path || "body"}: ${i.message}`;
+    })
+    .join("; ");
+}
+
+/**
+ * hono-openapi's validator with the envelope-shaped 400. The thrown HttpError
+ * reaches app.onError, so validation failures share the error path with every
+ * other 400.
+ */
+export function validate<
+  Schema extends StandardSchemaV1,
+  Target extends keyof ValidationTargets,
+  E extends HonoEnv,
+  P extends string,
+>(target: Target, schema: Schema): ReturnType<typeof validator<Schema, Target, E, P>> {
+  return validator<Schema, Target, E, P>(target, schema, (result) => {
+    if (!result.success) throw badRequest(`Validation failed - ${describeIssues(result.error)}`);
+  });
+}

--- a/apps/serve/src/modules/detect/index.ts
+++ b/apps/serve/src/modules/detect/index.ts
@@ -1,50 +1,52 @@
-import type { RouteConfig } from "@hono/zod-openapi";
-import type { Context } from "hono";
-import { envelope, errorResponse, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { errorResponse, jsonResponse, success } from "../../core/api-response.js";
 import { readSingle } from "../../core/input.js";
 import { runDetect } from "../../core/runner.js";
-import { detectResultSchema, jsonDetectSchema, multipartDetectSchema } from "../../core/schemas.js";
+import { detectResultSchema, jsonDetectSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
 
 // Like /v1/ocr, this endpoint accepts BOTH multipart and JSON, so it is
-// documented via registerPath and parses its body manually.
-export const route: RouteConfig = {
-  method: "post",
-  path: "/v1/detect",
-  tags: ["OCR"],
-  summary: "Detect text boxes in a single image (no recognition)",
-  description:
-    "Runs only the detection model and returns bounding boxes in original image " +
-    "coordinates. multipart/form-data with a `file` field, or JSON `{ source, engine? }`.",
-  security: [{ Bearer: [] }],
-  request: {
-    body: {
-      required: true,
-      content: {
-        "multipart/form-data": { schema: multipartDetectSchema },
-        "application/json": { schema: jsonDetectSchema },
+// documented here and parses its body manually.
+export function mount(app: Hono<Env>): void {
+  app.post(
+    "/v1/detect",
+    describeRoute({
+      tags: ["OCR"],
+      summary: "Detect text boxes in a single image (no recognition)",
+      description:
+        "Runs only the detection model and returns bounding boxes in original image " +
+        "coordinates. multipart/form-data with a `file` field, or JSON `{ source, engine? }`.",
+      security: [{ Bearer: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          "multipart/form-data": {
+            schema: { $ref: "#/components/schemas/DetectMultipartRequest" },
+          },
+          "application/json": { schema: resolver(jsonDetectSchema) },
+        },
       },
-    },
-  },
-  responses: {
-    200: {
-      description: "Detected boxes. `metadata` carries `speed` (seconds) and `count`.",
-      content: { "application/json": { schema: envelope(detectResultSchema) } },
-    },
-    400: errorResponse("Invalid input, unsupported image type, or source error."),
-    413: errorResponse("Image exceeds MAX_UPLOAD_BYTES."),
-    429: errorResponse("Rate limit or inference queue full."),
-  },
-};
-
-export const handler = async (c: Context<Env>): Promise<Response> => {
-  const { image, opts } = await readSingle(c);
-  const { result, meta } = await runDetect(image, opts);
-  return c.json(
-    success(c, result, {
-      speed: meta.ms / 1000,
-      count: result.boxes.length,
-      engine: meta.engine,
-    })
+      responses: {
+        200: jsonResponse(
+          "Detected boxes. `metadata` carries `speed` (seconds) and `count`.",
+          detectResultSchema
+        ),
+        400: errorResponse("Invalid input, unsupported image type, or source error."),
+        413: errorResponse("Image exceeds MAX_UPLOAD_BYTES."),
+        429: errorResponse("Rate limit or inference queue full."),
+      },
+    }),
+    async (c) => {
+      const { image, opts } = await readSingle(c);
+      const { result, meta } = await runDetect(image, opts);
+      return c.json(
+        success(c, result, {
+          speed: meta.ms / 1000,
+          count: result.boxes.length,
+          engine: meta.engine,
+        })
+      );
+    }
   );
-};
+}

--- a/apps/serve/src/modules/health/index.ts
+++ b/apps/serve/src/modules/health/index.ts
@@ -1,20 +1,17 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import * as v from "valibot";
+import { jsonResponse, success } from "../../core/api-response.js";
 import type { Env } from "../../core/types.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/health",
-  tags: ["System"],
-  summary: "Liveness probe",
-  responses: {
-    200: {
-      description: "Service is up.",
-      content: { "application/json": { schema: envelope(z.object({ alive: z.boolean() })) } },
-    },
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) =>
-  c.json(success(c, { alive: true }), 200);
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/health",
+    describeRoute({
+      tags: ["System"],
+      summary: "Liveness probe",
+      responses: { 200: jsonResponse("Service is up.", v.object({ alive: v.boolean() })) },
+    }),
+    (c) => c.json(success(c, { alive: true }), 200)
+  );
+}

--- a/apps/serve/src/modules/metrics/index.ts
+++ b/apps/serve/src/modules/metrics/index.ts
@@ -1,20 +1,21 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
 import { renderMetrics } from "../../core/metrics.js";
 import type { Env } from "../../core/types.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/metrics",
-  tags: ["System"],
-  summary: "Prometheus metrics",
-  responses: {
-    200: {
-      description: "Prometheus exposition text.",
-      content: { "text/plain": { schema: z.string() } },
-    },
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) =>
-  c.text(renderMetrics(), 200, { "content-type": "text/plain; version=0.0.4" });
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/metrics",
+    describeRoute({
+      tags: ["System"],
+      summary: "Prometheus metrics",
+      responses: {
+        200: {
+          description: "Prometheus exposition text.",
+          content: { "text/plain": { schema: { type: "string" } } },
+        },
+      },
+    }),
+    (c) => c.text(renderMetrics(), 200, { "content-type": "text/plain; version=0.0.4" })
+  );
+}

--- a/apps/serve/src/modules/models/index.ts
+++ b/apps/serve/src/modules/models/index.ts
@@ -1,28 +1,28 @@
-import { createRoute } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { jsonResponse, success } from "../../core/api-response.js";
 import { config } from "../../core/config.js";
 import { modelsSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/v1/models",
-  tags: ["System"],
-  summary: "Available engines, strategies, and defaults",
-  security: [{ Bearer: [] }],
-  responses: {
-    200: { description: "ok", content: { "application/json": { schema: envelope(modelsSchema) } } },
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) =>
-  c.json(
-    success(c, {
-      engines: ["opencv", "canvas-native"],
-      strategies: ["per-box", "per-line", "cross-line"],
-      default: { engine: config.defaultEngine, strategy: config.defaultStrategy },
-      executionProviders: config.executionProviders,
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/v1/models",
+    describeRoute({
+      tags: ["System"],
+      summary: "Available engines, strategies, and defaults",
+      security: [{ Bearer: [] }],
+      responses: { 200: jsonResponse("ok", modelsSchema) },
     }),
-    200
+    (c) =>
+      c.json(
+        success(c, {
+          engines: ["opencv", "canvas-native"],
+          strategies: ["per-box", "per-line", "cross-line"],
+          default: { engine: config.defaultEngine, strategy: config.defaultStrategy },
+          executionProviders: config.executionProviders,
+        }),
+        200
+      )
   );
+}

--- a/apps/serve/src/modules/ready/index.ts
+++ b/apps/serve/src/modules/ready/index.ts
@@ -1,24 +1,24 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, failure, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import * as v from "valibot";
+import { errorResponse, failure, jsonResponse, success } from "../../core/api-response.js";
 import { isReady } from "../../core/service.js";
 import type { Env } from "../../core/types.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/ready",
-  tags: ["System"],
-  summary: "Readiness probe (200 once models are warmed)",
-  responses: {
-    200: {
-      description: "Models warmed.",
-      content: { "application/json": { schema: envelope(z.object({ ready: z.boolean() })) } },
-    },
-    503: errorResponse("Models are still loading."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) =>
-  isReady()
-    ? c.json(success(c, { ready: true }), 200)
-    : c.json(failure("Models are still loading", c.get("requestId")), 503);
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/ready",
+    describeRoute({
+      tags: ["System"],
+      summary: "Readiness probe (200 once models are warmed)",
+      responses: {
+        200: jsonResponse("Models warmed.", v.object({ ready: v.boolean() })),
+        503: errorResponse("Models are still loading."),
+      },
+    }),
+    (c) =>
+      isReady()
+        ? c.json(success(c, { ready: true }), 200)
+        : c.json(failure("Models are still loading", c.get("requestId")), 503)
+  );
+}

--- a/apps/serve/src/modules/recognize-async/index.ts
+++ b/apps/serve/src/modules/recognize-async/index.ts
@@ -1,32 +1,34 @@
-import { createRoute } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { errorResponse, jsonResponse, success } from "../../core/api-response.js";
 import { submitJob } from "../../core/async-jobs.js";
 import { resolveBatch } from "../../core/runner.js";
 import { batchOcrSchema, taskAcceptedSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "post",
-  path: "/v1/ocr/async",
-  tags: ["Tasks"],
-  summary: "Enqueue a batch job",
-  security: [{ Bearer: [] }],
-  request: {
-    body: { required: true, content: { "application/json": { schema: batchOcrSchema } } },
-  },
-  responses: {
-    202: {
-      description: "Accepted.",
-      content: { "application/json": { schema: envelope(taskAcceptedSchema) } },
-    },
-    400: errorResponse("Invalid input."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = async (c) => {
-  const body = c.req.valid("json");
-  const images = await resolveBatch(body.sources);
-  const taskId = submitJob(images, body);
-  return c.json(success(c, { taskId, status: "queued" }), 202);
-};
+export function mount(app: Hono<Env>): void {
+  app.post(
+    "/v1/ocr/async",
+    describeRoute({
+      tags: ["Tasks"],
+      summary: "Enqueue a batch job",
+      security: [{ Bearer: [] }],
+      requestBody: {
+        required: true,
+        content: { "application/json": { schema: resolver(batchOcrSchema) } },
+      },
+      responses: {
+        202: jsonResponse("Accepted.", taskAcceptedSchema),
+        400: errorResponse("Invalid input."),
+      },
+    }),
+    validate("json", batchOcrSchema),
+    async (c) => {
+      const body = c.req.valid("json");
+      const images = await resolveBatch(body.sources);
+      const taskId = submitJob(images, body);
+      return c.json(success(c, { taskId, status: "queued" }), 202);
+    }
+  );
+}

--- a/apps/serve/src/modules/recognize-batch/index.ts
+++ b/apps/serve/src/modules/recognize-batch/index.ts
@@ -1,37 +1,43 @@
-import { createRoute } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { errorResponse, jsonResponse, success } from "../../core/api-response.js";
 import { resolveBatch, runBatch } from "../../core/runner.js";
 import { batchOcrSchema, batchResultSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "post",
-  path: "/v1/ocr/batch",
-  tags: ["OCR"],
-  summary: "Recognize many images",
-  security: [{ Bearer: [] }],
-  request: {
-    body: { required: true, content: { "application/json": { schema: batchOcrSchema } } },
-  },
-  responses: {
-    200: {
-      description: "Batch results, index-aligned to inputs.",
-      content: { "application/json": { schema: envelope(batchResultSchema) } },
-    },
-    400: errorResponse("Invalid input."),
-    429: errorResponse("Rate limited."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = async (c) => {
-  const body = c.req.valid("json");
-  const images = await resolveBatch(body.sources);
-  const { results, meta } = await runBatch(images, body);
-  return c.json(
-    // SAFETY: the envelope carries results verbatim; the array element type is
-    // the OCR result shape the route's response schema already declares.
-    success(c, { results: results as unknown[] }, { engine: meta.engine, strategy: meta.strategy }),
-    200
+export function mount(app: Hono<Env>): void {
+  app.post(
+    "/v1/ocr/batch",
+    describeRoute({
+      tags: ["OCR"],
+      summary: "Recognize many images",
+      security: [{ Bearer: [] }],
+      requestBody: {
+        required: true,
+        content: { "application/json": { schema: resolver(batchOcrSchema) } },
+      },
+      responses: {
+        200: jsonResponse("Batch results, index-aligned to inputs.", batchResultSchema),
+        400: errorResponse("Invalid input."),
+        429: errorResponse("Rate limited."),
+      },
+    }),
+    validate("json", batchOcrSchema),
+    async (c) => {
+      const body = c.req.valid("json");
+      const images = await resolveBatch(body.sources);
+      const { results, meta } = await runBatch(images, body);
+      return c.json(
+        // SAFETY: the envelope carries results verbatim; the array element type
+        // is the OCR result shape the route's response schema already declares.
+        success(
+          c,
+          { results: results as unknown[] },
+          { engine: meta.engine, strategy: meta.strategy }
+        ),
+        200
+      );
+    }
   );
-};
+}

--- a/apps/serve/src/modules/recognize-stream/index.ts
+++ b/apps/serve/src/modules/recognize-stream/index.ts
@@ -1,37 +1,42 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
+import type { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
 import { streamSSE } from "hono/streaming";
 import { errorResponse } from "../../core/api-response.js";
-import { batchOcrSchema } from "../../core/schemas.js";
 import { resolveBatch, streamBatch } from "../../core/runner.js";
+import { batchOcrSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "post",
-  path: "/v1/ocr/stream",
-  tags: ["OCR"],
-  summary: "Stream batch results (SSE)",
-  description: "Emits one `fulfilled`/`rejected` SSE event per image, then a `done` event.",
-  security: [{ Bearer: [] }],
-  request: {
-    body: { required: true, content: { "application/json": { schema: batchOcrSchema } } },
-  },
-  responses: {
-    200: {
-      description: "Server-sent events (one JSON event per image, then `done`).",
-      content: { "text/event-stream": { schema: z.string() } },
-    },
-    400: errorResponse("Invalid input."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = async (c) => {
-  const body = c.req.valid("json");
-  const images = await resolveBatch(body.sources);
-  return streamSSE(c, async (stream) => {
-    for await (const item of streamBatch(images, body)) {
-      await stream.writeSSE({ event: item.status, data: JSON.stringify(item) });
+export function mount(app: Hono<Env>): void {
+  app.post(
+    "/v1/ocr/stream",
+    describeRoute({
+      tags: ["OCR"],
+      summary: "Stream batch results (SSE)",
+      description: "Emits one `fulfilled`/`rejected` SSE event per image, then a `done` event.",
+      security: [{ Bearer: [] }],
+      requestBody: {
+        required: true,
+        content: { "application/json": { schema: resolver(batchOcrSchema) } },
+      },
+      responses: {
+        200: {
+          description: "Server-sent events (one JSON event per image, then `done`).",
+          content: { "text/event-stream": { schema: { type: "string" } } },
+        },
+        400: errorResponse("Invalid input."),
+      },
+    }),
+    validate("json", batchOcrSchema),
+    async (c) => {
+      const body = c.req.valid("json");
+      const images = await resolveBatch(body.sources);
+      return streamSSE(c, async (stream) => {
+        for await (const item of streamBatch(images, body)) {
+          await stream.writeSSE({ event: item.status, data: JSON.stringify(item) });
+        }
+        await stream.writeSSE({ event: "done", data: "{}" });
+      });
     }
-    await stream.writeSSE({ event: "done", data: "{}" });
-  });
-};
+  );
+}

--- a/apps/serve/src/modules/recognize/index.ts
+++ b/apps/serve/src/modules/recognize/index.ts
@@ -1,52 +1,52 @@
-import type { RouteConfig } from "@hono/zod-openapi";
-import type { Context } from "hono";
-import { envelope, errorResponse, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { errorResponse, jsonResponse, success } from "../../core/api-response.js";
 import { readSingle } from "../../core/input.js";
 import { runOcr } from "../../core/runner.js";
-import { jsonOcrSchema, multipartOcrSchema, ocrResultSchema } from "../../core/schemas.js";
+import { jsonOcrSchema, ocrResultSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
 
-// This endpoint accepts BOTH multipart and JSON. @hono/zod-openapi runs every
-// declared body validator, so it can't auto-validate a dual-content body -
-// hence we document it via registerPath and parse the body manually.
-export const route: RouteConfig = {
-  method: "post",
-  path: "/v1/ocr",
-  tags: ["OCR"],
-  summary: "Recognize a single image",
-  description: "multipart/form-data with a `file` field, or JSON `{ source, ...options }`.",
-  security: [{ Bearer: [] }],
-  request: {
-    body: {
-      required: true,
-      content: {
-        "multipart/form-data": { schema: multipartOcrSchema },
-        "application/json": { schema: jsonOcrSchema },
+// This endpoint accepts BOTH multipart and JSON. A body validator is bound to
+// one content type, so the route is documented here and parses its body
+// manually in readSingle().
+export function mount(app: Hono<Env>): void {
+  app.post(
+    "/v1/ocr",
+    describeRoute({
+      tags: ["OCR"],
+      summary: "Recognize a single image",
+      description: "multipart/form-data with a `file` field, or JSON `{ source, ...options }`.",
+      security: [{ Bearer: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          "multipart/form-data": { schema: { $ref: "#/components/schemas/OcrMultipartRequest" } },
+          "application/json": { schema: resolver(jsonOcrSchema) },
+        },
       },
-    },
-  },
-  responses: {
-    200: {
-      description: "OCR result. `metadata` carries `speed` (seconds) and `confidence`.",
-      content: { "application/json": { schema: envelope(ocrResultSchema) } },
-    },
-    400: errorResponse("Invalid input, unsupported image type, or source error."),
-    413: errorResponse("Image exceeds MAX_UPLOAD_BYTES."),
-    429: errorResponse("Rate limit or inference queue full."),
-  },
-};
-
-export const handler = async (c: Context<Env>): Promise<Response> => {
-  const { image, opts } = await readSingle(c);
-  const { result, meta } = await runOcr(image, opts);
-  return c.json(
-    success(c, result, {
-      speed: meta.ms / 1000,
-      // SAFETY: runOcr returns the flattened shape for this route, which
-      // always carries a confidence.
-      confidence: (result as { confidence: number }).confidence,
-      engine: meta.engine,
-      strategy: meta.strategy,
-    })
+      responses: {
+        200: jsonResponse(
+          "OCR result. `metadata` carries `speed` (seconds) and `confidence`.",
+          ocrResultSchema
+        ),
+        400: errorResponse("Invalid input, unsupported image type, or source error."),
+        413: errorResponse("Image exceeds MAX_UPLOAD_BYTES."),
+        429: errorResponse("Rate limit or inference queue full."),
+      },
+    }),
+    async (c) => {
+      const { image, opts } = await readSingle(c);
+      const { result, meta } = await runOcr(image, opts);
+      return c.json(
+        success(c, result, {
+          speed: meta.ms / 1000,
+          // SAFETY: runOcr returns the flattened shape for this route, which
+          // always carries a confidence.
+          confidence: (result as { confidence: number }).confidence,
+          engine: meta.engine,
+          strategy: meta.strategy,
+        })
+      );
+    }
   );
-};
+}

--- a/apps/serve/src/modules/task-cancel/index.ts
+++ b/apps/serve/src/modules/task-cancel/index.ts
@@ -1,32 +1,32 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, failure, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import * as v from "valibot";
+import { errorResponse, failure, jsonResponse, success } from "../../core/api-response.js";
 import { cancelJob } from "../../core/async-jobs.js";
 import { taskIdParamsSchema } from "../../core/schemas.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "delete",
-  path: "/v1/tasks/{id}",
-  tags: ["Tasks"],
-  summary: "Cancel a task",
-  security: [{ Bearer: [] }],
-  request: { params: taskIdParamsSchema },
-  responses: {
-    200: {
-      description: "Cancelled.",
-      content: {
-        "application/json": {
-          schema: envelope(z.object({ id: z.string(), status: z.literal("cancelled") })),
-        },
+export function mount(app: Hono<Env>): void {
+  app.delete(
+    "/v1/tasks/:id",
+    describeRoute({
+      tags: ["Tasks"],
+      summary: "Cancel a task",
+      security: [{ Bearer: [] }],
+      responses: {
+        200: jsonResponse(
+          "Cancelled.",
+          v.object({ id: v.string(), status: v.literal("cancelled") })
+        ),
+        404: errorResponse("Unknown task id."),
       },
-    },
-    404: errorResponse("Unknown task id."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) => {
-  const id = c.req.valid("param").id;
-  if (!cancelJob(id)) return c.json(failure("Unknown task id", c.get("requestId")), 404);
-  return c.json(success(c, { id, status: "cancelled" as const }), 200);
-};
+    }),
+    validate("param", taskIdParamsSchema),
+    (c) => {
+      const id = c.req.valid("param").id;
+      if (!cancelJob(id)) return c.json(failure("Unknown task id", c.get("requestId")), 404);
+      return c.json(success(c, { id, status: "cancelled" as const }), 200);
+    }
+  );
+}

--- a/apps/serve/src/modules/task-result/index.ts
+++ b/apps/serve/src/modules/task-result/index.ts
@@ -1,37 +1,37 @@
-import { createRoute } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, failure, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { errorResponse, failure, jsonResponse, success } from "../../core/api-response.js";
 import { batchResultSchema, taskIdParamsSchema } from "../../core/schemas.js";
 import { tasks } from "../../core/tasks.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/v1/tasks/{id}/result",
-  tags: ["Tasks"],
-  summary: "Task result",
-  security: [{ Bearer: [] }],
-  request: { params: taskIdParamsSchema },
-  responses: {
-    200: {
-      description: "Result.",
-      content: { "application/json": { schema: envelope(batchResultSchema) } },
-    },
-    404: errorResponse("Unknown task id."),
-    409: errorResponse("Task not finished, failed, or cancelled."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) => {
-  const requestId = c.get("requestId");
-  const task = tasks.get(c.req.valid("param").id);
-  if (!task) return c.json(failure("Unknown task id", requestId), 404);
-  if (task.status === "failed" || task.status === "cancelled") {
-    return c.json(failure(task.error ?? `Task ${task.status}`, requestId), 409);
-  }
-  if (task.status !== "done") return c.json(failure(`Task is ${task.status}`, requestId), 409);
-  // SAFETY: the status check above establishes the task completed, and the
-  // batch worker is the only writer of `result`.
-  const result = task.result as { results: unknown[] };
-  return c.json(success(c, { results: result.results }), 200);
-};
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/v1/tasks/:id/result",
+    describeRoute({
+      tags: ["Tasks"],
+      summary: "Task result",
+      security: [{ Bearer: [] }],
+      responses: {
+        200: jsonResponse("Result.", batchResultSchema),
+        404: errorResponse("Unknown task id."),
+        409: errorResponse("Task not finished, failed, or cancelled."),
+      },
+    }),
+    validate("param", taskIdParamsSchema),
+    (c) => {
+      const requestId = c.get("requestId");
+      const task = tasks.get(c.req.valid("param").id);
+      if (!task) return c.json(failure("Unknown task id", requestId), 404);
+      if (task.status === "failed" || task.status === "cancelled") {
+        return c.json(failure(task.error ?? `Task ${task.status}`, requestId), 409);
+      }
+      if (task.status !== "done") return c.json(failure(`Task is ${task.status}`, requestId), 409);
+      // SAFETY: the status check above establishes the task completed, and the
+      // batch worker is the only writer of `result`.
+      const result = task.result as { results: unknown[] };
+      return c.json(success(c, { results: result.results }), 200);
+    }
+  );
+}

--- a/apps/serve/src/modules/task-status/index.ts
+++ b/apps/serve/src/modules/task-status/index.ts
@@ -1,28 +1,31 @@
-import { createRoute } from "@hono/zod-openapi";
-import type { RouteHandler } from "@hono/zod-openapi";
-import { envelope, errorResponse, failure, success } from "../../core/api-response.js";
+import type { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { errorResponse, failure, jsonResponse, success } from "../../core/api-response.js";
 import { taskIdParamsSchema, taskStatusSchema } from "../../core/schemas.js";
 import { tasks } from "../../core/tasks.js";
 import type { Env } from "../../core/types.js";
+import { validate } from "../../core/validate.js";
 
-export const route = createRoute({
-  method: "get",
-  path: "/v1/tasks/{id}",
-  tags: ["Tasks"],
-  summary: "Task status",
-  security: [{ Bearer: [] }],
-  request: { params: taskIdParamsSchema },
-  responses: {
-    200: {
-      description: "Status.",
-      content: { "application/json": { schema: envelope(taskStatusSchema) } },
-    },
-    404: errorResponse("Unknown task id."),
-  },
-});
-
-export const handler: RouteHandler<typeof route, Env> = (c) => {
-  const task = tasks.get(c.req.valid("param").id);
-  if (!task) return c.json(failure("Unknown task id", c.get("requestId")), 404);
-  return c.json(success(c, { id: task.id, status: task.status, updatedAt: task.updatedAt }), 200);
-};
+export function mount(app: Hono<Env>): void {
+  app.get(
+    "/v1/tasks/:id",
+    describeRoute({
+      tags: ["Tasks"],
+      summary: "Task status",
+      security: [{ Bearer: [] }],
+      responses: {
+        200: jsonResponse("Status.", taskStatusSchema),
+        404: errorResponse("Unknown task id."),
+      },
+    }),
+    validate("param", taskIdParamsSchema),
+    (c) => {
+      const task = tasks.get(c.req.valid("param").id);
+      if (!task) return c.json(failure("Unknown task id", c.get("requestId")), 404);
+      return c.json(
+        success(c, { id: task.id, status: task.status, updatedAt: task.updatedAt }),
+        200
+      );
+    }
+  );
+}

--- a/apps/serve/test/api.test.ts
+++ b/apps/serve/test/api.test.ts
@@ -108,6 +108,16 @@ describe("POST /v1/ocr input validation (pre-inference)", () => {
     expect(body.data.message).toContain("Unsupported image type");
   });
 
+  test("malformed JSON on a validated route is 400, not 500", async () => {
+    const res = await app.request("/v1/ocr/batch", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{bad",
+    });
+    const body = await expectError(res, 400);
+    expect(body.data.message).toContain("JSON");
+  });
+
   test("multipart without a file field is 400", async () => {
     const form = new FormData();
     form.append("strategy", "per-line");


### PR DESCRIPTION
## What

Migrates the serve app's validation and OpenAPI generation from zod plus `@hono/zod-openapi` to valibot plus `hono-openapi`. Also fixes malformed JSON on the validated routes returning 500.

Stacked on the dependency bump PR; merge that first.

## Why

Requested move to valibot. There is no Hono-team OpenAPI package for valibot, so the OpenAPI layer moves too: `hono-openapi` works over Standard Schema and converts valibot through `@valibot/to-json-schema`. The spec, the `/docs` page, the response envelopes, and every route path are preserved, verified by diffing `/openapi.json` before and after.

## How

- `schemas.ts` and `config.ts` rewritten in valibot. `v.metadata({ ref })` keeps every component name (`OcrJsonRequest`, `BatchRequest`, `OcrResult`, ...). The two multipart bodies are documentation-only and now plain OpenAPI objects registered under `components.schemas`, since a `File` field has no schema-library shape.
- Each module exports `mount(app)` and registers `describeRoute`, `validate`, and the handler in one chain, which is what keeps `c.req.valid()` typed. `app.ts` becomes a plain `Hono` with `openAPIRouteHandler` at `/openapi.json`.
- `core/validate.ts` wraps hono-openapi's validator so failures throw the same `HttpError` as every other 400. The message format is unchanged: `Validation failed - path: message; ...`. hono-openapi's own `{ success, error, data }` validation response is disabled so the spec only documents the envelope.
- `readSingle` keeps parsing the dual-content routes manually; multipart fields coerce from strings through a dedicated `multipartOcrOptionsSchema`.
- `envelope()` now returns `v.GenericSchema`; it only feeds `resolver()` for documentation, nothing reads its inferred type.

Spec diff after normalizing examples and operationIds: 107 lines, all JSON Schema spelling. Literals render as `const` instead of a one-item `enum`, optional fields no longer carry a spurious `nullable: true`, `concurrency` documents `minimum: 1` instead of `exclusiveMinimum: 0`, and the multipart bodies now mark `file` as required. hono-openapi adds `operationId` to every operation.

One tightening: JSON bodies require real numbers and booleans for `minimumConfidence`, `flatten`, `settle`, and `concurrency`. zod's `coerce` silently accepted `"0.7"` and `"true"` in JSON; the README always documented the typed forms. Multipart fields still coerce, since form data is all strings.

Also fixed: malformed JSON on `/v1/ocr/batch`, `/stream`, and `/async` returned 500 on the zod build as well. Hono's body validator throws an `HTTPException(400)` the error handler was discarding.

Serve type-check, root lint, and the full suite (309 pass, 0 fail) are green. Coverage gate holds.

Note for the coverage PR (`test/raise-coverage`): both branches touch `apps/serve/src/core/input.ts` and its import block will conflict; the changes compose.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path - not applicable
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed - serve README and Dockerfile comment
- [x] New tests added for bugs fixed or features added - malformed JSON case

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [x] macOS (Apple Silicon)
