### PR TITLE
test: raise coverage past 90% and fix the two bugs it exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ private
 coverage/
 # stray test debug output
 out-test-debug/
+out-test-debug-per-box/
 
 # Cloudflare deploy output
 playground/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Serve: malformed JSON on `/v1/ocr/batch`, `/stream`, and `/async` returns
   `400` in the error envelope instead of `500`.
+- Per-box recognition in debug mode now runs through the same crop, rotate,
+  and batched recognize helpers as the production path (as a batch of one),
+  so turning `debugging.debug` on no longer changes the text. The debug path
+  had its own copy that skipped vertical crop rotation and dropped per-call
+  overrides.
+- Serve: an allowlisted `https` source whose host cannot be reached (DNS, TLS,
+  refused connection, or a redirect) now returns `502` with the host named,
+  instead of `500 Internal server error`.
 
 ## [6.5.0] - 2026-09-08
 

--- a/apps/serve/README.md
+++ b/apps/serve/README.md
@@ -71,7 +71,7 @@ The library is a building block; this wraps it as a service you'd be comfortable
 
 `minimumConfidence` (0 to 1) overrides `MIN_CONFIDENCE` for that request only; `0` disables the filter. The batch, stream, and async endpoints take the same field.
 
-`source` must be a `data:` URI or an `https` URL whose host is in `SOURCE_URL_ALLOWLIST` (empty = https disabled). **Local filesystem paths are rejected**, and URL fetches refuse redirects - so the API never reads arbitrary host files or gets steered off-allowlist. Uploads are sniffed by magic bytes; non-images get a `400`, not a `500`.
+`source` must be a `data:` URI or an `https` URL whose host is in `SOURCE_URL_ALLOWLIST` (empty = https disabled). **Local filesystem paths are rejected**, and URL fetches refuse redirects - so the API never reads arbitrary host files or gets steered off-allowlist. Uploads are sniffed by magic bytes; non-images get a `400`, not a `500`. An allowlisted host that cannot be reached (DNS, TLS, refused, or a redirect) is a `502` naming the host.
 
 `POST /v1/detect` takes the same input (`file` or `{ source, engine? }`; `strategy`/`flatten` don't apply) and returns `{ boxes: [{ x, y, width, height }] }` - detection inference only, no recognition. `metadata` carries `speed`, `count`, and `engine`.
 

--- a/apps/serve/src/core/errors.ts
+++ b/apps/serve/src/core/errors.ts
@@ -16,6 +16,8 @@ export class HttpError extends Error {
 
 export const badRequest = (message: string): HttpError =>
   new HttpError(400, "bad_request", message);
+export const badGateway = (message: string): HttpError =>
+  new HttpError(502, "bad_gateway", message);
 export const payloadTooLarge = (message: string): HttpError =>
   new HttpError(413, "payload_too_large", message);
 export const tooManyRequests = (message: string): HttpError =>

--- a/apps/serve/src/core/input.ts
+++ b/apps/serve/src/core/input.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import * as v from "valibot";
 import { config } from "./config.js";
-import { badRequest, payloadTooLarge } from "./errors.js";
+import { badGateway, badRequest, payloadTooLarge } from "./errors.js";
 import type { OcrOptions } from "./schemas.js";
 import { jsonOcrSchema, multipartOcrOptionsSchema } from "./schemas.js";
 import { describeIssues } from "./validate.js";
@@ -75,7 +75,15 @@ async function fetchHttps(source: string): Promise<ArrayBuffer> {
     throw badRequest(`Host "${url.host}" is not in SOURCE_URL_ALLOWLIST`);
   }
   // `redirect: "error"` blocks redirect-based SSRF past the allowlist.
-  const res = await fetch(url, { redirect: "error" });
+  let res: Response;
+  try {
+    res = await fetch(url, { redirect: "error" });
+  } catch (err: unknown) {
+    // DNS, TLS, refused connection, or a redirect: the allowlisted host is the
+    // one that failed, so report it as an upstream error rather than a 500.
+    const reason = err instanceof Error ? err.message : String(err);
+    throw badGateway(`Failed to fetch source from ${url.host}: ${reason}`);
+  }
   if (!res.ok) throw badRequest(`Failed to fetch source (HTTP ${res.status})`);
   const declared = Number(res.headers.get("content-length") ?? 0);
   if (declared > config.maxUploadBytes) throw tooBig();

--- a/apps/serve/test/api.test.ts
+++ b/apps/serve/test/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { app } from "../src/app.js";
+import { config } from "../src/core/config.js";
 
 const json = (body: unknown) =>
   ({
@@ -98,6 +99,43 @@ describe("POST /v1/ocr input validation (pre-inference)", () => {
       400
     );
     expect(body.data.message).toContain("SOURCE_URL_ALLOWLIST");
+  });
+
+  test("https host outside the allowlist is rejected, subdomains of an entry pass the host check", async () => {
+    // The allowlist is read from env at boot; push an entry for this test and
+    // remove it after so the empty-allowlist tests above stay valid.
+    config.sourceUrlAllowlist.push("cdn.example.org");
+    try {
+      const other = await expectError(
+        await app.request("/v1/ocr", json({ source: "https://evil.example.com/a.jpg" })),
+        400
+      );
+      expect(other.data.message).toContain("not in SOURCE_URL_ALLOWLIST");
+
+      // A subdomain clears the host check and reaches fetch(), which fails on
+      // the unresolvable host: an upstream failure, reported as 502 with the
+      // host named, never a 500.
+      const sub = await expectError(
+        await app.request("/v1/ocr", json({ source: "https://img.cdn.example.org/a.jpg" })),
+        502
+      );
+      expect(sub.data.message).toContain("img.cdn.example.org");
+    } finally {
+      config.sourceUrlAllowlist.pop();
+    }
+  });
+
+  test("malformed https source is 400, not a crash", async () => {
+    const body = await expectError(await app.request("/v1/ocr", json({ source: "https://" })), 400);
+    expect(body.data.message).toContain("Invalid source URL");
+  });
+
+  test("malformed data: URI without a comma is 400", async () => {
+    const body = await expectError(
+      await app.request("/v1/ocr", json({ source: "data:image/png;base64" })),
+      400
+    );
+    expect(body.data.message).toContain("Malformed data: URI");
   });
 
   test("a tiny non-image data: URI is rejected as unsupported type", async () => {

--- a/src/core/base-recognition.service.ts
+++ b/src/core/base-recognition.service.ts
@@ -13,9 +13,11 @@ import type {
 } from "../interface.js";
 import { calculateResizeDimensions } from "./detection/box-geometry.js";
 import type { CoreCanvas, PlatformProvider } from "./platform.js";
-import { supportsDynamicBatch } from "./recognition/batched.js";
+import { recognizeCropsBatched, supportsDynamicBatch } from "./recognition/batched.js";
 import type { RecognitionContext } from "./recognition/strategies.js";
 import {
+  cropRegion,
+  rotateTallCropIfNeeded,
   runCrossLineStrategy,
   runLineStrategy,
   runPerBoxStrategy,
@@ -151,7 +153,7 @@ export class BaseRecognitionService {
             cropBoxes,
             ctx,
             (canvas, box, index, total, debugPath, dict) =>
-              this.processBox(canvas, box, index, total, debugPath, dict),
+              this.processBox(canvas, box, index, total, debugPath, ctx, dict),
             charactersDictionary
           );
       }
@@ -258,7 +260,10 @@ export class BaseRecognitionService {
   }
 
   /**
-   * Process a single text box (used by per-box strategy for debug output)
+   * Debug-mode per-box recognition: the same crop, rotate, and batched
+   * recognize steps as the non-debug path (a batch of one), plus a saved
+   * crop and per-box timing. Sharing the pipeline is what keeps debug output
+   * identical to production output.
    */
   private async processBox(
     sourceCanvas: CoreCanvas,
@@ -266,22 +271,19 @@ export class BaseRecognitionService {
     index: number,
     totalBoxes: number,
     debugPath: string,
+    ctx: RecognitionContext,
     charactersDictionary?: string[]
   ): Promise<RecognitionResult | null> {
     const start = Date.now();
 
     try {
-      const cropCanvas = this.platform.canvas.getToolkit().crop({
-        bbox: { x0: box.x, y0: box.y, x1: box.x + box.width, y1: box.y + box.height },
-        canvas: sourceCanvas,
-      });
-
-      const ctx = this.buildContext();
-      const { text: recognizedText, confidence } = await this.recognizeTextViaContext(
-        cropCanvas,
-        ctx,
-        charactersDictionary
+      const cropCanvas = rotateTallCropIfNeeded(
+        cropRegion(sourceCanvas, box, this.platform.canvas),
+        ctx
       );
+      const [recognized] = await recognizeCropsBatched([cropCanvas], ctx, charactersDictionary);
+      const recognizedText = recognized?.text ?? "";
+      const confidence = recognized?.confidence ?? 0;
 
       if (this.debugging.debug && debugPath) {
         await this.platform.saveDebugImage(
@@ -292,7 +294,7 @@ export class BaseRecognitionService {
         const processingTime = Date.now() - start;
         this.log(
           `Box ${index + 1}/${totalBoxes}: [x:${box.x}, y:${box.y}, w:${box.width}, h:${box.height}]` +
-            `\n\t → "${recognizedText}" (processed in ${processingTime}ms)\n`
+            `\n\t -> "${recognizedText}" (processed in ${processingTime}ms)\n`
         );
       }
 
@@ -301,46 +303,6 @@ export class BaseRecognitionService {
       const err = e instanceof Error ? e : new Error(String(e));
       console.error(`Error processing box ${index + 1}: ${err.message}`, err.stack);
       return null;
-    }
-  }
-
-  private async recognizeTextViaContext(
-    cropCanvas: CoreCanvas,
-    ctx: RecognitionContext,
-    charactersDictionary?: string[]
-  ): Promise<{ text: string; confidence: number }> {
-    const { preprocessImage } = await import("./recognition/image-tensor.js");
-    const { decodeResults } = await import("./recognition/ctc.js");
-
-    const targetHeight = ctx.options.imageHeight ?? 48;
-    const imageProcessor = ctx.engine === "opencv" ? ctx.platform.imageProcessor : undefined;
-
-    const { imageTensor, tensorWidth, tensorHeight } = await preprocessImage(
-      cropCanvas,
-      targetHeight,
-      imageProcessor,
-      ctx.platform.canvas.createProcessor.bind(ctx.platform.canvas)
-    );
-
-    let inputTensor: Tensor | undefined;
-    try {
-      inputTensor = new ctx.platform.ort.Tensor("float32", imageTensor, [
-        1,
-        3,
-        tensorHeight,
-        tensorWidth,
-      ]);
-      const result = await ctx.runInference(inputTensor);
-      const dict = charactersDictionary ?? ctx.options.charactersDictionary ?? [];
-      return decodeResults(
-        result,
-        dict,
-        tensorWidth,
-        this.debugging.verbose,
-        ctx.options.spaceRecovery ?? false
-      );
-    } finally {
-      inputTensor?.dispose();
     }
   }
 

--- a/src/core/recognition/strategies.ts
+++ b/src/core/recognition/strategies.ts
@@ -43,7 +43,8 @@ export function rotateTallCropIfNeeded(crop: CoreCanvas, ctx: RecognitionContext
   return rotated;
 }
 
-function cropRegion(sourceCanvas: CoreCanvas, box: Box, canvasOps: CanvasOps): CoreCanvas {
+/** Crops one detected box out of the source canvas. */
+export function cropRegion(sourceCanvas: CoreCanvas, box: Box, canvasOps: CanvasOps): CoreCanvas {
   return canvasOps.getToolkit().crop({
     bbox: { x0: box.x, y0: box.y, x1: box.x + box.width, y1: box.y + box.height },
     canvas: sourceCanvas,

--- a/tests/per-box-debug.test.ts
+++ b/tests/per-box-debug.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { PaddleOcrService } from "../src/processor/paddle-ocr.service.js";
+
+const imageBuffer = await Bun.file(`${import.meta.dir}/../assets/receipt.jpg`).arrayBuffer();
+const debugFolder = `${import.meta.dir}/../out-test-debug-per-box`;
+const SEQUENTIAL_BATCH_SIZE = 1;
+
+beforeAll(async () => {
+  await PaddleOcrService.downloadModels();
+});
+
+afterAll(() => {
+  if (existsSync(debugFolder)) rmSync(debugFolder, { recursive: true, force: true });
+});
+
+describe("per-box strategy in debug mode", () => {
+  test("saves one crop per box and matches the sequential production output", async () => {
+    // Debug mode recognizes boxes one at a time so it can save each crop with
+    // its timing. Padding inside a multi-crop batch can shift a CTC decode, so
+    // the reference is the production path at batch size 1, the same batch
+    // composition the debug path sees.
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const plain = new PaddleOcrService();
+      await plain.initialize();
+      const reference = await plain.recognize(imageBuffer, {
+        noCache: true,
+        strategy: "per-box",
+        recBatchSize: SEQUENTIAL_BATCH_SIZE,
+      });
+      await plain.destroy();
+
+      const service = new PaddleOcrService({ debugging: { debug: true, debugFolder } });
+      await service.initialize();
+      const debugged = await service.recognize(imageBuffer, { noCache: true, strategy: "per-box" });
+      await service.destroy();
+
+      expect(debugged.text).toBe(reference.text);
+
+      const crops = readdirSync(join(debugFolder, "crops")).filter((f) =>
+        /^crop_\d{3}\.png$/.test(f)
+      );
+      // One crop per detected box; the confidence filter only trims results.
+      expect(crops.length).toBeGreaterThanOrEqual(debugged.lines.flat().length);
+      expect(crops.length).toBeGreaterThan(0);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }, 60000);
+});

--- a/tests/platform-node.test.ts
+++ b/tests/platform-node.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { NodePlatformProvider } from "../src/processor/platform.node.js";
+
+const receiptPath = `${import.meta.dir}/../assets/receipt.jpg`;
+const receipt = await Bun.file(receiptPath).arrayBuffer();
+const HTTP_NOT_FOUND = 404;
+
+let server: ReturnType<typeof Bun.serve>;
+let origin: string;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new URL(req.url).pathname === "/receipt.jpg"
+        ? new Response(receipt)
+        : new Response("nope", { status: HTTP_NOT_FOUND });
+    },
+  });
+  origin = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("NodePlatformProvider.loadResource", () => {
+  const platform = new NodePlatformProvider();
+
+  test("returns an ArrayBuffer source untouched", async () => {
+    expect(await platform.loadResource(receipt, `${origin}/unused`)).toBe(receipt);
+  });
+
+  test("reads a file path from disk", async () => {
+    const loaded = await platform.loadResource(receiptPath, `${origin}/unused`);
+    expect(loaded.byteLength).toBe(receipt.byteLength);
+  });
+
+  test("fetches an http URL and falls back to the default URL", async () => {
+    const explicit = await platform.loadResource(`${origin}/receipt.jpg`, `${origin}/unused`);
+    expect(explicit.byteLength).toBe(receipt.byteLength);
+
+    const fallback = await platform.loadResource(undefined, `${origin}/receipt.jpg`);
+    expect(fallback.byteLength).toBe(receipt.byteLength);
+  });
+
+  test("rejects a non-2xx response with the URL in the message", async () => {
+    await expect(platform.loadResource(`${origin}/missing.onnx`, "")).rejects.toThrow(
+      `${origin}/missing.onnx`
+    );
+  });
+});
+
+describe("NodePlatformProvider canvases", () => {
+  const platform = new NodePlatformProvider();
+
+  test("createCanvas produces something isCanvas accepts, plain objects are refused", () => {
+    const canvas = platform.createCanvas(4, 3);
+    expect(canvas.width).toBe(4);
+    expect(canvas.height).toBe(3);
+    expect(platform.isCanvas(canvas)).toBe(true);
+    expect(platform.isCanvas({ width: 4, height: 3 })).toBe(false);
+    expect(platform.isCanvas(receipt)).toBe(false);
+  });
+});

--- a/tests/web-ocr.test.ts
+++ b/tests/web-ocr.test.ts
@@ -186,6 +186,37 @@ describe("web OCR service (onnxruntime-web under the polyfilled runtime)", () =>
     await expect(service.changeTextDictionary("")).rejects.toBeDefined();
   }, 60000);
 
+  test("swaps the recognition model and loads a dictionary from a URL", async () => {
+    // The web loader treats every string as a URL; serve the cached dictionary
+    // from a local server so the fetch path runs without touching the network.
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req) =>
+        new URL(req.url).pathname === "/dict.txt"
+          ? new Response(v6Dict)
+          : new Response("nope", { status: 404 }),
+    });
+    try {
+      service = new WebPaddleOcrService({
+        model: { detection: v6Det, recognition: v6Rec, charactersDictionary: v6Dict },
+        processing: { engine: "canvas-native" },
+      });
+      await service.initialize();
+      const before = await service.recognize(smallBuffer, { noCache: true });
+
+      await service.changeRecognitionModel(v6Rec);
+      await service.changeTextDictionary(`http://localhost:${server.port}/dict.txt`);
+      const after = await service.recognize(smallBuffer, { noCache: true });
+      expect(after.text).toBe(before.text);
+
+      await expect(
+        service.changeTextDictionary(`http://localhost:${server.port}/missing.txt`)
+      ).rejects.toThrow("missing.txt");
+    } finally {
+      server.stop(true);
+    }
+  }, 60000);
+
   test("recognize before initialize throws", async () => {
     const fresh = new WebPaddleOcrService();
     await expect(fresh.recognize(imageBuffer)).rejects.toBeDefined();


### PR DESCRIPTION
## What

Raises Codecov line coverage on `main` from 88.74% to about 92% by testing three real gaps, and fixes the two bugs those tests exposed.

## Why

The README badge landed at 89% after 6.5.0. Codecov counts lcov lines, which is stricter than bun's own summary (94%), so the badge needed real coverage rather than a config change. The largest uncovered blocks were library code: the debug-mode per-box recognizer, the Node platform loader, the web model-swap and URL-loader paths, and the serve source-URL validation.

## How

- **Debug per-box recognition** had a private crop-and-decode copy (85 uncovered lines). Writing the test showed it produced different text from the production path: it skipped vertical crop rotation and rebuilt its context without per-call overrides. The copy is deleted; debug mode now calls the same `cropRegion`, `rotateTallCropIfNeeded`, and `recognizeCropsBatched` helpers as a batch of one, then saves the crop and logs timing. The test compares debug output against production at `recBatchSize: 1`, since padding inside a multi-crop batch legitimately shifts a CTC decode (the receipt's "Kembalian" reads "Kembal ian" alone at batch size 1 on both paths).
- **Serve source fetch**: a DNS or TLS failure on an allowlisted host escaped `fetchHttps` as a bare `TypeError` and became `500 Internal server error`. It now maps to `502` with the host named. Test covers the out-of-allowlist host, the subdomain-passes-host-check path, a malformed `https://` source, and a `data:` URI with no comma.
- **Node platform loader**: ArrayBuffer passthrough, file path, http fetch, default-URL fallback, and the non-2xx rejection, against a local `Bun.serve`. Plus `createCanvas` and `isCanvas` probes.
- **Web service**: `changeRecognitionModel` and `changeTextDictionary` from a local URL, proving the web loader's fetch path and that a swap to the same model preserves output; a 404 dictionary URL rejects with the URL in the message.

Local lcov (what Codecov reads), rebased on the valibot migration: 4417 of 4789 lines, 92.23%. Bun's summary: 93.32% functions, 94.14% lines. Suite: 320 pass, 0 fail.

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Lint + format are clean (`bun run lint` and `bun run fmt`)
- [ ] Benchmark run if this touches the hot path - debug path only; the production per-box path is unchanged
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated if the public API, defaults, or setup changed - serve README notes the 502
- [x] New tests added for bugs fixed or features added

### Compatibility

- [x] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [x] Browser - WebAssembly fallback (web suite under the polyfilled runtime)
- [ ] Browser - WebGPU path
- [x] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [ ] Windows
