### PR TITLE
feat: add opt-in detection binarization threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suits places with bounded request volume such as CI. A model URL you supplied
   yourself is never rewritten.
 
+- `detection.detectionThreshold` - binarizes the detector's probability map
+  before text regions are extracted, which the detection path previously never
+  did. Without it the map goes to `findContours` unmodified, and since that
+  treats any non-zero pixel as foreground the effective cut is around 0.002
+  rather than the 0.3 PaddleOCR and arboOCR use, so weak probability tails can
+  bridge neighbouring lines into single loose boxes. Setting `0.3` measured
+  +1.46 points of character accuracy on the 40-stem SROIE2019 sample (83.51% ->
+  84.97%) for roughly 11% more engine time. Off by default (`0` keeps today's
+  behavior), and applies to both the OpenCV and canvas-native engines.
+
 ### Fixed
 
 - Model downloads honour a `Retry-After` header on a failed response, capped at

--- a/README.md
+++ b/README.md
@@ -1013,14 +1013,15 @@ Extends `RecognizeOptions` (applied to every image) for `batchRecognize()` / `ba
 
 Controls preprocessing and filtering during text detection.
 
-| Property               |            Type            |         Default         | Description                                                                                                                                  |
-| :--------------------- | :------------------------: | :---------------------: | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mean`                 | `[number, number, number]` | `[0.485, 0.456, 0.406]` | Per-channel mean for input normalization [R, G, B].                                                                                          |
-| `stdDeviation`         | `[number, number, number]` | `[0.229, 0.224, 0.225]` | Per-channel std dev for input normalization.                                                                                                 |
-| `maxSideLength`        |     `number \| "auto"`     |        `"auto"`         | Longest side limit (px). `"auto"` = clamp(0.75 x longest, 960, 1920): fixed-960 behavior up to ~1280px inputs, more pixels for large photos. |
-| `paddingVertical`      |          `number`          |          `0.4`          | Fractional vertical padding per detected box.                                                                                                |
-| `paddingHorizontal`    |          `number`          |          `0.6`          | Fractional horizontal padding per detected box.                                                                                              |
-| `minimumAreaThreshold` |          `number`          |          `20`           | Minimum box area (px^2); smaller boxes are discarded.                                                                                        |
+| Property               |            Type            |         Default         | Description                                                                                                                                                                                   |
+| :--------------------- | :------------------------: | :---------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mean`                 | `[number, number, number]` | `[0.485, 0.456, 0.406]` | Per-channel mean for input normalization [R, G, B].                                                                                                                                           |
+| `stdDeviation`         | `[number, number, number]` | `[0.229, 0.224, 0.225]` | Per-channel std dev for input normalization.                                                                                                                                                  |
+| `maxSideLength`        |     `number \| "auto"`     |        `"auto"`         | Longest side limit (px). `"auto"` = clamp(0.75 x longest, 960, 1920): fixed-960 behavior up to ~1280px inputs, more pixels for large photos.                                                  |
+| `paddingVertical`      |          `number`          |          `0.4`          | Fractional vertical padding per detected box.                                                                                                                                                 |
+| `paddingHorizontal`    |          `number`          |          `0.6`          | Fractional horizontal padding per detected box.                                                                                                                                               |
+| `minimumAreaThreshold` |          `number`          |          `20`           | Minimum box area (px^2); smaller boxes are discarded.                                                                                                                                         |
+| `detectionThreshold`   |          `number`          |           `0`           | Binarization cut on the detector's probability map, in `(0, 1)`. `0` leaves the map unmodified; `0.3` matches PaddleOCR/arboOCR and reads +1.46 points of accuracy for ~11% more engine time. |
 
 ### `RecognitionOptions`
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const DEFAULT_DETECTION_OPTIONS: DetectionOptions = {
   minimumAreaThreshold: 20,
   paddingVertical: 0.4,
   paddingHorizontal: 0.6,
+  detectionThreshold: 0,
 };
 
 /** Default text recognition options. */

--- a/src/core/base-detection.service.ts
+++ b/src/core/base-detection.service.ts
@@ -293,6 +293,18 @@ export class BaseDetectionService {
 
     const processor = new ip.ImageProcessor(mat);
     try {
+      // Binarize before the contour pass when asked. Default 0 is the identity:
+      // findContours only tests for non-zero, so a probability map above 0 and
+      // the same map cut at 0 are the same foreground. See `detectionThreshold`.
+      const detectionThreshold = this.options.detectionThreshold ?? 0;
+      if (detectionThreshold > 0) {
+        processor.threshold({
+          lower: detectionThreshold * 255,
+          upper: 255,
+          type: ip.cv.THRESH_BINARY,
+        });
+      }
+
       const contours = new ip.Contours(processor.toMat(), {
         mode: ip.cv.RETR_LIST,
         method: ip.cv.CHAIN_APPROX_SIMPLE,
@@ -332,17 +344,20 @@ export class BaseDetectionService {
     paddingHorizontal: number
   ): Box[] {
     // Match the OpenCV path: cv.findContours treats any nonzero pixel as
-    // foreground, so binarize at >0 instead of >127 - thresholding at 0.5
-    // probability erases weak detections the OpenCV engine keeps.
+    // foreground, so the default cut is >0 rather than >127. Both engines can
+    // go higher through `detectionThreshold`; the two use the same 8-bit
+    // convention (this processor's binary threshold is cv.threshold with
+    // THRESH_BINARY), so one probability maps to the same cut on each.
+    const detectionThreshold = Math.round((this.options.detectionThreshold ?? 0) * 255);
     const processor = this.platform.canvas
       .createProcessor(canvas)
       .grayscale()
-      .threshold({ thresh: 0 });
+      .threshold({ thresh: detectionThreshold });
 
     const regions = processor.findRegions({
       foreground: "light",
       minArea: minBoxAreaOnPadded,
-      thresh: 0,
+      thresh: detectionThreshold,
       padding: {
         vertical: paddingVertical,
         horizontal: paddingHorizontal,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -123,6 +123,29 @@ export type DetectionOptions = {
    * @default 20
    */
   minimumAreaThreshold?: number;
+
+  /**
+   * Binarization threshold applied to the detector's probability map before
+   * text regions are extracted, as a probability in `(0, 1)`.
+   *
+   * `0` (the default) leaves the map's pixels as they are, which is also what
+   * an OpenCV threshold of `0` means: `findContours` treats any non-zero pixel
+   * as foreground, so the effective cut is `round(p * 255) > 0` — around
+   * 0.002. That is far below the 0.3 PaddleOCR and arboOCR use, and it lets
+   * weak probability tails bridge neighbouring lines into single, loose boxes.
+   *
+   * Measured on the 40-stem SROIE2019 sample, `0.3` reads +1.46 points of
+   * character accuracy (83.51% -> 84.97%) for roughly 11% more engine time:
+   * fewer boxes come out, but each one is tighter around its text. Values
+   * above 0.5 measured no further gain.
+   *
+   * Set `0.3` for PaddleOCR parity, or higher on clean, high-contrast input
+   * where the extra boxes are noise. Applies to both the OpenCV and the
+   * canvas-native detection path.
+   *
+   * @default 0
+   */
+  detectionThreshold?: number;
 };
 
 /**

--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -69,3 +69,73 @@ describe("detect()", () => {
     }
   });
 });
+
+describe("detectionThreshold", () => {
+  const service = new PaddleOcrService();
+
+  beforeAll(async () => {
+    await service.initialize();
+  });
+
+  afterAll(async () => {
+    await service.destroy();
+  });
+
+  const totalArea = (boxes: Array<{ width: number; height: number }>) =>
+    boxes.reduce((sum, box) => sum + box.width * box.height, 0);
+
+  test("defaults to no binarization", async () => {
+    // `0` means "leave the probability map alone", so an explicit 0 must be
+    // indistinguishable from omitting the option.
+    const omitted = await service.detect(imageBuffer);
+    const explicit = await service.detect(imageBuffer, { detectionThreshold: 0 });
+
+    expect(omitted.boxes.length).toBeGreaterThan(0);
+    expect(explicit.boxes).toEqual(omitted.boxes);
+  });
+
+  test("binarizing tightens the detected regions", async () => {
+    const all = await service.detect(imageBuffer);
+    const cut = await service.detect(imageBuffer, { detectionThreshold: 0.3 });
+
+    // A cut has to leave text behind, not blank the map.
+    expect(cut.boxes.length).toBeGreaterThan(0);
+
+    // Only pixels above the cut survive it, so the surviving regions sit
+    // closer to the text cores and cover strictly less area. Measured on
+    // assets/receipt.jpg: 28 boxes / ~151k px at the default versus 22 boxes /
+    // ~121k px at 0.3. A threshold that never reached the map would leave the
+    // total exactly equal.
+    expect(totalArea(cut.boxes)).toBeLessThan(totalArea(all.boxes));
+
+    // A cut past the sigmoid's saturation is still not a no-op: it keeps only
+    // the saturated cores, so the covered area keeps shrinking.
+    const saturated = await service.detect(imageBuffer, { detectionThreshold: 0.999 });
+    expect(totalArea(saturated.boxes)).toBeLessThan(totalArea(cut.boxes));
+  });
+
+  test("does not leak into service defaults", async () => {
+    await service.detect(imageBuffer, { detectionThreshold: 0.999 });
+
+    const defaults = await service.detect(imageBuffer);
+    expect(defaults.boxes.length).toBeGreaterThan(0);
+  });
+
+  test("applies on the canvas-native engine too", async () => {
+    const canvasNative = new PaddleOcrService({
+      processing: { engine: "canvas-native" },
+    });
+
+    try {
+      await canvasNative.initialize();
+
+      const all = await canvasNative.detect(imageBuffer);
+      const cut = await canvasNative.detect(imageBuffer, { detectionThreshold: 0.999 });
+
+      expect(all.boxes.length).toBeGreaterThan(0);
+      expect(totalArea(cut.boxes)).toBeLessThan(totalArea(all.boxes));
+    } finally {
+      await canvasNative.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `detection.detectionThreshold`, an opt-in binarization cut applied to the detection probability map before text regions are extracted. Defaults to `0`, which is the identity — no existing configuration changes behavior.

Also corrects a comment on the canvas-native path that claimed the opposite of what the measurement shows.

## Why

The detection pipeline never binarized the probability map. `postprocessWithOpenCV` quantizes the map into a `CV_8UC1` mat and hands it straight to `findContours`, which treats **any non-zero pixel** as foreground. The effective detection cut was therefore `round(p * 255) > 0` — around **0.002** — where PaddleOCR and arboOCR cut at **0.3**.

That is three orders of magnitude off, and it is not a cosmetic difference: weak probability tails stay foreground, so noise bridges neighbouring lines into single loose boxes. The symptom a user sees is not obviously a threshold problem — you get a plausible number of boxes, just worse ones. On the 40-stem SROIE2019 sample against box ground truth at IoU ≥ 0.5, only 76.4% of GT lines had a matching box before, versus 88.1% after.

This is opt-in rather than a default change because it is a genuine trade, not a free win: accuracy up, engine time up on an engine already measured slowest of the three I benchmark against. A default belongs to the maintainers' judgement about which side of that trade the library should sit on; the option lets anyone take the accuracy now.

## How

`base-detection.service.ts`, both engines, one option read twice:

- **OpenCV** (`postprocessWithOpenCV`): `processor.threshold({ lower: t * 255, upper: 255, type: THRESH_BINARY })` before `new Contours(...)`.
- **canvas-native** (`postprocessWithCanvasNative`): the same probability as an 8-bit cut feeds both `.threshold({ thresh })` and `findRegions({ thresh })` — they must agree or the binary canvas and the region flood-fill disagree about what is foreground. The canvas processor's binary threshold is documented as equivalent to `cv.threshold(..., THRESH_BINARY)`, so one probability maps to the same cut on each engine.

`0` is the identity rather than a special case: `findContours` only tests for non-zero, so an unmodified map and one cut at 0 have identical foreground. That keeps the default path byte-for-byte what it was. No new dependency — `ppu-ocv` was already the detection dependency.

### Numbers

40 SROIE2019 stems, PP-OCRv6 small, `per-box`, same dictionary/model as my 3-way harness. The baseline is run **first and last as a control**, because a single before/after session cannot separate an effect from drift:

| config | avg sim | engine ms |
|---|---|---|
| baseline A | 83.51% | 454 |
| binarize 0.3 | **84.97%** | 513 |
| baseline B (control) | 83.51% | 462 |

Control drift was +8 ms against a +51 ms effect, so the cost is real: **+1.46 points of accuracy for roughly 11% more engine time.** Both baseline runs agree exactly, so the accuracy gain is not drift either.

Box quality against SROIE box GT (12 stems, IoU ≥ 0.5):

| threshold | GT matched | mean best IoU |
|---|---|---|
| 0 (default) | 76.4% | 0.630 |
| 0.3 | 88.1% | 0.730 |
| 0.5 | 90.2% | 0.739 |

Binarizing above 0.5 measured no further gain, so 0.3 — the PaddleOCR/arboOCR value — captures all of it. I did not invent a new constant.

### What I measured and deliberately did not ship

A **box score gate** (arboOCR's `detBoxThresh = 0.5`, a masked-polygon mean on the float map) is a **no-op once the map is binarized**: every region surviving a 0.3 cut already means above 0.5. Gates at 0.3, 0.5 and 0.7 measured identically, and adding one at 0.3 measured marginally *worse* (86.7% vs 88.1% matched) because it only discards marginal-but-real boxes. Left out rather than shipped as dead code.

### Tests

Four tests in `tests/detect.test.ts`, all against the real model:

- an explicit `0` is indistinguishable from omitting the option;
- a cut reduces total covered area (28 boxes / ~151k px → 22 boxes / ~121k px) while still finding text, and a cut past the sigmoid's saturation shrinks it further;
- the option does not leak into service defaults;
- the canvas-native engine honors it too.

The area assertions are deliberately not box-count assertions: a higher threshold can *merge* nearby lines (fewer boxes) or *split* a long line (more boxes) — measured counts are non-monotonic (28 → 22 → 24 from 0 to 0.999) even as covered area falls monotonically. Asserting a count direction would be flaky; area is the property the threshold actually controls.

### Checklist

- [x] Tests pass locally — `tests/detect.test.ts` 8/8, plus `canvas-compatibility`, `engine-parity`, `recognition-crop-cap`, `strategies-options` (48 total, 0 fail)
- [x] Types are clean (`bun run type-check`)
- [x] Lint clean (`bun run lint`)
- [x] Formatting clean on the touched files (`bunx oxfmt --check`)
- [ ] Benchmark run if this touches the hot path — the SROIE numbers above are the before/after; `bun bench/index.bench.ts` not re-run
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] README updated (`DetectionOptions` table)
- [x] New tests added for the feature

### Compatibility

- [ ] Node.js (via `onnxruntime-node`)
- [x] Bun (via `onnxruntime-node`)
- [ ] Browser - WebAssembly fallback (Safari, older Firefox)
- [ ] Browser - WebGPU path (Chrome / Edge with a discrete or integrated GPU)
- [ ] macOS (Apple Silicon)
- [ ] Linux (x86-64)
- [x] Windows

Only Windows + Bun was exercised manually. This is threshold plumbing through existing `ppu-ocv` calls with no runtime-specific code, so CI should cover the rest — but the canvas-native path in particular would be worth a browser run, since my only canvas-native coverage is the Node fallback.

### Related

Part of the port list in my arboOCR ↔ oar-ocr ↔ ppu comparison benchmark. The dict-alignment fix from the same comparison is #128.
